### PR TITLE
feat(api): allow add one responder as a route

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -220,6 +220,33 @@ def create_http_method_map(resource, uri_fields, before, after):
     return method_map, na_responder
 
 
+def create_http_method_proxy(responder, allow, uri_fields):
+    """Maps HTTP methods (such as GET and POST) to a responder
+
+    Args:
+        responder: A callable object.
+        allow: A list of allowed HTTP methods. Pass None to allow
+            any methods.
+        uri_fields: A set of field names from the route's URI template that
+            a responder must support in order to avoid "method not allowed".
+
+    Returns:
+        A tuple containing a dict mapping HTTP methods to the responder, and
+        a method-not-allowed responder.
+
+    """
+
+    allowed_methods = (sorted(allow) if allow is not None
+                       else HTTP_METHODS)
+    na_responder = responders.create_method_not_allowed(allowed_methods)
+    method_map = dict((method,
+                       responder if method in allowed_methods
+                       else na_responder)
+                      for method in HTTP_METHODS)
+
+    return method_map, na_responder
+
+
 #-----------------------------------------------------------------------------
 # Helpers
 #-----------------------------------------------------------------------------

--- a/falcon/tests/test_http_method_proxy.py
+++ b/falcon/tests/test_http_method_proxy.py
@@ -1,0 +1,47 @@
+import random
+
+from testtools.matchers import Contains
+
+import falcon
+import falcon.testing as testing
+
+
+HTTP_METHODS = list(falcon.HTTP_METHODS)
+random.shuffle(HTTP_METHODS)
+
+
+def unlimited_blade_works(req, resp, invoker):
+    pass
+
+
+class IonioiHetairoi:
+    def __call__(self, req, resp):
+        pass
+
+
+class TestHttpMethodProxy(testing.TestBase):
+
+    def before(self):
+        self.api.add_proxy('/{invoker}', unlimited_blade_works)
+        self.api.add_proxy('/Alexander', IonioiHetairoi(),
+                           allow=['GET', 'HEAD'])
+
+    def test_unrestricted_route(self):
+        for method in HTTP_METHODS:
+            result = self.simulate_request('/Shiro', method=method)
+
+            self.assertEquals(self.srmock.status, falcon.HTTP_200)
+            self.assertEquals(result, [])
+
+    def test_restricted_route(self):
+        self.simulate_request('/Alexander')
+        self.assertEquals(self.srmock.status, falcon.HTTP_200)
+
+        # on_options is not added
+        self.simulate_request('/Alexander', method='OPTIONS')
+        self.assertEquals(self.srmock.status, falcon.HTTP_405)
+
+        headers = self.srmock.headers
+        allow_header = ('Allow', 'GET, HEAD')
+
+        self.assertThat(headers, Contains(allow_header))


### PR DESCRIPTION
The new API add_proxy is similar to add_route, but only takes
one responder, and passes all allowed HTTP methods to such a
responder.

The API simplifies building proxies, especially the ones forwarding
all requests to other nodes.

Closes: #183
