### PR TITLE
fix(test_cookies): Fix references to *httponly* and *secure*

### DIFF
--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,4 +1,4 @@
-
+import sys
 import falcon
 import falcon.testing as testing
 
@@ -54,18 +54,29 @@ class TestCookies(testing.TestBase):
         self.resource = CookieResource()
         self.api.add_route(self.test_route, self.resource)
         self.simulate_request(self.test_route, method="GET")
-        self.assertIn(
-            ("set-cookie",
-                "foo=bar; Domain=example.com; httponly; Path=/; secure"),
-            self.srmock.headers)
+        if sys.version_info < (3, 4, 3):
+            self.assertIn(
+                ("set-cookie",
+                    "foo=bar; Domain=example.com; httponly; Path=/; secure"),
+                self.srmock.headers)
+        else:
+            self.assertIn(
+                ("set-cookie",
+                    "foo=bar; Domain=example.com; HttpOnly; Path=/; Secure"),
+                self.srmock.headers)
 
     def test_response_complex_case(self):
         self.resource = CookieResource()
         self.api.add_route(self.test_route, self.resource)
         self.simulate_request(self.test_route, method="HEAD")
-        self.assertIn(("set-cookie", "foo=bar; httponly; Max-Age=300; secure"),
-                      self.srmock.headers)
-        self.assertIn(("set-cookie", "bar=baz; secure"), self.srmock.headers)
+        if sys.version_info < (3, 4, 3):
+            self.assertIn(("set-cookie", "foo=bar; httponly; Max-Age=300; secure"),
+                          self.srmock.headers)
+            self.assertIn(("set-cookie", "bar=baz; secure"), self.srmock.headers)
+        else:
+            self.assertIn(("set-cookie", "foo=bar; HttpOnly; Max-Age=300; Secure"),
+                          self.srmock.headers)
+            self.assertIn(("set-cookie", "bar=baz; Secure"), self.srmock.headers)
         self.assertNotIn(("set-cookie", "bad=cookie"), self.srmock.headers)
 
     def test_cookie_expires_naive(self):


### PR DESCRIPTION
Since Python 3.4 the attributes *httponly* and *secure* are capitalized like this:
- HttpOnly
- Secure

This quick fix adapt the attributes case to the Python version in use.

See issue #572

A better way to fix that would be to refactor the unit tests and use a unittest.skipIf(). If refactoring is welcome, I can do that when I have time.