### PR TITLE
feat(HTTPError): Support custom media types for error responses

### DIFF
--- a/doc/api/errors.rst
+++ b/doc/api/errors.rst
@@ -3,13 +3,13 @@
 Error Handling
 ==============
 
-When something goes horribly (or mildly) wrong, you *could* manually set the
+When a request results in an error condition, you *could* manually set the
 error status, appropriate response headers, and even an error body using the
-``resp`` object. However, Falcon tries to make things a bit easier by
-providing a set of exceptions you can raise when something goes wrong. In fact,
-if Falcon catches any exception your responder throws that inherits from
-``falcon.HTTPError``, the framework will convert that exception to an
-appropriate HTTP error response.
+``resp`` object. However, Falcon tries to make things a bit easier and more
+consistent by providing a set of error classes you can raise from within
+your app. Falcon catches any exception that inherits from
+``falcon.HTTPError``, and automatically converts it to an appropriate HTTP
+response.
 
 You may raise an instance of ``falcon.HTTPError`` directly, or use any one
 of a number of predefined error classes that try to be idiomatic in

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -141,28 +141,68 @@ def get_body(resp, wsgi_file_wrapper=None):
     return []
 
 
-def compose_error_response(req, resp, ex):
+def serialize_error(req, exception):
+    """Serialize the given instance of HTTPError.
+
+    This function determines which of the supported media types, if
+    any, are acceptable by the client, and serializes the error
+    to the preferred type.
+
+    Currently, JSON and XML are the only supported media types. If the
+    client accepts both JSON and XML with equal weight, JSON will be
+    chosen.
+
+    Other media types can be supported by using a custom error serializer.
+
+    Note:
+        If a custom media type is used and the type includes a
+        "+json" or "+xml" suffix, the error will be serialized
+        to JSON or XML, respectively. If this behavior is not
+        desirable, a custom error serializer may be used to
+        override this one.
+
+    Args:
+        req: Instance of falcon.Request
+        exception: Instance of falcon.HTTPError
+
+    Returns:
+        A tuple of the form ``(media_type, representation)``, or
+        ``(None, None)`` if the client does not support any of the
+        available media types.
+
+    """
+    representation = None
 
     preferred = req.client_prefers(('application/xml',
                                     'text/xml',
                                     'application/json'))
 
+    if preferred is None:
+        # NOTE(kgriffs): See if the client expects a custom media
+        # type based on something Falcon supports. Returning something
+        # is probably better than nothing, but if that is not
+        # desired, this behavior can be customized by adding a
+        # custom HTTPError serializer for the custom type.
+        accept = req.accept.lower()
+
+        # NOTE(kgriffs): Simple heuristic, but it's fast, and
+        # should be sufficiently accurate for our purposes. Does
+        # not take into account weights if both types are
+        # acceptable (simply chooses JSON). If it turns out we
+        # need to be more sophisticated, we can always change it
+        # later (YAGNI).
+        if '+json' in accept:
+            preferred = 'application/json'
+        elif '+xml' in accept:
+            preferred = 'application/xml'
+
     if preferred is not None:
         if preferred == 'application/json':
-            resp.body = ex.json()
+            representation = exception.json()
         else:
-            resp.body = ex.xml()
+            representation = exception.xml()
 
-    resp.status = ex.status
-
-    if ex.headers is not None:
-        resp.set_headers(ex.headers)
-
-    # NOTE(kgriffs): Do this after setting headers from ex.headers,
-    # so that we will override Content-Type if it was mistakenly set
-    # by the app.
-    if resp.body is not None:
-        resp.content_type = preferred
+    return (preferred, representation)
 
 
 def compile_uri_template(template):

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,6 +1,8 @@
 coverage
+ddt
 nose
 ordereddict
+pyyaml
 requests
 six
 testtools


### PR DESCRIPTION
This patch adds support for serializing errors to other media types
besides the generic JSON and XML formats. It does this in two ways:
1. The default serializer will check for a '+xml' and '+json' suffix
   in the media type requested by the client, and if present, serialize
   to XML or JSON, respectively. This was thought to be better than
   simply returning an empty body in the response.
2. The default serializer can now be overriden with a custom
   serializer function, which affords complete control over the
   error serialization process.

Closes #265
