### PR TITLE
Add error classes for additional error codes

### DIFF
--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -28,7 +28,7 @@ started writing an API:
     # Falcon follows the REST architectural style, meaning (among
     # other things) that you think in terms of resources and state
     # transitions, which map to HTTP verbs.
-    class ThingsResource:
+    class ThingsResource(object):
         def on_get(self, req, resp):
             """Handles GET requests"""
             resp.status = falcon.HTTP_200  # This is the default status
@@ -207,7 +207,7 @@ parameters, handling errors, and working with request and response bodies.
         return hook
 
 
-    class ThingsResource:
+    class ThingsResource(object):
 
         def __init__(self, db):
             self.db = db

--- a/doc/user/quickstart.rst
+++ b/doc/user/quickstart.rst
@@ -28,7 +28,7 @@ started writing an API:
     # Falcon follows the REST architectural style, meaning (among
     # other things) that you think in terms of resources and state
     # transitions, which map to HTTP verbs.
-    class ThingsResource(object):
+    class ThingsResource:
         def on_get(self, req, resp):
             """Handles GET requests"""
             resp.status = falcon.HTTP_200  # This is the default status
@@ -207,7 +207,7 @@ parameters, handling errors, and working with request and response bodies.
         return hook
 
 
-    class ThingsResource(object):
+    class ThingsResource:
 
         def __init__(self, db):
             self.db = db

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -306,6 +306,110 @@ class HTTPRangeNotSatisfiable(NoRepresentation, HTTPError):
                                                       headers=headers)
 
 
+class HTTPPreconditionRequired(HTTPError):
+    """428 Precondition Required.
+
+    The 428 status code indicates that the origin server requires the
+    request to be conditional.
+
+    Its typical use is to avoid the "lost update" problem, where a client
+    GETs a resource's state, modifies it, and PUTs it back to the server,
+    when meanwhile a third party has modified the state on the server,
+    leading to a conflict.  By requiring requests to be conditional, the
+    server can assure that clients are working with the correct copies.
+
+    Responses using this status code SHOULD explain how to resubmit the
+    request successfully.
+
+     (RFC 6585)
+
+    Args:
+        description (str): Human-friendly description of the error, along with
+            a helpful suggestion or two.
+        kwargs (optional): Same as for ``HTTPError``.
+
+    """
+    def __init__(self, description, **kwargs):
+        super(HTTPPreconditionRequired, self).__init__(
+            status.HTTP_428, 'Precondition Required', description, **kwargs)
+
+
+class HTTPTooManyRequests(HTTPError):
+    """429 Too Many Requests.
+
+   The 429 status code indicates that the user has sent too many
+   requests in a given amount of time ("rate limiting").
+
+   The response representations SHOULD include details explaining the
+   condition, and MAY include a Retry-After header indicating how long
+   to wait before making a new request.
+
+    (RFC 6585)
+
+    Args:
+        title (str): Error title (e.g., 'Too Many Requests').
+        description (str): Human-friendly description of the error, along with
+            a helpful suggestion or two.
+        retry_after (datetime or int, optional): Value for the Retry-After
+            header. If a ``datetime`` object, will serialize as an HTTP date.
+            Otherwise, a non-negative ``int`` is expected, representing the
+            number of seconds to wait. See also: http://goo.gl/DIrWr .
+        kwargs (optional): Same as for ``HTTPError``.
+
+    """
+
+    def __init__(self, title, description, retry_after=None, **kwargs):
+        headers = kwargs.setdefault('headers', {})
+
+        if isinstance(retry_after, datetime):
+            headers['Retry-After'] = util.dt_to_http(retry_after)
+
+        elif retry_after is not None:
+            headers['Retry-After'] = str(retry_after)
+
+        super(HTTPTooManyRequests, self).__init__(
+            status.HTTP_429, title, description, **kwargs)
+
+
+class HTTPRequestHeaderFieldsTooLarge(HTTPError):
+    """431 Request Header Fields Too Large.
+
+    The 431 status code indicates that the server is unwilling to process
+    the request because its header fields are too large.  The request MAY
+    be resubmitted after reducing the size of the request header fields.
+
+    It can be used both when the set of request header fields in total is
+    too large, and when a single header field is at fault.  In the latter
+    case, the response representation SHOULD specify which header field
+    was too large.
+
+     (RFC 6585)
+
+    Args:
+        title (str): Error title (e.g., 'Request Header Fields Too Large').
+        description (str): Human-friendly description of the error, along with
+            a helpful suggestion or two.
+        retry_after (datetime or int, optional): Value for the Retry-After
+            header. If a ``datetime`` object, will serialize as an HTTP date.
+            Otherwise, a non-negative ``int`` is expected, representing the
+            number of seconds to wait. See also: http://goo.gl/DIrWr .
+        kwargs (optional): Same as for ``HTTPError``.
+
+    """
+
+    def __init__(self, title, description, retry_after=None, **kwargs):
+        headers = kwargs.setdefault('headers', {})
+
+        if isinstance(retry_after, datetime):
+            headers['Retry-After'] = util.dt_to_http(retry_after)
+
+        elif retry_after is not None:
+            headers['Retry-After'] = str(retry_after)
+
+        super(HTTPRequestHeaderFieldsTooLarge, self).__init__(
+            status.HTTP_431, title, description, **kwargs)
+
+
 class HTTPInternalServerError(HTTPError):
     """500 Internal Server Error.
 
@@ -366,6 +470,40 @@ class HTTPServiceUnavailable(HTTPError):
                                                      title,
                                                      description,
                                                      **kwargs)
+
+
+class HTTPNetworkAuthenticationRequired(HTTPError):
+    """   The 511 status code indicates that the client needs to authenticate
+    to gain network access.
+
+    The response representation SHOULD contain a link to a resource that
+    allows the user to submit credentials (e.g., with an HTML form).
+
+    Note that the 511 response SHOULD NOT contain a challenge or the
+    login interface itself, because browsers would show the login
+    interface as being associated with the originally requested URL,
+    which may cause confusion.
+
+    The 511 status SHOULD NOT be generated by origin servers; it is
+    intended for use by intercepting proxies that are interposed as a
+    means of controlling access to the network.
+
+    Responses with the 511 status code MUST NOT be stored by a cache.
+
+     (RFC 6585)
+
+    Args:
+        link (str): link to a resource that allows the user to submit
+             credentials (e.g., with an HTML form).
+        description (str): Human-friendly description of the error, along with
+            a helpful suggestion or two.
+        kwargs (optional): Same as for ``HTTPError``.
+
+    """
+
+    def __init__(self, link, description, **kwargs):
+        super(HTTPNetworkAuthenticationRequired, self).__init__(
+            status.HTTP_511, link, description, **kwargs)
 
 
 class HTTPInvalidHeader(HTTPBadRequest):


### PR DESCRIPTION
Added error classes per RFC 6585
- Error Code 428 Precondition Required
- Error Code 429 Too Many Requests
- Error Code 431 Request Header Fields Too Large
- Error Code 511 Network Authentication Required

https://github.com/falconry/falcon/issues/561
