### PR TITLE
fix(Request): Be more lenient regarding query string param names

### DIFF
--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -28,9 +28,9 @@ _ALL_ALLOWED = _UNRESERVED + _DELIMITERS
 
 _HEX_DIGITS = '0123456789ABCDEFabcdef'
 
-# NOTE(kgriffs): Match query string fields that have names that
-# start with a letter.
-_QS_PATTERN = re.compile(r'(?<![0-9])([a-zA-Z][a-zA-Z_0-9\-.]*)=([^&]+)')
+# NOTE(kgriffs): Match query string fields. If this is modified, take
+# care not to reduce performance.
+_QS_PATTERN = re.compile(r'(?:&|\A)([^=]+)=([^&]+)')
 
 
 def _create_char_encoder(allowed_chars):

--- a/tests/test_before_hooks.py
+++ b/tests/test_before_hooks.py
@@ -251,11 +251,11 @@ class TestHooks(testing.TestBase):
         self.assertEqual(falcon.HTTP_400, self.srmock.status)
 
     def test_param_validator(self):
-        self.simulate_request(self.test_route, query_string='?limit=10',
+        self.simulate_request(self.test_route, query_string='limit=10',
                               body='{}')
         self.assertEqual(falcon.HTTP_200, self.srmock.status)
 
-        self.simulate_request(self.test_route, query_string='?limit=101')
+        self.simulate_request(self.test_route, query_string='limit=101')
         self.assertEqual(falcon.HTTP_400, self.srmock.status)
 
     def test_field_validator(self):
@@ -276,7 +276,7 @@ class TestHooks(testing.TestBase):
         self.simulate_request('/wrapped', method='PATCH')
         self.assertEqual(falcon.HTTP_405, self.srmock.status)
 
-        self.simulate_request('/wrapped', query_string='?limit=10')
+        self.simulate_request('/wrapped', query_string='limit=10')
         self.assertEqual(falcon.HTTP_200, self.srmock.status)
         self.assertEqual('fuzzy', self.wrapped_resource.bunnies)
 
@@ -288,7 +288,7 @@ class TestHooks(testing.TestBase):
         self.assertEqual(falcon.HTTP_200, self.srmock.status)
         self.assertEqual('slippery', self.wrapped_resource.fish)
 
-        self.simulate_request('/wrapped', query_string='?limit=101')
+        self.simulate_request('/wrapped', query_string='limit=101')
         self.assertEqual(falcon.HTTP_400, self.srmock.status)
         self.assertEqual('fuzzy', self.wrapped_resource.bunnies)
 
@@ -296,7 +296,7 @@ class TestHooks(testing.TestBase):
         self.simulate_request('/wrapped_aware', method='PATCH')
         self.assertEqual(falcon.HTTP_405, self.srmock.status)
 
-        self.simulate_request('/wrapped_aware', query_string='?limit=10')
+        self.simulate_request('/wrapped_aware', query_string='limit=10')
         self.assertEqual(falcon.HTTP_200, self.srmock.status)
         self.assertEqual('fuzzy', self.wrapped_aware_resource.bunnies)
 
@@ -305,6 +305,6 @@ class TestHooks(testing.TestBase):
             self.assertEqual(falcon.HTTP_200, self.srmock.status)
             self.assertEqual('fuzzy', self.wrapped_aware_resource.bunnies)
 
-        self.simulate_request('/wrapped_aware', query_string='?limit=101')
+        self.simulate_request('/wrapped_aware', query_string='limit=101')
         self.assertEqual(falcon.HTTP_400, self.srmock.status)
         self.assertEqual('fuzzy', self.wrapped_aware_resource.bunnies)

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -55,19 +55,22 @@ class _TestQueryParams(testing.TestBase):
         self.assertEqual(req.get_param('q'), u'\u8c46 \u74e3')
 
     def test_allowed_names(self):
-        query_string = ('p=0&p1=23&2p=foo&some-thing=that&blank=&some_thing=x&'
-                        '-bogus=foo&more.things=blah')
+        query_string = ('p=0&p1=23&2p=foo&some-thing=that&blank=&'
+                        'some_thing=x&-bogus=foo&more.things=blah&'
+                        '_thing=42&_charset_=utf-8')
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req
         self.assertEqual(req.get_param('p'), '0')
         self.assertEqual(req.get_param('p1'), '23')
-        self.assertIs(req.get_param('2p'), None)
+        self.assertEqual(req.get_param('2p'), 'foo')
         self.assertEqual(req.get_param('some-thing'), 'that')
         self.assertIs(req.get_param('blank'), None)
         self.assertEqual(req.get_param('some_thing'), 'x')
-        self.assertIs(req.get_param('-bogus'), None)
+        self.assertEqual(req.get_param('-bogus'), 'foo')
         self.assertEqual(req.get_param('more.things'), 'blah')
+        self.assertEqual(req.get_param('_thing'), '42')
+        self.assertEqual(req.get_param('_charset_'), 'utf-8')
 
     def test_required(self):
         query_string = ''


### PR DESCRIPTION
This patch allows a wider variety of characters to be used in
query string params, while also slightly improving the performance
of parsing the same.
