### PR TITLE
perf(request): Optimize HTTP date parsing

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -601,7 +601,7 @@ class Request(object):
 
             raise HTTPMissingHeader(name)
 
-    def get_header_as_datetime(self, header, required=False):
+    def get_header_as_datetime(self, header, required=False, obs_date=False):
         """Return an HTTP header with HTTP-Date values as a datetime.
 
         Args:
@@ -609,6 +609,8 @@ class Request(object):
             required (bool, optional): Set to ``True`` to raise
                 ``HTTPBadRequest`` instead of returning gracefully when the
                 header is not found (default ``False``).
+            obs_date (bool, optional): Support obs-date formats according to
+                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
         Returns:
             datetime: The value of the specified header if it exists,
@@ -622,7 +624,7 @@ class Request(object):
 
         try:
             http_date = self.get_header(header, required=required)
-            return util.http_date_to_dt(http_date, obs_date=True)
+            return util.http_date_to_dt(http_date, obs_date=obs_date)
         except TypeError:
             # When the header does not exist and isn't required
             return None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,13 +79,21 @@ class TestFalconUtils(testtools.TestCase):
             falcon.http_date_to_dt('Thu, 04 Apr 2013 10:28:54 GMT'),
             datetime(2013, 4, 4, 10, 28, 54))
 
-        self.assertEqual(
-            falcon.http_date_to_dt('Sunday, 06-Nov-94 08:49:37 GMT',
-                                   obs_date=True),
-            datetime(1994, 11, 6, 8, 49, 37))
+        self.assertRaises(
+            ValueError,
+            falcon.http_date_to_dt, 'Sun Nov  6 08:49:37 1994')
+
+        self.assertRaises(
+            ValueError,
+            falcon.http_date_to_dt, 'Nov  6 08:49:37 1994', obs_date=True)
 
         self.assertEqual(
             falcon.http_date_to_dt('Sun Nov  6 08:49:37 1994', obs_date=True),
+            datetime(1994, 11, 6, 8, 49, 37))
+
+        self.assertEqual(
+            falcon.http_date_to_dt('Sunday, 06-Nov-94 08:49:37 GMT',
+                                   obs_date=True),
             datetime(1994, 11, 6, 8, 49, 37))
 
     def test_pack_query_params_none(self):


### PR DESCRIPTION
Don't check for obsolete date formats by default. When obsolete date
formats are not enabled, avoid unnecessary processing time and data
structure instantiation.