### PR TITLE
fix(Request.get_param_as_list): Handle missing list items

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,5 @@ commands = py3kwarn falcon
 deps = flake8
 commands = flake8 \
            --max-complexity=12 \
-           --exclude=.venv,.tox,dist,doc,./falcon/bench/nuts \
+           --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
            --ignore=F403


### PR DESCRIPTION
This patch modifies get_param_as_list to handle missing list items by
inserting None as a placeholder. If the query parameter's value is just
commas, then they are collapsed into a single None (as if the query
param hadn't been specified).

Fixes #154
