### PR TITLE
feat(response): Add get_header method

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -136,6 +136,20 @@ class Response(object):
         self.stream = stream
         self.stream_len = stream_len
 
+    def get_header(self, name):
+        """Check if a header is set on the response.
+
+        Args:
+            name (str): Header name to set (case-insensitive).
+                The same rules apply here as the do to the name
+                argument of :py:meth:`set_header`.
+
+        Returns:
+            The raw value of the header if it is set, or ``None``
+            if it is not set.
+        """
+        return self._headers.get(name.lower(), None)
+
     def set_header(self, name, value):
         """Set a header for this response to a given value.
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -356,7 +356,7 @@ class TestHeaders(testing.TestBase):
         content_location = ('content-location', '/%C3%A7runchy/bacon')
         self.assertIn(content_location, self.srmock.headers)
 
-    def test_response_set_header(self):
+    def test_response_set_and_get_header(self):
         self.resource = HeaderHelpersResource()
         self.api.add_route(self.test_route, self.resource)
 
@@ -365,11 +365,13 @@ class TestHeaders(testing.TestBase):
 
             content_type = 'x-falcon/peregrine'
             self.assertIn(('content-type', content_type), self.srmock.headers)
+            self.assertEquals(self.resource.resp.get_header('content-type'), content_type)
             self.assertIn(('cache-control', 'no-store'), self.srmock.headers)
             self.assertIn(('x-auth-token', 'toomanysecrets'),
                           self.srmock.headers)
 
             self.assertEqual(None, self.resource.resp.location)
+            self.assertEquals(self.resource.resp.get_header('not-real'), None)
 
             # Check for duplicate headers
             hist = defaultdict(lambda: 0)


### PR DESCRIPTION
Previously there was no way to check if a header had been set on
a response, without accessing _headers which doesn't feel clean.
This commit adds a get_header method on the response object for
checking if a header is set.