### PR TITLE
docs(api): Add info to docstring about resource middleware

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -53,7 +53,7 @@ class API(object):
                         \"""
 
                     def process_resource(self, req, resp, resource):
-                        \"""Process the request after routing.
+                        \"""Process the request and resource *after* routing.
 
                         Args:
                             req: Request object that will be passed to the


### PR DESCRIPTION
The docstring for the api class has info about middleware.
The part about resource middleware was a little non-descriptive.

Change to docstring