### PR TITLE
fix(testing): create_environ does not decode the path

### DIFF
--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -20,6 +20,7 @@ from datetime import datetime
 import six
 
 import falcon
+from falcon.util import uri
 
 # Constants
 DEFAULT_HOST = 'falconframework.org'
@@ -87,6 +88,10 @@ def create_environ(path='/', query_string='', protocol='HTTP/1.1',
 
     body = io.BytesIO(body.encode('utf-8')
                       if isinstance(body, six.text_type) else body)
+
+    # NOTE(kgriffs): wsgiref, gunicorn, and uWSGI all unescape
+    # the paths before setting PATH_INFO
+    path = uri.decode(path)
 
     # NOTE(kgriffs): nocover since this branch will never be
     # taken in Python3. However, the branch is tested under Py2,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,6 +233,10 @@ class TestFalconUtils(testtools.TestCase):
 class TestFalconTesting(falcon.testing.TestBase):
     """Catch some uncommon branches not covered elsewhere."""
 
+    def test_path_escape_chars_in_create_environ(self):
+        env = falcon.testing.create_environ('/hello%20world%21')
+        self.assertEqual(env['PATH_INFO'], '/hello world!')
+
     def test_unicode_path_in_create_environ(self):
         if six.PY3:
             self.skip('Test does not apply to Py3K')


### PR DESCRIPTION
WSGI servers decode the path submitted in the request before passing it
to the app via the PATH_INFO environ field (wsgiref, uWSGI, and gunicorn
were tested to verify this behavior). This patch updates create_environ
to behave similarly.
