### PR TITLE
feat(req+resp): add HTTP headers property

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -344,6 +344,22 @@ class Request(object):
         """Value of the User-Agent string, or None if missing."""
         return self._get_header_by_wsgi_name('USER_AGENT')
 
+    @property
+    def headers(self):
+        """Get HTTP headers
+
+        Build a temporary dictionary of dash-separated HTTP headers,
+        which can be used as a whole, like, to perform an HTTP request.
+
+        If you want to lookup a header, please use `get_header` instead.
+
+        Returns:
+            A dictionary of HTTP headers.
+
+        """
+        return dict((k.lower().replace('_', '-'), v)
+                    for k, v in self._headers.items())
+
     def get_header(self, name, required=False):
         """Return a header value as a string
 

--- a/falcon/tests/test_headers.py
+++ b/falcon/tests/test_headers.py
@@ -206,6 +206,14 @@ class TestHeaders(testing.TestBase):
             actual_value = self.resource.req.get_header(name)
             self.assertEquals(actual_value, expected_value)
 
+        self.simulate_request(self.test_route,
+                              headers=self.resource.req.headers)
+
+        # Compare the request HTTP headers with the original headers
+        for name, expected_value in req_headers.items():
+            actual_value = self.resource.req.get_header(name)
+            self.assertEquals(actual_value, expected_value)
+
     def test_passthrough_resp_headers(self):
         self.simulate_request(self.test_route)
 


### PR DESCRIPTION
The property is read-only, and users are not supposed to lookup
the dictionary returned from the property.

Closes: #164
