### PR TITLE
fix(Request): get_header raises the wrong exception

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -599,7 +599,7 @@ class Request(object):
             if not required:
                 return None
 
-            raise HTTPMissingParam(name)
+            raise HTTPMissingHeader(name)
 
     def get_header_as_datetime(self, header, required=False):
         """Return an HTTP header with HTTP-Date values as a datetime.

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -183,9 +183,14 @@ class TestHeaders(testing.TestBase):
     def test_required_header(self):
         self.simulate_request(self.test_route)
 
-        self.assertRaises(falcon.HTTPBadRequest,
-                          self.resource.req.get_header, 'X-Not-Found',
-                          required=True)
+        try:
+            self.resource.req.get_header('X-Not-Found', required=True)
+            self.fail('falcon.HTTPMissingHeader not raised')
+        except falcon.HTTPMissingHeader as ex:
+            self.assertIsInstance(ex, falcon.HTTPBadRequest)
+            self.assertEqual(ex.title, 'Missing header value')
+            expected_desc = 'The X-Not-Found header is required.'
+            self.assertEqual(ex.description, expected_desc)
 
     def test_no_body_on_100(self):
         self.resource = StatusTestResource(falcon.HTTP_100)

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -94,6 +94,7 @@ class _TestQueryParams(testing.TestBase):
             getattr(req, method_name)('marker', required=True)
             self.fail('falcon.HTTPMissingParam not raised')
         except falcon.HTTPMissingParam as ex:
+            self.assertIsInstance(ex, falcon.HTTPBadRequest)
             self.assertEqual(ex.title, 'Missing query parameter')
             expected_desc = 'The "marker" query parameter is required.'
             self.assertEqual(ex.description, expected_desc)


### PR DESCRIPTION
Modify req.get_header to raise HTTPMissingHeader and update the relevant
test to verify the fix.

Fixes #534