### PR TITLE
Add support for setting the realm to the HTTPUnauthorized class

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -49,18 +49,18 @@ class HTTPUnauthorized(HTTPError):
         title (str): Error title (e.g., 'Authentication Required').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-        scheme (str): Authentication scheme to use as the value of the
-            WWW-Authenticate header in the response (default ``None``).
+        challenges (iterable of str): One or more authentication
+            challenges to use as the value of the WWW-Authenticate header in
+            the response.
         kwargs (optional): Same as for ``HTTPError``.
 
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title, description, challenges, **kwargs):
         headers = kwargs.setdefault('headers', {})
 
-        scheme = kwargs.pop('scheme', None)
-        if scheme is not None:
-            headers['WWW-Authenticate'] = scheme
+        if challenges:
+            headers['WWW-Authenticate'] = ', '.join(challenges)
 
         HTTPError.__init__(self, status.HTTP_401, title, description, **kwargs)
 


### PR DESCRIPTION
Based on RFC 7235, add challenges to HTTP Unauthorized to indicate
authentication scheme. A server generating a 401 must send a WWW-Authenticate
header field containing at least one challenge

BREAKING CHANGE: Add new parameter to the __init__ method of class HTTPUnauthorized
to add determine authentication scheme in the WWW-Authenticate header field when a
401 (Unauthorized) is generated