### PR TITLE
style(pep8): Allow lines up to 99 characters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -71,6 +71,7 @@ commands = flake8 \
              --max-complexity=15 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
              --ignore=F403 \
+             --max-line-length=99 \
              {posargs}
 
 [testenv:pylint]


### PR DESCRIPTION
Change flake8 config in tox.ini to allow lines up to 99 characters