### PR TITLE
feat(Requests): Add req.host and req.subdomain

### DIFF
--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -37,16 +37,6 @@ def normalize_headers(env):
     if 'CONTENT_LENGTH' in env:
         env['HTTP_CONTENT_LENGTH'] = env['CONTENT_LENGTH']
 
-    # Fallback to SERVER_* vars if the Host header isn't specified
-    if 'HTTP_HOST' not in env:
-        host = env['SERVER_NAME']
-        port = env['SERVER_PORT']
-
-        if port != '80':
-            host = ''.join([host, ':', port])
-
-        env['HTTP_HOST'] = host
-
 
 class Body(object):
     """Wrap wsgi.input streams to make them more robust.

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -187,30 +187,6 @@ class TestHeaders(testing.TestBase):
                           self.resource.req.get_header, 'X-Not-Found',
                           required=True)
 
-    def test_prefer_host_header(self):
-        self.simulate_request(self.test_route)
-
-        # Make sure we picked up host from HTTP_HOST, not SERVER_NAME
-        host = self.resource.req.get_header('host')
-        self.assertEqual(host, testing.DEFAULT_HOST)
-
-    def test_host_fallback(self):
-        # Set protocol to 1.0 so that we won't get a host header
-        self.simulate_request(self.test_route, protocol='HTTP/1.0')
-
-        # Make sure we picked up host from HTTP_HOST, not SERVER_NAME
-        host = self.resource.req.get_header('host')
-        self.assertEqual(host, 'localhost')
-
-    def test_host_fallback_port8000(self):
-        # Set protocol to 1.0 so that we won't get a host header
-        self.simulate_request(self.test_route, protocol='HTTP/1.0',
-                              port='8000')
-
-        # Make sure we picked up host from HTTP_HOST, not SERVER_NAME
-        host = self.resource.req.get_header('host')
-        self.assertEqual(host, 'localhost:8000')
-
     def test_no_body_on_100(self):
         self.resource = StatusTestResource(falcon.HTTP_100)
         self.api.add_route('/1xx', self.resource)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,6 +185,50 @@ class TestFalconUtils(testtools.TestCase):
             actual = uri.decode(case)
             self.assertEqual(expect, actual)
 
+    def test_parse_host(self):
+        self.assertEqual(uri.parse_host('::1'), ('::1', None))
+        self.assertEqual(uri.parse_host('2001:ODB8:AC10:FE01::'),
+                         ('2001:ODB8:AC10:FE01::', None))
+        self.assertEqual(
+            uri.parse_host('2001:ODB8:AC10:FE01::', default_port=80),
+            ('2001:ODB8:AC10:FE01::', 80))
+
+        ipv6_addr = '2001:4801:1221:101:1c10::f5:116'
+
+        self.assertEqual(uri.parse_host(ipv6_addr), (ipv6_addr, None))
+        self.assertEqual(uri.parse_host('[' + ipv6_addr + ']'),
+                         (ipv6_addr, None))
+        self.assertEqual(uri.parse_host('[' + ipv6_addr + ']:28080'),
+                         (ipv6_addr, 28080))
+        self.assertEqual(uri.parse_host('[' + ipv6_addr + ']:8080'),
+                         (ipv6_addr, 8080))
+        self.assertEqual(uri.parse_host('[' + ipv6_addr + ']:123'),
+                         (ipv6_addr, 123))
+        self.assertEqual(uri.parse_host('[' + ipv6_addr + ']:42'),
+                         (ipv6_addr, 42))
+
+        self.assertEqual(uri.parse_host('173.203.44.122'),
+                         ('173.203.44.122', None))
+        self.assertEqual(uri.parse_host('173.203.44.122', default_port=80),
+                         ('173.203.44.122', 80))
+        self.assertEqual(uri.parse_host('173.203.44.122:27070'),
+                         ('173.203.44.122', 27070))
+        self.assertEqual(uri.parse_host('173.203.44.122:123'),
+                         ('173.203.44.122', 123))
+        self.assertEqual(uri.parse_host('173.203.44.122:42'),
+                         ('173.203.44.122', 42))
+
+        self.assertEqual(uri.parse_host('example.com'),
+                         ('example.com', None))
+        self.assertEqual(uri.parse_host('example.com', default_port=443),
+                         ('example.com', 443))
+        self.assertEqual(uri.parse_host('falcon.example.com'),
+                         ('falcon.example.com', None))
+        self.assertEqual(uri.parse_host('falcon.example.com:9876'),
+                         ('falcon.example.com', 9876))
+        self.assertEqual(uri.parse_host('falcon.example.com:42'),
+                         ('falcon.example.com', 42))
+
 
 class TestFalconTesting(falcon.testing.TestBase):
     """Catch some uncommon branches not covered elsewhere."""


### PR DESCRIPTION
This patch adds two new properties, .host and .subdomain, to the
Request class. req.host works with domain names, as well as IP
addresses (IPv4 and IPv6).

In support of these new properties, .parse_host was added to the
uri module. uri.parse_host returns both the host and port, but
req.host ignores the port (if any). This was done so that apps
may call uri.parse_host directly if desired, in order to parse
out a canonical host:port string.

Closes #332
