### PR TITLE
feat(Request): Normalize wsgi.input semantics

### DIFF
--- a/falcon/tests/dump_wsgi.py
+++ b/falcon/tests/dump_wsgi.py
@@ -11,7 +11,7 @@ def application(environ, start_response):
 
     body += '}\n\n'
 
-    return [body]
+    return [body.encode('utf-8')]
 
 app = application
 

--- a/falcon/tests/test_request_body.py
+++ b/falcon/tests/test_request_body.py
@@ -1,4 +1,14 @@
+import io
+import multiprocessing
+from wsgiref import simple_server
+
+import requests
+
+import falcon
+from falcon import request_helpers
 import falcon.testing as testing
+
+SIZE_1_KB = 1024
 
 
 class TestRequestBody(testing.TestBase):
@@ -25,8 +35,17 @@ class TestRequestBody(testing.TestBase):
         stream.seek(0, 2)
         self.assertEquals(stream.tell(), 1)
 
+    def test_tiny_body_overflow(self):
+        expected_body = '.'
+        self.simulate_request('', body=expected_body)
+        stream = self.resource.req.stream
+
+        # Read too many bytes; shouldn't block
+        actual_body = stream.read(len(expected_body) + 1)
+        self.assertEquals(actual_body, expected_body.encode('utf-8'))
+
     def test_read_body(self):
-        expected_body = testing.rand_string(2, 1 * 1024 * 1024)
+        expected_body = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
         expected_len = len(expected_body)
         headers = {'Content-Length': str(expected_len)}
 
@@ -44,3 +63,85 @@ class TestRequestBody(testing.TestBase):
         self.assertEquals(stream.tell(), expected_len)
 
         self.assertEquals(stream.tell(), expected_len)
+
+    def test_read_socket_body(self):
+        expected_body = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+
+        def server():
+            class Echo(object):
+                def on_post(self, req, resp):
+                    # wsgiref socket._fileobject blocks when len not given,
+                    # but Falcon is smarter than that. :D
+                    body = req.stream.read()
+                    resp.body = body
+
+                def on_put(self, req, resp):
+                    # wsgiref socket._fileobject blocks when len too long,
+                    # but Falcon should work around that for me.
+                    body = req.stream.read(req.content_length + 1)
+                    resp.body = body
+
+            api = falcon.API()
+            api.add_route('/echo', Echo())
+
+            httpd = simple_server.make_server('127.0.0.1', 8989, api)
+            httpd.serve_forever()
+
+        process = multiprocessing.Process(target=server)
+        process.daemon = True
+        process.start()
+
+        # Let it boot
+        process.join(1)
+
+        url = 'http://127.0.0.1:8989/echo'
+        resp = requests.post(url, data=expected_body)
+        self.assertEquals(resp.text, expected_body)
+
+        resp = requests.put(url, data=expected_body)
+        self.assertEquals(resp.text, expected_body)
+
+        process.terminate()
+
+    def test_body_stream_wrapper(self):
+        data = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+        expected_body = data.encode('utf-8')
+        expected_len = len(expected_body)
+
+        # NOTE(kgriffs): Append newline char to each line
+        # to match readlines behavior
+        expected_lines = [(line + '\n').encode('utf-8')
+                          for line in data.split('\n')]
+
+        # NOTE(kgriffs): Remove trailing newline to simulate
+        # what readlines does
+        expected_lines[-1] = expected_lines[-1][:-1]
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(body.read(), expected_body)
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(body.read(2), expected_body[0:2])
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(body.read(expected_len + 1), expected_body)
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(body.readline(), expected_lines[0])
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(body.readlines(), expected_lines)
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        self.assertEquals(next(body), expected_lines[0])
+
+        stream = io.BytesIO(expected_body)
+        body = request_helpers.Body(stream, expected_len)
+        for i, line in enumerate(body):
+            self.assertEquals(line, expected_lines[i])

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,5 +1,6 @@
 coverage
 nose
 ordereddict
+requests
 six
 testtools


### PR DESCRIPTION
The socket._fileobject and io.BufferedReader are sometimes used
to implement wsgi.input. However, app developers are often burned
by the fact that the read() method for these objects block
indefinitely if either no size is passed, or a size greater than
the request's content length is passed to the method.

This patch makes Falcon detect when the above native stream types
are used by a WSGI server, and wraps them with a simple Body
object that provides more forgiving read, readline, and readlines
methods than what is otherwise provided.

The end result is that app developers are shielded from this
silly inconsistency between WSGI servers.

Fixes issue #147
