### PR TITLE
feat(falcon.Response): Support wsgi.file_wrapper

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -120,7 +120,7 @@ class API(object):
         use_body = not helpers.should_ignore_body(resp.status, req.method)
         if use_body:
             helpers.set_content_length(resp)
-            body = helpers.get_body(resp)
+            body = helpers.get_body(resp, env.get('wsgi.file_wrapper'))
         else:
             # Default: return an empty body
             body = []

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -46,7 +46,7 @@ class Request(object):
     """Represents a client's HTTP request.
 
     Note:
-        Request is not meant to be instantiated directly by responders.
+        `Request` is not meant to be instantiated directly by responders.
 
     Args:
         env (dict): A WSGI environment dict passed in from the server. See
@@ -80,7 +80,7 @@ class Request(object):
             the header is missing.
         content_length (int): Value of the Content-Length header converted
             to an int, or *None* if the header is missing.
-        stream (io): File-like object for reading the body of the request, if
+        stream: File-like object for reading the body of the request, if any.
             any.
         date (datetime): Value of the Date header, converted to a
             `datetime.datetime` instance. The header value is assumed to

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -19,8 +19,10 @@ from falcon.util import dt_to_http, uri
 
 
 class Response(object):
-    """Represents an HTTP response to a client request
+    """Represents an HTTP response to a client request.
 
+    Note:
+        `Response` is not meant to be instantiated directly by responders.
 
     Attributes:
         status (str): HTTP status line, such as "200 OK"
@@ -39,8 +41,6 @@ class Response(object):
 
             Note:
                 Under Python 2.x, if your content is of type *str*, setting
-                the `data` attribute will short-circuit the encoding check
-                used for `body`, and will make your app a little more
                 efficient. However, if your text is of type *unicode*,
                 you will want to use the *body* attribute instead.
 
@@ -50,10 +50,13 @@ class Response(object):
                 ensure Unicode characters are properly encoded in the
                 response body.
 
-        stream (io): File-like object, representing response content.
-            Use this in lieu of *body* or *data* when you want to stream
-            out the response body without having to buffer the entire thing
-            in memory first.
+        stream: Either a file-like object with a *read()* method that takes
+            an optional size argument and returns a block of bytes, or an
+            iterable object, representing response content, and yielding
+            blocks as byte strings. Falcon will use wsgi.file_wrapper, if
+            provided by the WSGI server, in order to efficiently serve
+            file-like objects.
+
         stream_len (int): Expected length of *stream* (e.g., file size).
     """
 

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -53,7 +53,7 @@ def rand_string(min, max):
 
 def create_environ(path='/', query_string='', protocol='HTTP/1.1', port='80',
                    headers=None, app='', body='', method='GET',
-                   wsgierrors=None):
+                   wsgierrors=None, file_wrapper=None):
 
     """Creates a mock PEP-3333 environ dict for simulating WSGI requests.
 
@@ -74,6 +74,8 @@ def create_environ(path='/', query_string='', protocol='HTTP/1.1', port='80',
         body (str or unicode): The body of the request (default '')
         method (str): The HTTP method to use (default 'GET')
         wsgierrors (io): The stream to use as wsgierrors (default sys.stderr)
+        file_wrapper: Callable that returns an iterable, to be used as
+            the value for 'wsgi.file_wrapper' in the environ.
 
     """
 
@@ -107,6 +109,9 @@ def create_environ(path='/', query_string='', protocol='HTTP/1.1', port='80',
         'wsgi.multiprocess': True,
         'wsgi.run_once': False
     }
+
+    if file_wrapper is not None:
+        env['wsgi.file_wrapper'] = file_wrapper
 
     if protocol != 'HTTP/1.0':
         env['HTTP_HOST'] = DEFAULT_HOST


### PR DESCRIPTION
This patch adds support for wsgi.file_wrapper, if it is provided by the
WSGI server, to more efficiently pipe resp.stream to the client.

NOTE: Applications do not need to do anything differently; Falcon will
automatically use wsgi.file_wrapper if it is available, and a file-like
object has been assigned to the resp.stream attribute.

See also PEP-0333: http://goo.gl/Y1pbQD

Closes #181
