### PR TITLE
fix(Request): QUERY_STRING is not required to be present in env

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -92,7 +92,8 @@ class Request(object):
         self.app = env['SCRIPT_NAME']
         self.method = env['REQUEST_METHOD']
         self.path = env['PATH_INFO'] or '/'
-        # QUERY_STRING isn't required to be in env so lets check
+
+        # QUERY_STRING isn't required to be in env, so let's check
         if 'QUERY_STRING' in env:
             self.query_string = query_string = env['QUERY_STRING']
         else:

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -22,10 +22,9 @@ class TestReqVars(testing.TestSuite):
         env = testing.create_environ()
         if 'QUERY_STRING' in env:
             del env['QUERY_STRING']
-        # should not cause an exception when Request instantiated
+
+        # Should not cause an exception when Request instantiated
         req = Request(env)
-        # just make sure we don't cause regression
-        self.assertIsNone(req.get_param("foo"))
 
     def test_reconstruct_url(self):
         req = self.req


### PR DESCRIPTION
Per PEP-333, QUERY_STRING may be empty or absent. It seems to be absent if using eventlet.wsgi.server so this change checks for
QUERY_STRING in env and behaves as before if present. If absent, this sets query_string to empty string.
