### PR TITLE
feat(API): Add middlewares to falcon API

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -41,6 +41,42 @@ def prepare_global_hooks(hooks):
     return hooks
 
 
+def prepare_mw(middleware=None):
+    """Check middleware interface and prepare it to iterate.
+
+    Args:
+        middleware:  list (or object) of input middleware
+
+    Returns:
+        A middleware list
+    """
+    if middleware is None:
+        middleware = []
+    else:
+        if not isinstance(middleware, list):
+            middleware = [middleware]
+
+    # check basic interface of middleware objects
+    for mw in middleware:
+        if not hasattr(mw, 'process_request') and not\
+                hasattr(mw, 'process_response'):
+
+            raise TypeError('{0} is not a valid middlware'.format(str(mw)))
+
+        # Check process_request and process_response are bounded methods
+        for mw_method in ('process_request', 'process_response'):
+            method_mw_bound = getattr(mw, mw_method, None)
+
+            if method_mw_bound is not None:
+
+                if six.get_method_self(method_mw_bound) is None:
+                    raise AttributeError(
+                        '{0} must be a bound method'.format(method_mw_bound))\
+                        # pragma: no cover
+
+    return middleware
+
+
 def should_ignore_body(status, method):
     """Return True if the status or method indicates no body, per RFC 2616
 

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,0 +1,294 @@
+import falcon
+import falcon.testing as testing
+from datetime import datetime
+
+context = {'executed_methods': []}
+
+
+class RequestTimeMiddleware(object):
+
+    def process_request(self, req, resp, params):
+        global context
+        context['start_time'] = datetime.utcnow()
+
+    def process_response(self, req, resp):
+        global context
+        context['end_time'] = datetime.utcnow()
+
+
+class TransactionIdMiddleware(object):
+
+    def process_request(self, req, resp, params):
+        global context
+        context['transaction_id'] = 'unique-req-id'
+
+
+class ExecutedFirstMiddleware(object):
+
+    def process_request(self, req, resp, params):
+        global context
+        context['executed_methods'].append(
+            '{0}.{1}'.format(self.__class__.__name__, 'process_request'))
+
+    def process_response(self, req, resp):
+        global context
+        context['executed_methods'].append(
+            '{0}.{1}'.format(self.__class__.__name__, 'process_response'))
+
+
+class ExecutedLastMiddleware(ExecutedFirstMiddleware):
+    pass
+
+
+class MiddlewareClassResource(object):
+
+    def on_get(self, req, resp):
+        resp.status = falcon.HTTP_200
+        resp.body = {'status': 'ok'}
+
+
+class TestMiddleware(testing.TestBase):
+
+    def setUp(self):
+        # Clear context
+        global context
+        context = {'executed_methods': []}
+        testing.TestBase.setUp(self)
+
+
+class TestRequestTimeMiddleware(TestMiddleware):
+
+    def test_add_invalid_middleware(self):
+        """Test than an invalid class can not be added as middleware"""
+        class InvalidMiddleware():
+            def process_request(self, *args):
+                pass
+
+        mw_list = [RequestTimeMiddleware(), InvalidMiddleware]
+        self.assertRaises(AttributeError, falcon.API, middleware=mw_list)
+        mw_list = [RequestTimeMiddleware(), "InvalidMiddleware"]
+        self.assertRaises(TypeError, falcon.API, middleware=mw_list)
+        mw_list = [{'process_request': 90}]
+        self.assertRaises(TypeError, falcon.API, middleware=mw_list)
+
+    def test_response_middleware_raises_exception(self):
+        """Test that error in response middleware is propagated up"""
+        class RaiseErrorMiddleware(object):
+
+            def process_response(self, req, resp, params):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[RaiseErrorMiddleware()])
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.assertRaises(Exception, self.simulate_request, self.test_route)
+
+    def test_log_get_request(self):
+        """Test that Log middleware is executed"""
+        global context
+        self.api = falcon.API(middleware=[RequestTimeMiddleware()])
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        body = self.simulate_request(self.test_route)
+        self.assertEqual([{'status': 'ok'}], body)
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertIn("start_time", context)
+        self.assertIn("end_time", context)
+        self.assertTrue(context['end_time'] > context['start_time'],
+                        "process_response not executed after request")
+
+
+class TestTransactionIdMiddleware(TestMiddleware):
+
+    def test_generate_trans_id_with_request(self):
+        """Test that TransactionIdmiddleware is executed"""
+        global context
+        self.api = falcon.API(middleware=TransactionIdMiddleware())
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        body = self.simulate_request(self.test_route)
+        self.assertEqual([{'status': 'ok'}], body)
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertIn("transaction_id", context)
+        self.assertEqual("unique-req-id", context['transaction_id'])
+
+
+class TestSeveralMiddlewares(TestMiddleware):
+
+    def test_generate_trans_id_and_time_with_request(self):
+        global context
+        self.api = falcon.API(middleware=[TransactionIdMiddleware(),
+                                          RequestTimeMiddleware()])
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        body = self.simulate_request(self.test_route)
+        self.assertEqual([{'status': 'ok'}], body)
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertIn("transaction_id", context)
+        self.assertEqual("unique-req-id", context['transaction_id'])
+        self.assertIn("start_time", context)
+        self.assertIn("end_time", context)
+        self.assertTrue(context['end_time'] > context['start_time'],
+                        "process_response not executed after request")
+
+    def test_middleware_execution_order(self):
+        global context
+        self.api = falcon.API(middleware=[ExecutedFirstMiddleware(),
+                                          ExecutedLastMiddleware()])
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        body = self.simulate_request(self.test_route)
+        self.assertEqual([{'status': 'ok'}], body)
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        # as the method registration is in a list, the order also is
+        # tested
+        expectedExecutedMethods = [
+            "ExecutedFirstMiddleware.process_request",
+            "ExecutedLastMiddleware.process_request",
+            "ExecutedLastMiddleware.process_response",
+            "ExecutedFirstMiddleware.process_response"
+        ]
+        self.assertEqual(expectedExecutedMethods, context['executed_methods'])
+
+    def test_inner_mw_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp, params):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[TransactionIdMiddleware(),
+                                          RequestTimeMiddleware(),
+                                          RaiseErrorMiddleware()])
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.assertRaises(Exception, self.simulate_request, self.test_route)
+
+        # RequestTimeMiddleware process_response should be executed
+        self.assertIn("transaction_id", context)
+        self.assertIn("start_time", context)
+        self.assertIn("end_time", context)
+
+    def test_inner_mw_with_ex_handler_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp, params):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[TransactionIdMiddleware(),
+                                          RequestTimeMiddleware(),
+                                          RaiseErrorMiddleware()])
+
+        def handler(ex, req, resp, params):
+            context['error_handler'] = True
+
+        self.api.add_error_handler(Exception, handler)
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.simulate_request(self.test_route)
+
+        # RequestTimeMiddleware process_response should be executed
+        self.assertIn("transaction_id", context)
+        self.assertIn("start_time", context)
+        self.assertIn("end_time", context)
+        self.assertIn("error_handler", context)
+
+    def test_outer_mw_with_ex_handler_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp, params):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[TransactionIdMiddleware(),
+                                          RaiseErrorMiddleware(),
+                                          RequestTimeMiddleware()])
+
+        def handler(ex, req, resp, params):
+            context['error_handler'] = True
+
+        self.api.add_error_handler(Exception, handler)
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.simulate_request(self.test_route)
+
+        # Any mw is executed now...
+        self.assertIn("transaction_id", context)
+        self.assertNotIn("start_time", context)
+        self.assertNotIn("end_time", context)
+        self.assertIn("error_handler", context)
+
+    def test_order_mw_executed_when_exception_in_resp(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_response(self, req, resp):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[ExecutedFirstMiddleware(),
+                                          RaiseErrorMiddleware(),
+                                          ExecutedLastMiddleware()])
+
+        def handler(ex, req, resp, params):
+            context['error_handler'] = True
+
+        self.api.add_error_handler(Exception, handler)
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.simulate_request(self.test_route)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            "ExecutedFirstMiddleware.process_request",
+            "ExecutedLastMiddleware.process_request",
+            "ExecutedLastMiddleware.process_response",
+            "ExecutedFirstMiddleware.process_response"
+        ]
+        self.assertEqual(expectedExecutedMethods, context['executed_methods'])
+
+    def test_order_mw_executed_when_exception_in_req(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp):
+                raise Exception("Always fail")
+
+        self.api = falcon.API(middleware=[ExecutedFirstMiddleware(),
+                                          RaiseErrorMiddleware(),
+                                          ExecutedLastMiddleware()])
+
+        def handler(ex, req, resp, params):
+            context['error_handler'] = True
+
+        self.api.add_error_handler(Exception, handler)
+
+        self.api.add_route(self.test_route, MiddlewareClassResource())
+
+        self.simulate_request(self.test_route)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            "ExecutedFirstMiddleware.process_request",
+            "ExecutedFirstMiddleware.process_response"
+        ]
+        self.assertEqual(expectedExecutedMethods, context['executed_methods'])


### PR DESCRIPTION
Currently falcon provides hooks as a way to add logic to all "routed" requests. With this approach it's not possible to execute code when a request is not routed (e.g., method not allowed, path not found ...)
I would like to include the concept of middlewares (same as django) in falcon as it may be useful for many projects. Typical middlewares:
- Generate unique transaction for all requests
- Log all requests and include time ellapsed
- Authentication (imo this should happend before any logic of routing, aka find responder).

A list of Middleware classes can be added to falcon WSGI in this way: 

api.add_middlewares([MiddClass1,MidClass2])

A middleware will be executed always with every request/response dispatched, no matters routing and errors.
A middleware can define process_request or process_response or both; internally the code will be executed when corresponds.
Arguments are the same as hooks and error_handlers. In unit tests, some examples can be seen.
