### PR TITLE
Run tests/benchmarks on PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - TOX_ENV=py33
   - TOX_ENV=py33_cython
   - TOX_ENV=pypy
+  - TOX_ENV=pypy3
   - TOX_ENV=pep8
   - TOX_ENV=pylint
   - TOX_ENV=py27_smoke

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist = py26,
           py34,
           py34_cython,
           pypy,
+          pypy3,
           pep8,
           pylint,
           py27_smoke,
@@ -19,6 +20,7 @@ envlist = py26,
           ; py34_bench,
           ; py34_bench_cython,
           ; pypy_bench
+          ; pypy3_bench
 
 [testenv]
 deps = -r{toxinidir}/tools/test-requires
@@ -121,6 +123,11 @@ commands = falcon-bench -b falcon -b falcon-ext -b pecan -b bottle {posargs}
 [testenv:pypy_bench]
 deps = -r{toxinidir}/tools/bench-requires
 basepython = pypy
+commands = falcon-bench {posargs}
+
+[testenv:pypy3_bench]
+deps = -r{toxinidir}/tools/bench-requires
+basepython = pypy3
 commands = falcon-bench {posargs}
 
 


### PR DESCRIPTION
Unfortunately, PyPy3 seems pretty slow:

``` console
rouge8 at andy-laptop in ~/tmp/falcon on git:pypy3
$ tox -e pypy_bench,pypy3_bench
GLOB sdist-make: /Users/rouge8/tmp/falcon/setup.py
pypy_bench create: /Users/rouge8/tmp/falcon/.tox/pypy_bench
pypy_bench installdeps: -r/Users/rouge8/tmp/falcon/tools/bench-requires
pypy_bench inst: /Users/rouge8/tmp/falcon/.tox/dist/falcon-0.2.0a1.zip
pypy_bench runtests: PYTHONHASHSEED='3965413554'
pypy_bench runtests: commands[0] | falcon-bench

Benchmarking, Trial 1 of 3......done.
Benchmarking, Trial 2 of 3......done.
Benchmarking, Trial 3 of 3......done.

Results:

1. falcon.........165327 req/sec or 6.05 μs/req (101x)
2. bottle.........127429 req/sec or 7.85 μs/req (78x)
3. falcon-ext.....103420 req/sec or 9.67 μs/req (63x)
4. werkzeug........47438 req/sec or 21.08 μs/req (29x)
5. flask...........10991 req/sec or 90.98 μs/req (7x)
6. pecan............1637 req/sec or 611.03 μs/req (1x)

pypy3_bench create: /Users/rouge8/tmp/falcon/.tox/pypy3_bench
pypy3_bench installdeps: -r/Users/rouge8/tmp/falcon/tools/bench-requires
pypy3_bench inst: /Users/rouge8/tmp/falcon/.tox/dist/falcon-0.2.0a1.zip
pypy3_bench runtests: PYTHONHASHSEED='3965413554'
pypy3_bench runtests: commands[0] | falcon-bench

Benchmarking, Trial 1 of 3......done.
Benchmarking, Trial 2 of 3......done.
Benchmarking, Trial 3 of 3......done.

Results:

1. falcon.........122550 req/sec or 8.16 μs/req (51x)
2. falcon-ext......17388 req/sec or 57.51 μs/req (7x)
3. bottle..........10261 req/sec or 97.46 μs/req (4x)
4. werkzeug.........3542 req/sec or 282.31 μs/req (1x)
5. pecan............2680 req/sec or 373.11 μs/req (1x)
6. flask............2402 req/sec or 416.26 μs/req (1x)

________________________________________________________________ summary _________________________________________________________________
  pypy_bench: commands succeeded
  pypy3_bench: commands succeeded
  congratulations :)
```
