### PR TITLE
test(req.uri): Test HTTPS URIs

### DIFF
--- a/falcon/testing/base.py
+++ b/falcon/testing/base.py
@@ -70,7 +70,7 @@ class TestBase(unittest.TestCase):
 
     # NOTE(warsaw): Pythons earlier than 2.7 do not have a self.assertIn()
     # method, so use this compatibility function instead.
-    if not hasattr(unittest.TestCase, 'assertIn'):
+    if not hasattr(unittest.TestCase, 'assertIn'):  # pragma: nocover
         def assertIn(self, a, b):
             self.assertTrue(a in b)
 

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -120,6 +120,34 @@ class TestReqVars(testing.TestBase):
         uri_noqs = ('http://' + testing.DEFAULT_HOST + self.app + self.path)
         self.assertEqual(self.req_noqs.uri, uri_noqs)
 
+    def test_uri_https(self):
+        # =======================================================
+        # Default port, implicit
+        # =======================================================
+        req = Request(testing.create_environ(
+            path='/hello', scheme='https'))
+        uri = ('https://' + testing.DEFAULT_HOST + '/hello')
+
+        self.assertEqual(req.uri, uri)
+
+        # =======================================================
+        # Default port, explicit
+        # =======================================================
+        req = Request(testing.create_environ(
+            path='/hello', scheme='https', port=443))
+        uri = ('https://' + testing.DEFAULT_HOST + '/hello')
+
+        self.assertEqual(req.uri, uri)
+
+        # =======================================================
+        # Non-default port
+        # =======================================================
+        req = Request(testing.create_environ(
+            path='/hello', scheme='https', port=22))
+        uri = ('https://' + testing.DEFAULT_HOST + ':22/hello')
+
+        self.assertEqual(req.uri, uri)
+
     def test_uri_http_1_0(self):
         # =======================================================
         # HTTP, 80

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -82,7 +82,7 @@ class TestWsgi(testtools.TestCase):
         thread.start()
 
         # Wait a moment for the thread to start up
-        time.sleep(0.1)
+        time.sleep(0.2)
 
         resp = requests.get('http://localhost:9803')
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
Add tests to cover HTTPS URIs using default and non-default ports.
