### PR TITLE
(fix)(utils/uri) change decode behavior for handle json/url values

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -220,16 +220,13 @@ class Request(object):
 
         # PERF(kgriffs): if...in is faster than using env.get(...)
         if 'QUERY_STRING' in env:
-            query_str = env['QUERY_STRING']
+            self.query_string = env['QUERY_STRING']
 
-            if query_str:
-                self.query_string = uri.decode(query_str)
+            if self.query_string:
                 self._params = uri.parse_query_string(
                     self.query_string,
                     keep_blank_qs_values=self.options.keep_blank_qs_values,
                 )
-            else:
-                self.query_string = six.text_type()
 
         else:
             self.query_string = six.text_type()
@@ -915,7 +912,7 @@ class Request(object):
 
         if body:
             extra_params = uri.parse_query_string(
-                uri.decode(body),
+                body,
                 keep_blank_qs_values=self.options.keep_blank_qs_values,
             )
 

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -49,7 +49,7 @@ class _TestQueryParams(testing.TestBase):
         self.assertEqual(store['limit'], '25')
 
     def test_percent_encoded(self):
-        query_string = 'id=23%2c42&q=%e8%b1%86+%e7%93%a3'
+        query_string = 'id=23,42&q=%e8%b1%86+%e7%93%a3'
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,6 +185,38 @@ class TestFalconUtils(testtools.TestCase):
             actual = uri.decode(case)
             self.assertEqual(expect, actual)
 
+    def test_parse_query_string(self):
+        query_strinq = (
+            "a=http%3A%2F%2Ffalconframework.org%3Ftest%3D1"
+            "&b=%7B%22test1%22%3A%20%22data1%22%"
+            "2C%20%22test2%22%3A%20%22data2%22%7D"
+            "&c=1,2,3"
+            "&d=test"
+            "&e=a,,%26%3D%2C"
+            "&f=a&f=a%3Db"
+            "&%C3%A9=a%3Db"
+        )
+        decoded_url = 'http://falconframework.org?test=1'
+        decoded_json = '{"test1": "data1", "test2": "data2"}'
+
+        result = uri.parse_query_string(query_strinq)
+        self.assertEqual(result['a'], decoded_url)
+        self.assertEqual(result['b'], decoded_json)
+        self.assertEqual(result['c'], ['1', '2', '3'])
+        self.assertEqual(result['d'], 'test')
+        self.assertEqual(result['e'], ['a', '&=,'])
+        self.assertEqual(result['f'], ['a', 'a=b'])
+        self.assertEqual(result[u'é'], 'a=b')
+
+        result = uri.parse_query_string(query_strinq, True)
+        self.assertEqual(result['a'], decoded_url)
+        self.assertEqual(result['b'], decoded_json)
+        self.assertEqual(result['c'], ['1', '2', '3'])
+        self.assertEqual(result['d'], 'test')
+        self.assertEqual(result['e'], ['a', '', '&=,'])
+        self.assertEqual(result['f'], ['a', 'a=b'])
+        self.assertEqual(result[u'é'], 'a=b')
+
     def test_parse_host(self):
         self.assertEqual(uri.parse_host('::1'), ('::1', None))
         self.assertEqual(uri.parse_host('2001:ODB8:AC10:FE01::'),


### PR DESCRIPTION
Fix problem when client send json/full url percent-encoded in a query string.
Now make decode in parse_query_string rather than in the requests processing.

ex:
url=http%3A%2F%2Ffalconframework.org%3Ftest%3D1
json=%7B%22test1%22%3A%20%22data1%22%2C%20%22test2%22%3A%20%22data2%22%7D