### PR TITLE
fix(API): Content-Length header not set for 416 status

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -25,7 +25,6 @@ IGNORE_BODY_STATUS_CODES = set([
     status.HTTP_100,
     status.HTTP_101,
     status.HTTP_204,
-    status.HTTP_416,
     status.HTTP_304
 ])
 

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -375,7 +375,7 @@ class TestHTTPError(testing.TestBase):
         self.assertEqual(self.srmock.status, falcon.HTTP_416)
         self.assertEqual(body, [])
         self.assertIn(('content-range', 'bytes */123456'), self.srmock.headers)
-        self.assertNotIn('content-length', self.srmock.headers_dict)
+        self.assertIn(('content-length', '0'), self.srmock.headers)
 
     def test_503(self):
         self.api.add_route('/503', ServiceUnavailableResource())


### PR DESCRIPTION
The latest HTTP 1.1 RFC states that the Content-Length header MUST NOT be
set for 1xx and 204. It is also normally not set for 304. 416 is not
mentioned, so we should set Content-Length for it.
