### PR TITLE
fix(errors): Remove HTTPUpgradeRequired class

### DIFF
--- a/falcon/exceptions.py
+++ b/falcon/exceptions.py
@@ -254,24 +254,6 @@ class HTTPRangeNotSatisfiable(HTTPError):
         HTTPError.__init__(self, status.HTTP_416, None, None, headers=headers)
 
 
-class HTTPUpgradeRequired(HTTPError):
-    """426 Upgrade Required.
-
-    The protocol used by the client is not supported. It must retry the
-    request using the protocol identified in the Upgrade header.
-
-    Args:
-        title (str): Error title.
-        description (str): Human-friendly description of the error, along with
-            a helpful suggestion or two.
-        kwargs (optional): Same as for ``HTTPError``.
-
-    """
-
-    def __init__(self, title, description, **kwargs):
-        HTTPError.__init__(self, status.HTTP_426, title, description, **kwargs)
-
-
 class HTTPInternalServerError(HTTPError):
     """500 Internal Server Error.
 

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -335,6 +335,5 @@ class TestHTTPError(testing.TestBase):
         self._misc_test(falcon.HTTPPreconditionFailed, falcon.HTTP_412)
         self._misc_test(falcon.HTTPUnsupportedMediaType, falcon.HTTP_415,
                         needs_title=False)
-        self._misc_test(falcon.HTTPUpgradeRequired, falcon.HTTP_426)
         self._misc_test(falcon.HTTPInternalServerError, falcon.HTTP_500)
         self._misc_test(falcon.HTTPBadGateway, falcon.HTTP_502)


### PR DESCRIPTION
The '426 Upgrade Required' status code is for renegotiating the protocol
used to talk between client and server; the app should rely on the
WSGI server to perform this work.
