### PR TITLE
perf: Use `callable` instead of testing for `__call__` attribute.

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -39,7 +39,7 @@ def prepare_global_hooks(hooks):
             hooks = [hooks]
 
         for action in hooks:
-            if not hasattr(action, '__call__'):
+            if not callable(action):
                 raise TypeError('One or more hooks are not callable')
 
     return hooks
@@ -197,7 +197,7 @@ def create_http_method_map(resource, uri_fields, before, after):
             pass
         else:
             # Usually expect a method, but any callable will do
-            if hasattr(responder, '__call__'):
+            if callable(responder):
                 responder = _wrap_with_hooks(before, after, responder)
                 method_map[method] = responder
 

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -57,7 +57,7 @@ def before(action):
                     pass
                 else:
                     # Usually expect a method, but any callable will do
-                    if hasattr(responder, '__call__'):
+                    if callable(responder):
                         # This pattern is necessary to capture the current
                         # value of responder in the do_before_all closure;
                         # otherwise, they will capture the same responder
@@ -117,7 +117,7 @@ def after(action):
                     pass
                 else:
                     # Usually expect a method, but any callable will do
-                    if hasattr(responder, '__call__'):
+                    if callable(responder):
                         def let(responder=responder):
                             @wraps(responder)
                             def do_after_all(self, req, resp, **kwargs):

--- a/falcon/testing/base.py
+++ b/falcon/testing/base.py
@@ -57,14 +57,14 @@ class TestBase(unittest.TestCase):
         self.test_route = '/{0}'.format(next(self._id))
 
         before = getattr(self, 'before', None)
-        if hasattr(before, '__call__'):
+        if callable(before):
             before()
 
     def tearDown(self):
         """Destructor, unittest-style"""
 
         after = getattr(self, 'after', None)
-        if hasattr(after, '__call__'):
+        if callable(after):
             after()
 
         super(TestBase, self).tearDown()


### PR DESCRIPTION
Should be faster, more elegant. See http://stackoverflow.com/questions/16388059/using-callablex-vs-hasattrx-call

Only caveat would be if you want to prevent classes from being passed in these places, given that classes are _callable_ but don't have a `__call__` attribute.
