### PR TITLE
Instruct browser to remove cookies

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -246,6 +246,10 @@ class Response(object):
 
     def unset_cookie(self, name):
         """Unset a cookie from the response
+        
+        Note:
+            This will instruct the browser to expire its copy of the cookie
+            if it has previously been set.
         """
         if self._cookies is None:
             self._cookies = SimpleCookie()

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -247,8 +247,16 @@ class Response(object):
     def unset_cookie(self, name):
         """Unset a cookie from the response
         """
-        if self._cookies is not None and name in self._cookies:
-            del self._cookies[name]
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
+        if name not in self._cookies:
+            self._cookies[name] = ""
+        # SimpleCookie apparently special cases the expires attribute to
+        # automatically use strftime and set the time as a delta from the
+        # current time. We use -1 here to basically tell the browser to
+        # immediately expire the cookie, thus removing it from future
+        # request objects.
+        self._cookies[name]["expires"] = -1
 
     def set_header(self, name, value):
         """Set a header for this response to a given value.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -253,8 +253,7 @@ class Response(object):
         """
         if self._cookies is None:
             self._cookies = SimpleCookie()
-        if name not in self._cookies:
-            self._cookies[name] = ""
+        self._cookies[name] = ""
         # SimpleCookie apparently special cases the expires attribute to
         # automatically use strftime and set the time as a delta from the
         # current time. We use -1 here to basically tell the browser to

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -254,11 +254,12 @@ class Response(object):
         if self._cookies is None:
             self._cookies = SimpleCookie()
         self._cookies[name] = ""
-        # SimpleCookie apparently special cases the expires attribute to
-        # automatically use strftime and set the time as a delta from the
-        # current time. We use -1 here to basically tell the browser to
-        # immediately expire the cookie, thus removing it from future
-        # request objects.
+        
+        # NOTE(Freezerburn): SimpleCookie apparently special cases the
+        # expires attribute to automatically use strftime and set the
+        # time as a delta from the current time. We use -1 here to
+        # basically tell the browser to immediately expire the cookie,
+        # thus removing it from future request objects.
         self._cookies[name]["expires"] = -1
 
     def set_header(self, name, value):


### PR DESCRIPTION
fix: Cookies not being removed from browser

The previous behavior of Response's unset_cookie function was just to delete the given name from the SimpleCookie object if it existed. However, this causes a problem in that the browser is not told to remove the cookie on its side, causing all future Request objects to still contain the cookie that was supposed to have been unset/removed. This change causes the Response object to actually set the expires token for the cookie that is being unset to a point in the past, causing the browser to immediately remove the now-expired cookie, which will remove the cookie from future Request objects.