### PR TITLE
doc(README): Updating CI status badges to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Falcon [![Build Status](https://travis-ci.org/racker/falcon.png)](https://travis-ci.org/racker/falcon) [![Coverage Status](https://coveralls.io/repos/racker/falcon/badge.png?branch=master)](https://coveralls.io/r/racker/falcon)
+Falcon [![Build Status](https://travis-ci.org/racker/falcon.svg)](https://travis-ci.org/racker/falcon) [![Coverage Status](https://coveralls.io/repos/racker/falcon/badge.svg?branch=master)](https://coveralls.io/r/racker/falcon)
 ======
 
 :runner: Come hang out with us in **#falconframework** on freenode.

--- a/README.rst
+++ b/README.rst
@@ -434,7 +434,7 @@ permissions and limitations under the License.
 .. |Runner| image:: https://a248.e.akamai.net/assets.github.com/images/icons/emoji/runner.png
     :width: 20
     :height: 20
-.. |Build Status| image:: https://travis-ci.org/racker/falcon.png
+.. |Build Status| image:: https://travis-ci.org/racker/falcon.svg
    :target: https://travis-ci.org/racker/falcon
-.. |Coverage Status| image:: https://coveralls.io/repos/racker/falcon/badge.png?branch=master
+.. |Coverage Status| image:: https://coveralls.io/repos/racker/falcon/badge.svg?branch=master
    :target: https://coveralls.io/r/racker/falcon


### PR DESCRIPTION
Using svgs for the badges produces a more consistent visual experience
when rendered.