### PR TITLE
perf(Request): Use partition in lieu of split

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -320,7 +320,10 @@ class Request(object):
             raise HTTPInvalidHeader(msg, 'Range')
 
         try:
-            first, last = value.split('-')
+            first, sep, last = value.partition('-')
+
+            if not sep:
+                raise ValueError()
 
             if first:
                 return (int(first), int(last or -1))
@@ -333,7 +336,7 @@ class Request(object):
         except ValueError:
             href = 'http://goo.gl/zZ6Ey'
             href_text = 'HTTP/1.1 Range Requests'
-            msg = ('It must be formatted according to RFC 2616.')
+            msg = ('It must be a byte range formatted according to RFC 2616.')
             raise HTTPInvalidHeader(msg, 'Range', href=href,
                                     href_text=href_text)
 

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -417,8 +417,8 @@ class TestReqVars(testing.TestBase):
 
         headers = {'Range': 'x-y'}
         expected_desc = ('The value provided for the Range header is '
-                         'invalid. It must be formatted according to '
-                         'RFC 2616.')
+                         'invalid. It must be a byte range formatted '
+                         'according to RFC 2616.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value', expected_desc)


### PR DESCRIPTION
In the range property, use string.partition instead of string.split, since
the latter executes slightly faster.
