### PR TITLE
fix(dependencies): falcon needs at least six 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ VERSION = VERSION.__version__
 
 # NOTE(kgriffs): python-mimeparse is newer than mimeparse, supports Py3
 # TODO(kgriffs): Fork and optimize/modernize python-mimeparse
-REQUIRES = ['six', 'python-mimeparse']
+REQUIRES = ['six>=1.4.0', 'python-mimeparse']
 
 PYPY = True
 CYTHON = False


### PR DESCRIPTION
six.PY2 is used several times in falcon, but that wasn't added to six until 1.4.0