### PR TITLE
feat(HTTPError): Support XML response bodies

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -117,12 +117,7 @@ class API(object):
                     raise
 
         except HTTPError as ex:
-            resp.status = ex.status
-            if ex.headers is not None:
-                resp.set_headers(ex.headers)
-
-            if req.client_accepts('application/json'):
-                resp.body = ex.json()
+            helpers.compose_error_response(req, resp, ex)
 
         #
         # Set status and headers

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -14,6 +14,7 @@
 
 import json
 import sys
+import xml.etree.ElementTree as et
 
 if sys.version_info < (2, 7):  # pragma: no cover
     # NOTE(kgriffs): We could use the module from PyPI, but ordering isn't
@@ -94,8 +95,8 @@ class HTTPError(Exception):
         """Returns a pretty JSON-encoded version of the exception
 
         Returns:
-            A JSON representation of the exception except the status line, or
-            NONE if title was set to *None*.
+            A JSON representation of the exception, or
+            None if title was set to *None* in the initializer.
 
         """
 
@@ -116,3 +117,33 @@ class HTTPError(Exception):
 
         return json.dumps(obj, indent=4, separators=(',', ': '),
                           ensure_ascii=False)
+
+    def xml(self):
+        """Returns an XML-encoded version of the exception
+
+        Returns:
+            An XML representation of the exception, or
+            None if title was set to *None* in the initializer.
+
+        """
+
+        if self.title is None:
+            return None
+
+        error_element = et.Element('error')
+        et.SubElement(error_element, 'title').text = self.title
+
+        if self.description:
+            et.SubElement(error_element, 'description').text = self.description
+
+        if self.code:
+            et.SubElement(error_element, 'code').text = str(self.code)
+
+        if self.link:
+            link_element = et.SubElement(error_element, 'link')
+
+            for key in ('text', 'href', 'rel'):
+                et.SubElement(link_element, key).text = self.link[key]
+
+        return (b'<?xml version="1.0" encoding="UTF-8"?>' +
+                et.tostring(error_element, encoding='utf-8'))

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -140,6 +140,12 @@ class TestReqVars(testing.TestBase):
         self.assertTrue(req.client_accepts('text/plain'))
         self.assertTrue(req.client_accepts('application/json'))
 
+    def test_client_accepts_bogus(self):
+        headers = {'Accept': '~'}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertFalse(req.client_accepts('text/plain'))
+        self.assertFalse(req.client_accepts('application/json'))
+
     def test_client_accepts_props(self):
         headers = {'Accept': 'application/xml'}
         req = Request(testing.create_environ(headers=headers))


### PR DESCRIPTION
Falcon will now return an XML error response if the client prefers that
media type over JSON. The XML will be UTF-8 encoded.

Closes #109
