### PR TITLE
Issue #18

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -190,3 +190,36 @@ class Request(object):
 
         raise HTTPBadRequest('Missing query parameter',
                              'The "' + name + '" query parameter is required.')
+
+    def get_param_as_list(self, name, default=None, required=False):
+        """Return the value of a query string parameter as an int
+
+        Args:
+            name: Parameter name, case-sensitive (e.g., 'limit')
+            default: Value to return in case the parameter is not found in the
+                query string, or it is not an integer (default None)
+            required: Set to True to raise HTTPBadRequest instead of returning
+                gracefully when the parameter is not found or is not an
+                integer (default False)
+
+        Returns:
+            The value of the param if it is found and can be converted to an
+            integer. Otherwise, returns the default value unless required is
+            True.
+
+        Raises
+            HTTPBadRequest: The param was not found in the request, but was
+                required.
+
+        """
+
+        # PERF: Use if..in since it is a good all-around performer; we don't
+        #       know how likely params are to be specified by clients.
+        if name in self._params:
+            return self._params[name].split(',')
+
+        if not required:
+            return default
+
+        raise HTTPBadRequest('Missing query parameter',
+                             'The "' + name + '" query parameter is required.')

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -44,9 +44,6 @@ def parse_query_string(query_string):
     # PERF: use for loop in lieu of the dict constructor
     params = {}
     for k, v in QS_PATTERN.findall(query_string):
-        if ',' in v:
-            v = v.split(',')
-
         params[k] = v
 
     return params

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -36,15 +36,18 @@ class TestQueryParams(helpers.TestSuite):
         self._simulate_request('/', query_string=query_string)
 
         req = self.resource.req
-        self.assertEquals(req.get_param('colors'),
+        self.assertEquals(req.get_param('colors'), 'red,green,blue')
+        self.assertEquals(req.get_param_as_list('colors'),
                           ['red', 'green', 'blue'])
-        self.assertEquals(req.get_param('limit'), '1')
+        self.assertEquals(req.get_param_as_list('limit'), ['1'])
+        self.assertEquals(req.get_param_as_list('marker'), None)
 
     def test_bogus_input(self):
         query_string = 'colors=red,green,&limit=1&pickle'
         self._simulate_request('/', query_string=query_string)
 
         req = self.resource.req
-        self.assertEquals(req.get_param('colors'), ['red', 'green', ''])
+        self.assertEquals(req.get_param_as_list('colors'),
+                          ['red', 'green', ''])
         self.assertEquals(req.get_param('limit'), '1')
         self.assertEquals(req.get_param('pickle'), None)


### PR DESCRIPTION
The idea is not to have to pay for what you don't use or want. Also
makes this consistent with req.get_param_as_int.

BREAKING CHANGE: get_param will no longer return lists for
comma-separated parameter values. Use get_param_as_list instead.

Implements #18
