### PR TITLE
Middleware object example using bound methods

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -45,7 +45,7 @@ class API(object):
             implement the following middleware component interface::
 
                 class ExampleComponent(object):
-                    def process_request(req, resp, params):
+                    def process_request(self, req, resp, params):
                         \"""Process the request before routing it.
 
                         Args:
@@ -55,7 +55,7 @@ class API(object):
                                 the on_* responder
                         \"""
 
-                    def process_response(req, resp)
+                    def process_response(self, req, resp)
                         \"""Post-processing of the response (after routing).
                         \"""
 


### PR DESCRIPTION
The `ExampleComponent` interface example didn't work for me so I updated it to use bound methods on the piece of Middleware.

Is this how Middlware is used with Falcon?

```
from falcon import API

class Middleware(object):
    def process_request(self, req, resp, params):
        pass
    def process_response(self, req, resp):
        pass

app = API(middleware=Middleware())
```
