### PR TITLE
Get rid of some wildcard imports

### DIFF
--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -24,8 +24,6 @@ if sys.version_info < (2, 7):  # pragma: no cover
 else:
     from collections import OrderedDict
 
-from falcon.status_codes import *
-
 
 class HTTPError(Exception):
     """Represents a generic HTTP error.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 import six
 
-from falcon.exceptions import *
+from falcon.exceptions import HTTPBadRequest
 from falcon import util
 from falcon import request_helpers as helpers
 

--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -16,7 +16,10 @@ limitations under the License.
 
 """
 
-from falcon.status_codes import *
+from falcon.status_codes import HTTP_400
+from falcon.status_codes import HTTP_404
+from falcon.status_codes import HTTP_405
+from falcon.status_codes import HTTP_500
 
 
 def path_not_found(req, resp, **kwargs):


### PR DESCRIPTION
- The wildcard import in falcon/http_error.py seems unnecessary
- Import specific exception in falcon/request.py
- Import specific status codes in falcon/responders.py
