### PR TITLE
chore(cython): Recusively remove compiled module files

### DIFF
--- a/tools/clean.sh
+++ b/tools/clean.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+find $1 \( -name '*.c' -or -name '*.so' -or -name '*.pyc' \) -delete

--- a/tools/clean_cythoned.sh
+++ b/tools/clean_cythoned.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-rm -f $1/*.c
-rm -f $1/*.so
-rm -f $1/*.pyc

--- a/tox.ini
+++ b/tox.ini
@@ -24,13 +24,13 @@ envlist = py26,
 
 [testenv]
 deps = -r{toxinidir}/tools/test-requires
-commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests {posargs}
 
 [testenv:py27]
 deps = -r{toxinidir}/tools/test-requires
        nose-cprof
-commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests \
                --with-cprofile \
                --cprofile-stats-erase \
@@ -41,7 +41,7 @@ commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
 deps = -r{toxinidir}/tools/test-requires
        cython
 basepython = python2.7
-commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests \
                {posargs}
 
@@ -49,7 +49,7 @@ commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
 deps = -r{toxinidir}/tools/test-requires
        cython
 basepython = python3.3
-commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests \
                {posargs}
 
@@ -57,7 +57,7 @@ commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
 deps = -r{toxinidir}/tools/test-requires
        cython
 basepython = python3.4
-commands = {toxinidir}/tools/clean_cythoned.sh {toxinidir}/falcon
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests \
                {posargs}
 


### PR DESCRIPTION
Modify clean_cythoned.sh to recusively delete compilation artifacts.