### PR TITLE
chore: Make travis run tests through tox the same way everyone else does

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - pypy
-install:
-  - pip install -r tools/test-requires --use-mirrors
-  - pip install coveralls
-  - python setup.py install
-script: nosetests
+install: pip install tox --use-mirrors
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=py33
+  - TOX_ENV=pypy
+  - TOX_ENV=pep8
+
+script: tox -e $TOX_ENV
 after_success: coveralls
 notifications:
   email:


### PR DESCRIPTION
This gives us flake8 stuff and makes the Travis test more real-world.
