### PR TITLE
doc(status): Document verbose status constants

### DIFF
--- a/doc/api/status.rst
+++ b/doc/api/status.rst
@@ -4,18 +4,31 @@ Status Codes
 ============
 
 Falcon provides a list of constants for common
-`HTTP response status codes <http://httpstatus.es>`_
-that you can use like so:
+`HTTP response status codes <http://httpstatus.es>`_.
+
+For example:
 
 .. code:: python
 
     # Override the default "200 OK" response status
     resp.status = falcon.HTTP_409
 
+Or, using the more verbose name:
+
+.. code:: python
+
+    resp.status = falcon.HTTP_CONFLICT
+
+Using these constants helps avoid typos and cuts down on the number of
+string objects that must be created when preparing responses.
+
 1xx Informational
 -----------------
 
 .. code:: python
+
+    HTTP_CONTINUE = HTTP_100
+    HTTP_SWITCHING_PROTOCOLS = HTTP_101
 
     HTTP_100 = '100 Continue'
     HTTP_101 = '101 Switching Protocols'
@@ -24,6 +37,9 @@ that you can use like so:
 -----------
 
 .. code:: python
+
+    HTTP_OK = HTTP_200
+    HTTP_CREATED = HTTP_201
 
     HTTP_200 = '200 OK'
     HTTP_201 = '201 Created'
@@ -39,6 +55,14 @@ that you can use like so:
 
 .. code:: python
 
+    HTTP_MULTIPLE_CHOICES = HTTP_300
+    HTTP_MOVED_PERMANENTLY = HTTP_301
+    HTTP_FOUND = HTTP_302
+    HTTP_SEE_OTHER = HTTP_303
+    HTTP_NOT_MODIFIED = HTTP_304
+    HTTP_USE_PROXY = HTTP_305
+    HTTP_TEMPORARY_REDIRECT = HTTP_307
+
     HTTP_300 = '300 Multiple Choices'
     HTTP_301 = '301 Moved Permanently'
     HTTP_302 = '302 Found'
@@ -51,6 +75,27 @@ that you can use like so:
 ----------------
 
 .. code:: python
+
+    HTTP_BAD_REQUEST = HTTP_400
+    HTTP_UNAUTHORIZED = HTTP_401  # <-- Really means "unauthenticated"
+    HTTP_PAYMENT_REQUIRED = HTTP_402
+    HTTP_FORBIDDEN = HTTP_403  # <-- Really means "unauthorized"
+    HTTP_NOT_FOUND = HTTP_404
+    HTTP_METHOD_NOT_ALLOWED = HTTP_405
+    HTTP_NOT_ACCEPTABLE = HTTP_406
+    HTTP_PROXY_AUTHENTICATION_REQUIRED = HTTP_407
+    HTTP_REQUEST_TIMEOUT = HTTP_408
+    HTTP_CONFLICT = HTTP_409
+    HTTP_GONE = HTTP_410
+    HTTP_LENGTH_REQUIRED = HTTP_411
+    HTTP_PRECONDITION_FAILED = HTTP_412
+    HTTP_REQUEST_ENTITY_TOO_LARGE = HTTP_413
+    HTTP_REQUEST_URI_TOO_LONG = HTTP_414
+    HTTP_UNSUPPORTED_MEDIA_TYPE = HTTP_415
+    HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = HTTP_416
+    HTTP_EXPECTATION_FAILED = HTTP_417
+    HTTP_IM_A_TEAPOT = HTTP_418
+    HTTP_UPGRADE_REQUIRED = HTTP_426
 
     HTTP_400 = '400 Bad Request'
     HTTP_401 = '401 Unauthorized'  # <-- Really means "unauthenticated"
@@ -77,6 +122,13 @@ that you can use like so:
 ----------------
 
 .. code:: python
+
+    HTTP_INTERNAL_SERVER_ERROR = HTTP_500
+    HTTP_NOT_IMPLEMENTED = HTTP_501
+    HTTP_BAD_GATEWAY = HTTP_502
+    HTTP_SERVICE_UNAVAILABLE = HTTP_503
+    HTTP_GATEWAY_TIMEOUT = HTTP_504
+    HTTP_HTTP_VERSION_NOT_SUPPORTED = HTTP_505
 
     HTTP_500 = '500 Internal Server Error'
     HTTP_501 = '501 Not Implemented'


### PR DESCRIPTION
Add verbose status constants to the RST docs so that developers can discover
them without having to use help().

See also #308