### PR TITLE
fix(HTTPError): Remove dependency on blank title to determine serialization

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -371,7 +371,7 @@ class API(object):
         if error.headers is not None:
             resp.set_headers(error.headers)
 
-        if error.serializable:
+        if error.has_representation:
             media_type, body = self._serialize_error(req, error)
 
             if body is not None:

--- a/tests/test_after_hooks.py
+++ b/tests/test_after_hooks.py
@@ -5,7 +5,7 @@ import falcon.testing as testing
 
 
 def validate_output(req, resp):
-    raise falcon.HTTPError(falcon.HTTP_723, title=None)
+    raise falcon.HTTPError(falcon.HTTP_723, 'Tricky')
 
 
 def serialize_body(req, resp):
@@ -257,7 +257,9 @@ class TestHooks(testing.TestBase):
     def test_output_validator(self):
         self.simulate_request(self.test_route)
         self.assertEqual(falcon.HTTP_723, self.srmock.status)
-        self.assertEqual(None, self.resource.resp.body_encoded)
+
+        expected = b'{\n    "title": "Tricky"\n}'
+        self.assertEqual(expected, self.resource.resp.body_encoded)
 
     def test_serializer(self):
         self.simulate_request(self.test_route, method='PUT')

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -37,7 +37,7 @@ class FaultyResource:
             code=8733224)
 
     def on_patch(self, req, resp):
-        raise falcon.HTTPError(falcon.HTTP_400, 'No-can-do')
+        raise falcon.HTTPError(falcon.HTTP_400)
 
 
 class UnicodeFaultyResource(object):
@@ -166,7 +166,7 @@ class TestHTTPError(testing.TestBase):
     def test_no_description_json(self):
         body = self.simulate_request('/fail', method='PATCH')
         self.assertEqual(self.srmock.status, falcon.HTTP_400)
-        self.assertEqual(body, [b'{\n    "title": "No-can-do"\n}'])
+        self.assertEqual(body, [b'{}'])
 
     def test_no_description_xml(self):
         body = self.simulate_request('/fail', method='PATCH',
@@ -174,7 +174,7 @@ class TestHTTPError(testing.TestBase):
         self.assertEqual(self.srmock.status, falcon.HTTP_400)
 
         expected_xml = (b'<?xml version="1.0" encoding="UTF-8"?>'
-                        b'<error><title>No-can-do</title></error>')
+                        b'<error />')
 
         self.assertEqual(body, [expected_xml])
 


### PR DESCRIPTION
This patch attempts to make the code easier to understand and maintain
going forward by removing the dependency between the title attribute and
the "serializable" property. The "serializable" property was renamed to
be more indicitive of the context in which it is actually used.

Closes #265
