### PR TITLE
Route must starts with a slash and contains no //

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -124,7 +124,7 @@ def get_body(resp):
     return []
 
 
-def compile_uri_template(template=None):
+def compile_uri_template(template):
     """Compile the given URI template string into a pattern matcher.
 
     Currently only recognizes Level 1 URI templates, and only for the path
@@ -144,9 +144,13 @@ def compile_uri_template(template=None):
     if not isinstance(template, str):
         raise TypeError('uri_template is not a string')
 
-    if not template:
-        template = '/'
-    elif template != '/' and template.endswith('/'):
+    if not template.startswith('/'):
+        raise ValueError("uri_template must start with '/'")
+
+    if '//' in template:
+        raise ValueError("uri_template may not contain '//'")
+
+    if template != '/' and template.endswith('/'):
         template = template[:-1]
 
     expression_pattern = r'{([a-zA-Z][a-zA-Z_]*)}'

--- a/falcon/tests/test_hello.py
+++ b/falcon/tests/test_hello.py
@@ -71,7 +71,7 @@ class TestHelloWorld(testing.TestBase):
         self.api.add_route('/nostatus', self.no_status_resource)
 
         self.root_resource = testing.TestResource()
-        self.api.add_route('', self.root_resource)
+        self.api.add_route('/', self.root_resource)
 
     def after(self):
         pass

--- a/falcon/tests/test_uri_templates.py
+++ b/falcon/tests/test_uri_templates.py
@@ -121,3 +121,26 @@ class TestUriTemplates(testing.TestBase):
 
         self.assertEquals(resource.id, test_id)
         self.assertEquals(resource.name, test_name)
+
+    def test_empty_path_component(self):
+        self.assertRaises(ValueError, self.api.add_route,
+                          '//', self.resource)
+
+        self.assertRaises(ValueError, self.api.add_route,
+                          '//begin', self.resource)
+
+        self.assertRaises(ValueError, self.api.add_route,
+                          '/end//', self.resource)
+
+        self.assertRaises(ValueError, self.api.add_route,
+                          '/in//side', self.resource)
+
+    def test_relative_path(self):
+        self.assertRaises(ValueError, self.api.add_route,
+                          '', self.resource)
+
+        self.assertRaises(ValueError, self.api.add_route,
+                          'no', self.resource)
+
+        self.assertRaises(ValueError, self.api.add_route,
+                          'no/leading_slash', self.resource)


### PR DESCRIPTION
In such a way, we enforce the routes to be normalized.

Note that this change breaks a use of the empty route '', which was
routed to '/' before.
