### PR TITLE
refactor(HTTPError): Add a "to_" prefix to serialization methods

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -198,9 +198,9 @@ def serialize_error(req, exception):
 
     if preferred is not None:
         if preferred == 'application/json':
-            representation = exception.json()
+            representation = exception.to_json()
         else:
-            representation = exception.xml()
+            representation = exception.to_xml()
 
     return (preferred, representation)
 

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -115,7 +115,7 @@ class HTTPError(Exception):
     def has_representation(self):
         return True
 
-    def dict(self, obj_type=dict):
+    def to_dict(self, obj_type=dict):
         """Returns a basic dictionary representing the error.
 
         This method can be useful when serializing the error to hash-like
@@ -148,7 +148,7 @@ class HTTPError(Exception):
 
         return obj
 
-    def json(self):
+    def to_json(self):
         """Returns a pretty-printed JSON representation of the error.
 
         Returns:
@@ -156,11 +156,11 @@ class HTTPError(Exception):
 
         """
 
-        obj = self.dict(OrderedDict)
+        obj = self.to_dict(OrderedDict)
         return json.dumps(obj, indent=4, separators=(',', ': '),
                           ensure_ascii=False)
 
-    def xml(self):
+    def to_xml(self):
         """Returns an XML-encoded representation of the error.
 
         Returns:

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -241,7 +241,7 @@ class TestHTTPError(testing.TestBase):
                 if preferred == 'application/json':
                     representation = exception.json()
                 else:
-                    representation = yaml.dump(exception.dict(),
+                    representation = yaml.dump(exception.to_dict(),
                                                encoding=None)
 
             return (preferred, representation)


### PR DESCRIPTION
Perfix the serialization method names (.dict, .json, .xml) with
"to_" in order to more clearly express their utility.
