### PR TITLE
test(util/uri): add property tests for decode/encode

### DIFF
--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -119,6 +119,8 @@ This function is faster in the average case than the similar
 `quote` function found in urlib. It also strives to be easier
 to use by assuming a sensible default of allowed characters.
 
+This models urllib.parse.quote(safe="~").
+
 RFC 3986 defines a set of "unreserved" characters as well as a
 set of "reserved" characters used as delimiters.
 
@@ -143,6 +145,9 @@ Returns:
 
 def decode(uri):
     """Decode any percent-encoded characters in a URI or query string.
+
+    uri.decode intends to model the behavior of
+    urllib.parse.unquote_plus.
 
     Args:
         uri: An encoded URI (full or partial). If of type str on Python 2,


### PR DESCRIPTION
This patchset introduces property-based testing for the new
uri-encoding utilities.

The strategy is simple and nondeterministic: ensure that the new
function give the same output as the stdlib uri encoders for all
inputs.

This gives us confidence that future modifications to these encoders
will remain correct.

Minor docstring updates are made to show users what is being modeled.
