### PR TITLE
fix(HTTPMethodNotAllowed): Blank body is always returned

### DIFF
--- a/falcon/exceptions.py
+++ b/falcon/exceptions.py
@@ -113,10 +113,24 @@ class HTTPMethodNotAllowed(HTTPError):
     """
 
     def __init__(self, allowed_methods, **kwargs):
+        HTTPError.__init__(self, status.HTTP_405, 'Method not allowed',
+                           **kwargs)
+
+        if kwargs:
+            title = 'Method not allowed'
+        else:
+            # NOTE(kgriffs): Trigger an empty body in the response; 405
+            # responses don't usually have bodies, so we only send one
+            # if the caller indicates they want one, by way of specifying
+            # a description, href, and/or other details.
+            title = None
+
+        # NOTE(kgriffs): Inject the "Allow" header so it will be included
+        # in the HTTP response.
         headers = kwargs.setdefault('headers', {})
         headers['Allow'] = ', '.join(allowed_methods)
 
-        HTTPError.__init__(self, status.HTTP_405, None, **kwargs)
+        HTTPError.__init__(self, status.HTTP_405, title, **kwargs)
 
 
 class HTTPNotAcceptable(HTTPError):

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -49,6 +49,8 @@ class HTTPError(Exception):
             be ignored except for headers.) Do this only when you don't
             wish to disclose sensitive information about why a request was
             refused, or if the status and headers are self-descriptive.
+
+    Keyword Args:
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two (default *None*).
         headers (dict): Extra headers to return in the

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -88,6 +88,10 @@ class MethodNotAllowedResource:
     def on_get(self, req, resp):
         raise falcon.HTTPMethodNotAllowed(['PUT'])
 
+    def on_post(self, req, resp):
+        raise falcon.HTTPMethodNotAllowed(
+            ['PUT'], description='POST is no longer available.')
+
 
 class LengthRequiredResource:
 
@@ -277,10 +281,19 @@ class TestHTTPError(testing.TestBase):
 
     def test_405(self):
         self.api.add_route('/405', MethodNotAllowedResource())
-        body = self.simulate_request('/405')
 
+        response = self.simulate_request('/405')
         self.assertEqual(self.srmock.status, falcon.HTTP_405)
-        self.assertEqual(body, [])
+        self.assertEqual(response, [])
+        self.assertIn(('allow', 'PUT'), self.srmock.headers)
+
+        body = self.simulate_request('/405', method='POST', decode='utf-8')
+        self.assertEqual(self.srmock.status, falcon.HTTP_405)
+
+        doc = json.loads(body)
+        self.assertEqual(doc['title'], 'Method not allowed')
+        self.assertEqual(doc['description'], 'POST is no longer available.')
+
         self.assertIn(('allow', 'PUT'), self.srmock.headers)
 
     def test_411(self):


### PR DESCRIPTION
This patch fixes HTTPMethodNotAllowed so that if kwargs are given, it
will include those in the body of the response; before this patch, the
body was always empty regardless of whether or not the caller provided
any details via kwargs.
