### PR TITLE
Object-based traversal

### DIFF
--- a/tests/test_rooted_api.py
+++ b/tests/test_rooted_api.py
@@ -14,6 +14,7 @@ class NotFound:
     on_patch = _oops
     on_delete = _oops
 
+
 class One:
     @child()
     def two(self, request, segments):
@@ -23,26 +24,31 @@ class One:
         response.status = falcon.HTTP_200
         response.body = 'one'
 
+
 class Two:
     def on_get(self, request, response):
         response.status = falcon.HTTP_200
         response.body = 'two'
+
 
 class Three:
     def on_get(self, request, response):
         response.status = falcon.HTTP_200
         response.body = 'three'
 
+
 class Four:
     def on_get(self, request, response):
         response.status = falcon.HTTP_200
         response.body = 'four'
+
 
 def matcher(request, segments):
     if 'token' in segments:
         # It matches, return positional args, keyword args, and segments.
         return ('ant', 'bee'), dict(cat='cat', dog='dog'), ()
     return None
+
 
 class Matched:
     def __init__(self, a, b, cat='elk', dog='fly'):
@@ -54,6 +60,7 @@ class Matched:
     def on_get(self, request, response):
         response.status = falcon.HTTP_200
         response.body = ''.join((self.a, self.b, self.c, self.d))
+
 
 class Root:
     @child()
@@ -76,7 +83,7 @@ class Root:
             2: Two,
             3: Three,
             4: Four,
-            }.get(segment_count, NotFound)
+        }.get(segment_count, NotFound)
         # No more path segments.
         return next_hop(), ()
 
@@ -120,19 +127,19 @@ class TestRootedAPI(testing.TestBase):
     def test_path_consumer(self):
         response = self.simulate_request('/consume/a')
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(response[0], 'one')
+        self.assertEqual(response[0], b'one')
 
         response = self.simulate_request('/consume/a/b')
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(response[0], 'two')
+        self.assertEqual(response[0], b'two')
 
         response = self.simulate_request('/consume/a/b/c')
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(response[0], 'three')
+        self.assertEqual(response[0], b'three')
 
         response = self.simulate_request('/consume/a/b/c/d')
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(response[0], 'four')
+        self.assertEqual(response[0], b'four')
 
         response = self.simulate_request('/consume/a/b/c/d/e')
         self.assertEqual(self.srmock.status, falcon.HTTP_404)
@@ -140,7 +147,7 @@ class TestRootedAPI(testing.TestBase):
     def test_callable_matches(self):
         response = self.simulate_request('/this/token/matches')
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertEqual(response[0], 'antbeecatdog')
+        self.assertEqual(response[0], b'antbeecatdog')
 
     def test_callable_misses(self):
         self.simulate_request('/these/tokens/miss')

--- a/tests/test_rooted_api.py
+++ b/tests/test_rooted_api.py
@@ -1,0 +1,147 @@
+import random
+import falcon
+from falcon.api import RootedAPI, child
+import falcon.testing as testing
+
+
+class NotFound:
+    def _oops(self, request, response):
+        raise falcon.HTTPError(falcon.HTTP_404, None)
+
+    on_get = _oops
+    on_post = _oops
+    on_put = _oops
+    on_patch = _oops
+    on_delete = _oops
+
+class One:
+    @child()
+    def two(self, request, segments):
+        return Two()
+
+    def on_get(self, request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'one'
+
+class Two:
+    def on_get(self, request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'two'
+
+class Three:
+    def on_get(self, request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'three'
+
+class Four:
+    def on_get(self, request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'four'
+
+def matcher(request, segments):
+    if 'token' in segments:
+        # It matches, return positional args, keyword args, and segments.
+        return ('ant', 'bee'), dict(cat='cat', dog='dog'), ()
+    return None
+
+class Matched:
+    def __init__(self, a, b, cat='elk', dog='fly'):
+        self.a = a
+        self.b = b
+        self.c = cat
+        self.d = dog
+
+    def on_get(self, request, response):
+        response.status = falcon.HTTP_200
+        response.body = ''.join((self.a, self.b, self.c, self.d))
+
+class Root:
+    @child()
+    def one(self, request, segments):
+        return One()
+
+    @child('child-o-mine')
+    def whatever(self, request, segments):
+        return Three()
+
+    @child('^[0-9]+')
+    def numbers(self, request, segments):
+        return Four()
+
+    @child()
+    def consume(self, request, segments):
+        segment_count = len(segments)
+        next_hop = {
+            1: One,
+            2: Two,
+            3: Three,
+            4: Four,
+            }.get(segment_count, NotFound)
+        # No more path segments.
+        return next_hop(), ()
+
+    @child(matcher)
+    def matched(self, request, segments, *args, **kws):
+        return Matched(*args, **kws)
+
+
+class TestRootedAPI(testing.TestBase):
+
+    def setUp(self):
+        super(TestRootedAPI, self).setUp()
+        self.api = RootedAPI(Root())
+
+    def test_child(self):
+        response = self.simulate_request('/one/two')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], b'two')
+
+    def test_renamed_child(self):
+        response = self.simulate_request('/child-o-mine')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], b'three')
+
+    def test_under_name_not_found(self):
+        self.simulate_request('/whatever/two')
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)
+
+    def test_regexp_child(self):
+        # Any number works.
+        for i in range(4):
+            path = '/%03d' % random.randint(0, 999)
+            response = self.simulate_request(path)
+            self.assertEqual(self.srmock.status, falcon.HTTP_200)
+            self.assertEqual(response[0], b'four')
+
+    def test_under_regexp_not_found(self):
+        self.simulate_request('/numbers')
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)
+
+    def test_path_consumer(self):
+        response = self.simulate_request('/consume/a')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], 'one')
+
+        response = self.simulate_request('/consume/a/b')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], 'two')
+
+        response = self.simulate_request('/consume/a/b/c')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], 'three')
+
+        response = self.simulate_request('/consume/a/b/c/d')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], 'four')
+
+        response = self.simulate_request('/consume/a/b/c/d/e')
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)
+
+    def test_callable_matches(self):
+        response = self.simulate_request('/this/token/matches')
+        self.assertEqual(self.srmock.status, falcon.HTTP_200)
+        self.assertEqual(response[0], 'antbeecatdog')
+
+    def test_callable_misses(self):
+        self.simulate_request('/these/tokens/miss')
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)


### PR DESCRIPTION
Here's a branch containing the object-based traversal subclass I'm using in my falcon branch of Mailman 3.  While probably not a full fidelity port of the restish API, it's close enough that my entire test suite passes.

For the most part, I'm PR'ing this to start a conversation about how and whether object-based traversal can be made a first class citizen of falcon.

Note that there are a number of other little helpers and utilities I'm using on top of falcon, but they're independent of the basic object-based traversal support, so I'll leave those off this branch and discuss them separately.

The tests should also give you a taste of what it looks like in practice.