### PR TITLE
bug(API): routing logic should be done after request mw

### DIFF
--- a/falcon/bench/queues/api.py
+++ b/falcon/bench/queues/api.py
@@ -22,7 +22,7 @@ from falcon.bench.queues import stats
 
 
 class RequestIDComponent(object):
-    def process_request(self, req, resp, params):
+    def process_request(self, req, resp):
         req.context['request_id'] = '<generate ID>'
 
     def process_response(self, req, resp):
@@ -30,7 +30,7 @@ class RequestIDComponent(object):
 
 
 class NoopComponent(object):
-    def process_request(self, req, resp, params):
+    def process_request(self, req, resp):
         pass
 
 


### PR DESCRIPTION
Routing logic should be done after the execution of request middleware. The execution of request middleware could
change the path, method, etc... They should be aware of routing logic
