### PR TITLE
test(falcon-bench): Add tox environments to run falcon-bench wrt #222

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,pypy,pep8,pylint
+envlist = py26,py27,py33,pypy,pep8,pylint,py26_bench,py27_bench,py33_bench,pypy_bench
 
 [testenv]
 deps = -r{toxinidir}/tools/test-requires
@@ -32,3 +32,23 @@ deps = pylint
 commands = pylint falcon \
            --ignore=bench,tests \
            -E
+
+[testenv:py26_bench]
+deps = -r{toxinidir}/tools/bench-requires
+basepython = python2.6
+commands = falcon-bench
+
+[testenv:py27_bench]
+deps = -r{toxinidir}/tools/bench-requires
+basepython = python2.7
+commands = falcon-bench
+
+[testenv:py33_bench]
+deps = -r{toxinidir}/tools/bench-requires
+basepython = python3.3
+commands = falcon-bench
+
+[testenv:pypy_bench]
+deps = -r{toxinidir}/tools/bench-requires
+basepython = pypy
+commands = falcon-bench


### PR DESCRIPTION
Added tox environments to run falcon-bench on supported pythons.
