### PR TITLE
fix(Request.client_accepts): Accept parsing doesn't handle application/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Falcon is a [high-performance Python framework][home] for building cloud APIs. I
 
 **Fast.** Cloud APIs need to turn around requests quickly, and make efficient use of hardware. This is particularly important when serving many concurrent requests. Falcon processes requests [several times faster][bench] than other popular web frameworks.
 
-**Light.** Only the essentials are included, with *six* being the only dependency outside the standard library. We work to keep the code lean, making Falcon easier to test, optimize, and deploy.
+**Light.** Only the essentials are included, with *six* and *mimeparse* being the only dependencies outside the standard library. We work to keep the code lean, making Falcon easier to test, optimize, and deploy.
 
 **Flexible.** Falcon can be deployed in a variety of ways, depending on your needs. The framework speaks WSGI, and works great with [Python 2.6 and 2.7, PyPy, and Python 3.3][ci]. There's no tight coupling with any async framework, leaving you free to mix-and-match what you need.
 

--- a/README.rst
+++ b/README.rst
@@ -28,9 +28,9 @@ many concurrent requests. Falcon processes requests `several times
 faster <http://falconframework.org/#Metrics>`__ than other popular web
 frameworks.
 
-**Light.** Only the essentials are included, with *six* being the only
-dependency outside the standard library. We work to keep the code lean,
-making Falcon easier to test, optimize, and deploy.
+**Light.** Only the essentials are included, with *six* and *mimeparse*
+being the only dependencies outside the standard library. We work to keep
+the code lean, making Falcon easier to test, optimize, and deploy.
 
 **Flexible.** Falcon can be deployed in a variety of ways, depending on
 your needs. The framework speaks WSGI, and works great with `Python 2.6

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -91,9 +91,7 @@ def create_environ(path='/', query_string='', protocol='HTTP/1.1', port='80',
         'REQUEST_METHOD': method,
         'PATH_INFO': path,
         'QUERY_STRING': query_string,
-        'HTTP_ACCEPT': '*/*',
-        'HTTP_USER_AGENT': ('curl/7.24.0 (x86_64-apple-darwin12.0) '
-                            'libcurl/7.24.0 OpenSSL/0.9.8r zlib/1.2.5'),
+        'HTTP_USER_AGENT': 'curl/7.24.0 (x86_64-apple-darwin12.0)',
         'REMOTE_PORT': '65133',
         'RAW_URI': '/',
         'REMOTE_ADDR': '127.0.0.1',
@@ -130,12 +128,6 @@ def _add_headers_to_environ(env, headers):
 
     for name, value in headers.items():
         name = name.upper().replace('-', '_')
-
-        if value is None:
-            if name == 'ACCEPT' or name == 'USER_AGENT':
-                del env['HTTP_' + name]
-
-            continue
 
         if name == 'CONTENT_TYPE':
             env[name] = value.strip()

--- a/falcon/tests/test_httperror.py
+++ b/falcon/tests/test_httperror.py
@@ -175,7 +175,7 @@ class TestHTTPError(testing.TestBase):
 
     def test_client_does_not_accept_anything(self):
         headers = {
-            'Accept': None,
+            'Accept': '45087gigo;;;;',
             'X-Error-Title': 'Storage service down',
             'X-Error-Description': ('The configured storage service is not '
                                     'responding to requests. Please contact '

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ from setuptools import setup, find_packages, Extension
 VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
-REQUIRES = ['six']
+# NOTE(kgriffs): python-mimeparse is newer than mimeparse, supports Py3
+# TODO(kgriffs): Fork and optimize/modernize python-mimeparse
+REQUIRES = ['six', 'python-mimeparse']
 if sys.version_info < (2, 7):
     REQUIRES.append('ordereddict')
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,5 +24,5 @@ commands = py3kwarn falcon
 deps = flake8
 commands = flake8 \
            --max-complexity=12 \
-           --exclude=.venv,.tox,dist,doc,./falcon/bench/nuts \
+           --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
            --ignore=F403


### PR DESCRIPTION
This patch adds support to the parser for robust accept header handling,
courtesy of mimeparse. Care was taken to make the common cases fast.

As part of this change, Request gains a new client_prefers() method that
can be used for content negotiation when the service supports multiple media
types.

Fixes #155
