### PR TITLE
fix(compile_uri_template): accept unicode literals

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+import six
 from functools import wraps
 
 from falcon import responders, HTTP_METHODS
@@ -160,7 +161,7 @@ def compile_uri_template(template):
 
     """
 
-    if not isinstance(template, str):
+    if not isinstance(template, six.string_types):
         raise TypeError('uri_template is not a string')
 
     if not template.startswith('/'):

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -1,5 +1,6 @@
 import falcon
 import falcon.testing as testing
+import six
 
 
 class IDResource(object):
@@ -48,6 +49,18 @@ class TestUriTemplates(testing.TestBase):
 
     def test_no_vars(self):
         self.api.add_route('/hello/world', self.resource)
+        self.simulate_request('/hello/world')
+
+        self.assertTrue(self.resource.called)
+        req = self.resource.req
+
+        self.assertEqual(req.get_param('world'), None)
+
+    def test_unicode_literal_routes(self):
+        if six.PY3:
+            self.skipTest('Test only applies to Python 2')
+
+        self.api.add_route(u'/hello/world', self.resource)
         self.simulate_request('/hello/world')
 
         self.assertTrue(self.resource.called)


### PR DESCRIPTION
In Python 2 with `from __future__ import unicode_literals`, any URI template strings will be of type `unicode`, not `str`.
