### PR TITLE
doc: Function _generate_id() in the tutorial is not py3k compatible

### DIFF
--- a/doc/user/tutorial.rst
+++ b/doc/user/tutorial.rst
@@ -241,6 +241,7 @@ Next, let's implement the POST responder:
 
     import os
     import time
+    import uuid
 
     import falcon
 
@@ -251,7 +252,7 @@ Next, let's implement the POST responder:
 
 
     def _generate_id():
-        return os.urandom(2).encode('hex') + hex(int(time.time() * 10))[5:]
+        return str(uuid.uuid4())
 
 
     class Resource(object):
@@ -337,6 +338,7 @@ Go ahead and edit your ``images.py`` file to look something like this:
 
     import os
     import time
+    import uuid
 
     import falcon
 
@@ -351,7 +353,7 @@ Go ahead and edit your ``images.py`` file to look something like this:
 
 
     def _generate_id():
-        return os.urandom(2).encode('hex') + hex(int(time.time() * 10))[5:]
+        return str(uuid.uuid4())
 
 
     class Collection(object):


### PR DESCRIPTION
This patch modifies the function to just generate a UUID, which will
work for both Python 2 and Python 3.

Closes #304
