### PR TITLE
Fix DefaultRouter conflict bug

### DIFF
--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -206,7 +206,7 @@ class CompiledRouter(object):
                     #   /foo/{id}/bar
                     #   /foo/{name}/bar
                     #
-                    assert len(nodes) == 1
+                    assert len([node for node in nodes if node.is_var]) == 1
                     found_simple = True
 
             else:
@@ -308,10 +308,6 @@ class CompiledRouterNode(object):
         else:
             self.is_var = False
 
-    @property
-    def is_simple_var(self):
-        return self.is_var and not self.is_complex
-
     def matches(self, segment):
         """Returns True if this node matches the supplied template segment."""
 
@@ -334,7 +330,7 @@ class CompiledRouterNode(object):
         #   complex, simple ==> True
         #   complex, complex ==> False
         #   complex, string ==> False
-        #   string, simple ==> True
+        #   string, simple ==> False
         #   string, complex ==> False
         #   string, string ==> False
         #
@@ -362,4 +358,4 @@ class CompiledRouterNode(object):
                 #   /foo/all
                 return True
 
-        return other.is_simple_var
+        return False

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -37,16 +37,18 @@ def setup_routes(router_interface):
     router_interface.add_route(
         '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
     router_interface.add_route(
-        '/emojis/signs/{id}', {}, ResourceWithId(12))
+        '/emojis/signs/0', {}, ResourceWithId(12))
+    router_interface.add_route(
+        '/emojis/signs/{id}', {}, ResourceWithId(13))
     router_interface.add_route(
         '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
-        {}, ResourceWithId(13))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
         {}, ResourceWithId(14))
     router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
         {}, ResourceWithId(15))
+    router_interface.add_route(
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
+        {}, ResourceWithId(16))
 
 
 @ddt.ddt
@@ -59,6 +61,7 @@ class TestStandaloneRouter(testing.TestBase):
     @ddt.data(
         '/teams/{collision}',
         '/repos/{org}/{repo}/compare/{simple-collision}',
+        '/emojis/signs/1',
     )
     def test_collision(self, template):
         self.assertRaises(
@@ -79,6 +82,13 @@ class TestStandaloneRouter(testing.TestBase):
         resource, method_map, params = self.router.find(
             '/repos/racker/falcon/compare/johndoe:master...janedoe:dev/bogus')
         self.assertIs(resource, None)
+
+    def test_literal_segment(self):
+        resource, method_map, params = self.router.find('/emojis/signs/0')
+        self.assertEqual(resource.resource_id, 12)
+
+        resource, method_map, params = self.router.find('/emojis/signs/1')
+        self.assertEqual(resource.resource_id, 13)
 
     def test_dead_segment(self):
         resource, method_map, params = self.router.find('/teams')
@@ -121,7 +131,7 @@ class TestStandaloneRouter(testing.TestBase):
         self.assertEqual(resource.resource_id, 11)
         self.assertEqual(params, {'org': 'racker', 'repo': 'falcon'})
 
-    @ddt.data(('', 5), ('/full', 10), ('/part', 13))
+    @ddt.data(('', 5), ('/full', 10), ('/part', 14))
     @ddt.unpack
     def test_complex(self, url_postfix, resource_id):
         uri = '/repos/racker/falcon/compare/johndoe:master...janedoe:dev'
@@ -137,7 +147,7 @@ class TestStandaloneRouter(testing.TestBase):
             'branch1': 'dev'
         })
 
-    @ddt.data(('', 14), ('/full', 15))
+    @ddt.data(('', 15), ('/full', 16))
     @ddt.unpack
     def test_complex_alt(self, url_postfix, resource_id):
         uri = '/repos/falconry/falcon/compare/johndoe:master'


### PR DESCRIPTION
The DefaultRouter will now allow static routes to be placed before
simple variable ones.  Placing static routes after simple variable ones
still raises a ValueError since they would be unreachable.