### PR TITLE
fix(falcon/request): HTTP headers as strings

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -152,9 +152,8 @@ class Response(object):
                 may be used on platforms that use wide characters.
 
         """
-
         # NOTE(kgriffs): normalize name by lowercasing it
-        self._headers[name.lower()] = value
+        self._headers[str(name).lower()] = str(value)
 
     def append_header(self, name, value):
         """Set or append a header for this response.
@@ -174,11 +173,11 @@ class Response(object):
                 may be used on platforms that use wide characters.
 
         """
-        name = name.lower()
+        name = str(name).lower()
         if name in self._headers:
             value = self._headers[name] + ',' + value
 
-        self._headers[name] = value
+        self._headers[name] = str(value)
 
     def set_headers(self, headers):
         """Set several headers at once.
@@ -209,7 +208,7 @@ class Response(object):
         # normalize the header names.
         _headers = self._headers
         for name, value in headers:
-            _headers[name.lower()] = value
+            _headers[str(name).lower()] = str(value)
 
     def add_link(self, target, rel, title=None, title_star=None,
                  anchor=None, hreflang=None, type_hint=None):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -117,6 +117,16 @@ class LocationHeaderUnicodeResource:
         resp.content_location = self.URL1
 
 
+class UnicodeHeaderResource:
+
+    def on_get(self, req, resp):
+        resp.set_headers([
+            (u'X-auTH-toKEN', 'toomanysecrets'),
+            ('Content-TYpE', u'application/json'),
+            (u'X-symBOl', u'\u0040'),
+        ])
+
+
 class VaryHeaderResource:
 
     def __init__(self, vary):
@@ -355,6 +365,19 @@ class TestHeaders(testing.TestBase):
 
         content_location = ('content-location', '/%C3%A7runchy/bacon')
         self.assertIn(content_location, self.srmock.headers)
+
+    def test_unicode_headers(self):
+        self.api.add_route(self.test_route, UnicodeHeaderResource())
+        self.simulate_request(self.test_route)
+
+        expect = ('x-auth-token', 'toomanysecrets')
+        self.assertIn(expect, self.srmock.headers)
+
+        expect = ('content-type', 'application/json')
+        self.assertIn(expect, self.srmock.headers)
+
+        expect = ('x-symbol', '@')
+        self.assertIn(expect, self.srmock.headers)
 
     def test_response_set_header(self):
         self.resource = HeaderHelpersResource()


### PR DESCRIPTION
Ensure HTTP headers and values are string types per PEP3333. This
fixes wsgi servers running under py2k.

Fixes #413
This doesn't enforce codepoint boundary yet (must be in \u00-\uFF)