### PR TITLE
Improve HTTP_RANGE support, Fix #380

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -340,6 +340,8 @@ class Request(object):
     def range(self):
         try:
             value = self.env['HTTP_RANGE']
+            if value.startswith('bytes='):
+                value = value[6:]
         except KeyError:
             return None
 

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -380,6 +380,10 @@ class TestReqVars(testing.TestBase):
         req = Request(testing.create_environ(headers=headers))
         self.assertEqual(req.range, (-10240, -1))
 
+        headers = {'Range': 'bytes=0-2'}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertEqual(req.range, (0, 2))
+
         headers = {'Range': ''}
         req = Request(testing.create_environ(headers=headers))
         self.assertRaises(falcon.HTTPInvalidHeader, lambda: req.range)


### PR DESCRIPTION
- Added a test to check whether "bytes=" is supported
- added a simple way to support the "bytes=" prefix by stripping it if present
  This should not break backward compatibility.
