### PR TITLE
doc(API): Improve middleware and req_options docs

### DIFF
--- a/doc/api/api.rst
+++ b/doc/api/api.rst
@@ -16,4 +16,7 @@ standard-compliant WSGI server.
     :members:
     :undoc-members:
 
+.. autoclass:: falcon.RequestOptions
+    :members:
+
 

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -35,5 +35,5 @@ from falcon.errors import *  # NOQA
 from falcon.http_error import HTTPError  # NOQA
 from falcon.util import *  # NOQA
 from falcon.hooks import before, after  # NOQA
-from falcon.request import Request  # NOQA
+from falcon.request import Request, RequestOptions  # NOQA
 from falcon.response import Response  # NOQA

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -911,10 +911,14 @@ class Request(object):
             self._params.update(extra_params)
 
 
+# PERF: To avoid typos and improve storage space and speed over a dict.
 class RequestOptions(object):
     """This class is a container for Request options.
 
-    PERF: To avoid typos and improve storage space and speed over a dict.
+    Attributes:
+        keep_blank_qs_values (bool): Set to ``True`` in order to retain
+            blank values in query string parameters (default ``False``.)
+
     """
     __slots__ = (
         'keep_blank_qs_values',


### PR DESCRIPTION
Expand middleware documentation and add API.req_options docs to the
API reference.
