### PR TITLE
fix(errors): bring 404 and 405 errors into RFC compliance

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from falcon.http_error import HTTPError, NoRepresentation
+from falcon.http_error import HTTPError, NoRepresentation, \
+    OptionalRepresentation
 import falcon.status_codes as status
 
 
@@ -85,7 +86,7 @@ class HTTPForbidden(HTTPError):
         HTTPError.__init__(self, status.HTTP_403, title, description, **kwargs)
 
 
-class HTTPNotFound(NoRepresentation, HTTPError):
+class HTTPNotFound(OptionalRepresentation, HTTPError):
     """404 Not Found.
 
     Use this when the URL path does not map to an existing resource, or you
@@ -93,11 +94,11 @@ class HTTPNotFound(NoRepresentation, HTTPError):
 
     """
 
-    def __init__(self):
-        HTTPError.__init__(self, status.HTTP_404)
+    def __init__(self, **kwargs):
+        super(HTTPNotFound, self).__init__(status.HTTP_404, **kwargs)
 
 
-class HTTPMethodNotAllowed(NoRepresentation, HTTPError):
+class HTTPMethodNotAllowed(OptionalRepresentation, HTTPError):
     """405 Method Not Allowed.
 
     The method specified in the Request-Line is not allowed for the
@@ -111,9 +112,14 @@ class HTTPMethodNotAllowed(NoRepresentation, HTTPError):
 
     """
 
-    def __init__(self, allowed_methods):
-        headers = {'Allow': ', '.join(allowed_methods)}
-        HTTPError.__init__(self, status.HTTP_405, headers=headers)
+    def __init__(self, allowed_methods, **kwargs):
+        new_headers = {'Allow': ', '.join(allowed_methods)}
+        super(HTTPMethodNotAllowed, self).__init__(status.HTTP_405,
+                                                   **kwargs)
+        if not self.headers:
+            self.headers = {}
+
+        self.headers.update(new_headers)
 
 
 class HTTPNotAcceptable(HTTPError):

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -213,3 +213,26 @@ class NoRepresentation(object):
     @property
     def has_representation(self):
         return False
+
+
+class OptionalRepresentation(object):
+    """Mixin for ``HTTPError`` child classes that may have a representation.
+
+    This class can be mixed in when inheriting from ``HTTPError``, in order
+    to override the `has_representation` property, such that it optionally
+    returns ``False``. This, in turn, will cause Falcon to return an empty
+    response body to the client.
+
+    You can use this mixin when defining errors that either may optionally have
+    a body (as dictated by HTTP standards or common practice), or in the
+    case that a detailed error response may leak information to an attacker.
+
+    Note:
+        This mixin class must appear before ``HTTPError`` in the base class
+        list when defining the child; otherwise, it will not override the
+        `has_representation` property as expected.
+
+    """
+    @property
+    def has_representation(self):
+        return super(OptionalRepresentation, self).description is not None


### PR DESCRIPTION
Per RFC 7231 6.5 states that 4xx errors should include a message to the user.
Corrects the 404 and 405 errors so that developers may provide all the same options
as available with other errors (f.e description, title, etc) in order to make them
RFC compliance while preserving the same default behavior.

No breaking changes. Default behavior is same as legacy behavior.
Closes JIRA Issue #331.
