### PR TITLE
refactor(API): Distinguish between different types of helpers

### DIFF
--- a/doc/api/routing.rst
+++ b/doc/api/routing.rst
@@ -1,0 +1,14 @@
+.. _routing:
+
+Routing
+=======
+
+The *falcon.routing* module contains utilities used internally by
+``falcon.API`` to route requests. They are exposed here for use by
+classes that inherit from ``falcon.API`` to implement custom
+routing logic, and in anticipation of a future version of the
+framework that will afford customization of routing via composition
+in lieu of inheritance.
+
+.. automodule:: falcon.routing
+    :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -116,5 +116,6 @@ Classes and Functions
    api/status
    api/errors
    api/hooks
+   api/routing
    api/util
 

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -1,0 +1,126 @@
+# Copyright 2013 by Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from falcon import util
+
+
+def prepare_global_hooks(hooks):
+    if hooks is not None:
+        if not isinstance(hooks, list):
+            hooks = [hooks]
+
+        for action in hooks:
+            if not callable(action):
+                raise TypeError('One or more hooks are not callable')
+
+    return hooks
+
+
+def prepare_middleware(middleware=None):
+    """Check middleware interface and prepare it to iterate.
+
+    Args:
+        middleware:  list (or object) of input middleware
+
+    Returns:
+        A middleware list
+    """
+
+    # PERF(kgriffs): do getattr calls once, in advance, so we don't
+    # have to do them every time in the request path.
+    prepared_middleware = []
+
+    if middleware is None:
+        middleware = []
+    else:
+        if not isinstance(middleware, list):
+            middleware = [middleware]
+
+    for component in middleware:
+        process_request = util.get_bound_method(component,
+                                                'process_request')
+        process_response = util.get_bound_method(component,
+                                                 'process_response')
+
+        if not (process_request or process_response):
+            msg = '{0} does not implement the middleware interface'
+            raise TypeError(msg.format(component))
+
+        prepared_middleware.append((process_request, process_response))
+
+    return prepared_middleware
+
+
+def default_serialize_error(req, exception):
+    """Serialize the given instance of HTTPError.
+
+    This function determines which of the supported media types, if
+    any, are acceptable by the client, and serializes the error
+    to the preferred type.
+
+    Currently, JSON and XML are the only supported media types. If the
+    client accepts both JSON and XML with equal weight, JSON will be
+    chosen.
+
+    Other media types can be supported by using a custom error serializer.
+
+    Note:
+        If a custom media type is used and the type includes a
+        "+json" or "+xml" suffix, the error will be serialized
+        to JSON or XML, respectively. If this behavior is not
+        desirable, a custom error serializer may be used to
+        override this one.
+
+    Args:
+        req: Instance of falcon.Request
+        exception: Instance of falcon.HTTPError
+
+    Returns:
+        A tuple of the form ``(media_type, representation)``, or
+        ``(None, None)`` if the client does not support any of the
+        available media types.
+
+    """
+    representation = None
+
+    preferred = req.client_prefers(('application/xml',
+                                    'text/xml',
+                                    'application/json'))
+
+    if preferred is None:
+        # NOTE(kgriffs): See if the client expects a custom media
+        # type based on something Falcon supports. Returning something
+        # is probably better than nothing, but if that is not
+        # desired, this behavior can be customized by adding a
+        # custom HTTPError serializer for the custom type.
+        accept = req.accept.lower()
+
+        # NOTE(kgriffs): Simple heuristic, but it's fast, and
+        # should be sufficiently accurate for our purposes. Does
+        # not take into account weights if both types are
+        # acceptable (simply chooses JSON). If it turns out we
+        # need to be more sophisticated, we can always change it
+        # later (YAGNI).
+        if '+json' in accept:
+            preferred = 'application/json'
+        elif '+xml' in accept:
+            preferred = 'application/xml'
+
+    if preferred is not None:
+        if preferred == 'application/json':
+            representation = exception.to_json()
+        else:
+            representation = exception.to_xml()
+
+    return (preferred, representation)

--- a/falcon/routing.py
+++ b/falcon/routing.py
@@ -1,0 +1,126 @@
+# Copyright 2013 by Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import six
+
+from falcon.hooks import _wrap_with_hooks
+from falcon import HTTP_METHODS, responders
+
+
+# NOTE(kgriffs): Published method; take care to avoid breaking changes.
+def compile_uri_template(template):
+    """Compile the given URI template string into a pattern matcher.
+
+    This function currently only recognizes Level 1 URI templates, and only
+    for the path portion of the URI.
+
+    See also: http://tools.ietf.org/html/rfc6570
+
+    Args:
+        template: A Level 1 URI template. Method responders must accept, as
+            arguments, all fields specified in the template (default '/').
+            Note that field names are restricted to ASCII a-z, A-Z, and
+            the underscore '_'.
+
+    Returns:
+        tuple: (template_field_names, template_regex)
+
+    """
+
+    if not isinstance(template, six.string_types):
+        raise TypeError('uri_template is not a string')
+
+    if not template.startswith('/'):
+        raise ValueError("uri_template must start with '/'")
+
+    if '//' in template:
+        raise ValueError("uri_template may not contain '//'")
+
+    if template != '/' and template.endswith('/'):
+        template = template[:-1]
+
+    expression_pattern = r'{([a-zA-Z][a-zA-Z_]*)}'
+
+    # Get a list of field names
+    fields = set(re.findall(expression_pattern, template))
+
+    # Convert Level 1 var patterns to equivalent named regex groups
+    escaped = re.sub(r'[\.\(\)\[\]\?\*\+\^\|]', r'\\\g<0>', template)
+    pattern = re.sub(expression_pattern, r'(?P<\1>[^/]+)', escaped)
+    pattern = r'\A' + pattern + r'\Z'
+
+    return fields, re.compile(pattern, re.IGNORECASE)
+
+
+# NOTE(kgriffs): Published method; take care to avoid breaking changes.
+def create_http_method_map(resource, uri_fields, before, after):
+    """Maps HTTP methods (e.g., GET, POST) to methods of a resource object.
+
+    Args:
+        resource: An object with *responder* methods, following the naming
+            convention *on_\**, that correspond to each method the resource
+            supports. For example, if a resource supports GET and POST, it
+            should define ``on_get(self, req, resp)`` and
+            ``on_post(self, req, resp)``.
+        uri_fields: A set of field names from the route's URI template
+            that a responder must support in order to avoid "method not
+            allowed".
+        before: An action hook or list of hooks to be called before each
+            *on_\** responder defined by the resource.
+        after: An action hook or list of hooks to be called after each
+            *on_\** responder defined by the resource.
+
+    Returns:
+        dict: A mapping of HTTP methods to responders.
+
+    """
+
+    method_map = {}
+
+    for method in HTTP_METHODS:
+        try:
+            responder = getattr(resource, 'on_' + method.lower())
+        except AttributeError:
+            # resource does not implement this method
+            pass
+        else:
+            # Usually expect a method, but any callable will do
+            if callable(responder):
+                responder = _wrap_with_hooks(
+                    before, after, responder, resource)
+                method_map[method] = responder
+
+    # Attach a resource for unsupported HTTP methods
+    allowed_methods = sorted(list(method_map.keys()))
+
+    # NOTE(sebasmagri): We want the OPTIONS and 405 (Not Allowed) methods
+    # responders to be wrapped on global hooks
+    if 'OPTIONS' not in method_map:
+        # OPTIONS itself is intentionally excluded from the Allow header
+        responder = responders.create_default_options(
+            allowed_methods)
+        method_map['OPTIONS'] = _wrap_with_hooks(
+            before, after, responder, resource)
+        allowed_methods.append('OPTIONS')
+
+    na_responder = responders.create_method_not_allowed(allowed_methods)
+
+    for method in HTTP_METHODS:
+        if method not in allowed_methods:
+            method_map[method] = _wrap_with_hooks(
+                before, after, na_responder, resource)
+
+    return method_map


### PR DESCRIPTION
Divide the helper methods into three groups:
1. Internal functions that are specific to the API class but do not
   require access to self. These go in "api_helpers".
2. Functions that are used for the API class but may also be useful
   to higher-level or custom web frameworks building on Falcon. There
   are presently two such functions, both related to routing, so they
   go into a new module, "routing". These functions will be included
   in Falcon's reference documentation, and care must be taken to
   avoid introducing breaking changes to them in future versions of
   the framework.
3. Functions that only need access to self for performance reasons,
   which would otherwise reside in "api_helpers". These go inside the
   definition of the API class itself.
