### PR TITLE
fix(Request): Unify behavior of get_param for lists

### DIFF
--- a/falcon/testing/base.py
+++ b/falcon/testing/base.py
@@ -68,6 +68,12 @@ class TestBase(unittest.TestCase):
 
         super(TestBase, self).tearDown()
 
+    # NOTE(warsaw): Pythons earlier than 2.7 do not have a self.assertIn()
+    # method, so use this compatibility function instead.
+    if not hasattr(unittest.TestCase, 'assertIn'):
+        def assertIn(self, a, b):
+            self.assertTrue(a in b)
+
     def simulate_request(self, path, decode=None, **kwargs):
         """Simulates a request to `self.api`.
 

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -259,6 +259,15 @@ def parse_query_string(query_string):
     parameters with values are parsed. for example, given "foo=bar&flag",
     this function would ignore "flag".
 
+    Note:
+        In addition to the standard HTML form-based method for specifying
+        lists by repeating a given param multiple times, Falcon supports
+        a more compact form in which the param may be given a single time
+        but set to a list of comma-separated elements (e.g., 'foo=a,b,c').
+
+        The two different ways of specifying lists may not be mixed in
+        a single query string for the same parameter.
+
     Args:
         query_string (str): The query string to parse
 
@@ -284,7 +293,16 @@ def parse_query_string(query_string):
                 old_value.append(v)
             else:
                 params[k] = [old_value, v]
+
         else:
+            if ',' in v:
+                # NOTE(kgriffs): Falcon supports a more compact form of
+                # lists, in which the elements are comma-separated and
+                # assigned to a single param instance. If it turns out that
+                # very few people use this, it can be deprecated at some
+                # point.
+                v = v.split(',')
+
             params[k] = v
 
     return params

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -50,7 +50,11 @@ class _TestQueryParams(testing.TestBase):
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req
-        self.assertEqual(req.get_param('id'), u'23,42')
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        self.assertIn(req.get_param('id'), [u'23', u'42'])
+
         self.assertEqual(req.get_param_as_list('id', int), [23, 42])
         self.assertEqual(req.get_param('q'), u'\u8c46 \u74e3')
 
@@ -199,7 +203,11 @@ class _TestQueryParams(testing.TestBase):
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req
-        self.assertEqual(req.get_param('colors'), 'red,green,blue')
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        self.assertIn(req.get_param('colors'), ('red', 'green', 'blue'))
+
         self.assertEqual(req.get_param_as_list('colors'),
                          ['red', 'green', 'blue'])
         self.assertEqual(req.get_param_as_list('limit'), ['1'])
@@ -229,7 +237,10 @@ class _TestQueryParams(testing.TestBase):
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req
-        self.assertEqual(req.get_param('coord'), '1.4,13,15.1')
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        self.assertIn(req.get_param('coord'), ('1.4', '13', '15.1'))
 
         expected = [1.4, 13.0, 15.1]
         actual = req.get_param_as_list('coord', transform=float)
@@ -254,12 +265,6 @@ class _TestQueryParams(testing.TestBase):
         self.assertEqual(
             sorted(req.params.items()),
             [('ant', '4'), ('bee', '3'), ('cat', '2'), ('dog', '1')])
-
-    # NOTE(warsaw): Pythons earlier than 2.7 do not have a self.assertIn()
-    # method, so use this compatibility function instead.
-    if not hasattr(testing.TestBase, 'assertIn'):
-        def assertIn(self, a, b):
-            self.assertTrue(a in b)
 
     def test_multiple_form_keys(self):
         query_string = 'ant=1&ant=2&bee=3&cat=6&cat=5&cat=4'


### PR DESCRIPTION
This patch changes get_param so that it behaves the same whether a
list was specified in the query string using the HTML form style (in
which each element is listed in a separate 'key=val' field) or in
the more compact API style (in which each element is comma-separated
and assigned to a single param instance, as in 'key=val1,val2,val3').

Closes #312
