### PR TITLE
fix: Add output encoding to tests for Python3

### DIFF
--- a/falcon/tests/test_wsgi_errors.py
+++ b/falcon/tests/test_wsgi_errors.py
@@ -27,7 +27,8 @@ class TestWSGIError(testing.TestBase):
         if six.PY3:
             # Simulate Gunicorn's behavior under Python 3
             self.wsgierrors = io.TextIOWrapper(self.wsgierrors_buffer,
-                                               line_buffering=True)
+                                               line_buffering=True,
+                                               encoding='utf-8')
         else:
             # WSGI servers typically present an open file object,
             # with undefined encoding, so do the encoding manually.


### PR DESCRIPTION
In certain environment setups python 3 will detect the appropriate
output as ASCII and will fail when trying to write a unicode string.
Override this by forcing UTF-8.
