### PR TITLE
Ensure long description is Unicode string in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     name='falcon',
     version=VERSION,
     description='A supersonic micro-framework for building cloud APIs.',
-    long_description=open('README.rst', 'r').read(),
+    long_description=open('README.rst', 'r').read().decode('utf-8'),
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
Python 3.3 is not able to properly install Falcon
due to UTF-8 characters in the README.rst file. The
characters are fine, we just need to be sure to decode
the open('README.rst', 'r').read() results as a unicode
string.

An example of the setup failure can be seen here:

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 586: ordinal not in range(128)

http://logs.openstack.org/40/55040/2/check/gate-solum-python33/02f9aca/console.html
