### PR TITLE
Add `access_route` and `remote_addr` to Request object

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -538,10 +538,11 @@ class Request(object):
             proxy servers.
 
         This property will try to derive addresses sequentially from:
-            - ``Forwarded``;
-            - ``X-Forwarded-For``;
-            - ``X-Real-IP``;
-            - **or** the IP address of the closest client/proxy.
+
+            - ``Forwarded``
+            - ``X-Forwarded-For``
+            - ``X-Real-IP``
+            - **or** the IP address of the closest client/proxy
 
         """
         if self._cached_access_route is None:
@@ -564,7 +565,7 @@ class Request(object):
         """String of the IP address of the closest client/proxy.
 
         Address will only be derived from WSGI ``REMOTE_ADDR`` header, which
-        can not be mofidied by any client or proxy.
+        can not be modified by any client or proxy.
 
         Note:
             If your application is behind one or more reverse proxies, you may

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -520,21 +520,28 @@ class Request(object):
     def access_route(self):
         """A list of all addresses from client to the last proxy server.
 
-        Inspired by werkzeug's `access_route`. Notice this list may contain
-        string(s) other than IPv4 / IPv6 address. For example the "unknown"
-        identifier and obfuscated identifier defined by RFC 7239.
+        Inspired by werkzeug's ``access_route``.
 
-        Warning: HTTP Forwarded headers can be forged by any client or proxy.
-        Use this property with caution and write your own verify function.
-        The best practice here is always using `.remote_addr` unless your
-        application is hosted behind some reverse proxy servers. Also only
-        trust the **last** N addresses provided by reverse proxy server(s).
+        Note:
+            The list may contain string(s) other than IPv4 / IPv6 address. For
+            example the "unknown" identifier and obfuscated identifier defined
+            by `RFC 7239`_.
+
+            .. _RFC 7239: https://tools.ietf.org/html/rfc7239#section-6
+
+        Warning:
+            HTTP Forwarded headers can be forged by any client or proxy.
+            Use this property with caution and write your own verify function.
+            The best practice is always using :py:attr:`~.remote_addr` unless
+            your application is hosted behind some reverse proxy server(s).
+            Also only trust the **last N** addresses provided by those reverse
+            proxy servers.
 
         This property will try to derive addresses sequentially from:
-            - `Forwarded`;
-            - `X-Forwarded-For`;
-            - `X-Real-IP`;
-            - **or** the IP address of the closest client/proxy
+            - ``Forwarded``;
+            - ``X-Forwarded-For``;
+            - ``X-Real-IP``;
+            - **or** the IP address of the closest client/proxy.
 
         """
         if self._cached_access_route is None:
@@ -556,12 +563,13 @@ class Request(object):
     def remote_addr(self):
         """String of the IP address of the closest client/proxy.
 
-        This property will only derive address directly from WSGI `REMOTE_ADDR`
-        header which can not be mofidied by any client or proxy.
+        Address will only be derived from WSGI ``REMOTE_ADDR`` header, which
+        can not be mofidied by any client or proxy.
 
-        If your application is behind one or more reverse proxies, you may use
-        `.access_remote` to retrieve the real IP address of client. Please See
-        the document of `.access_remote` for more detail.
+        Note:
+            If your application is behind one or more reverse proxies, you may
+            need to use :py:obj:`~.access_route` to retrieve the real IP
+            address of the client.
         """
         return self.env.get('REMOTE_ADDR')
 

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -650,7 +650,8 @@ class Request(object):
                 ``HTTPBadRequest`` instead of returning gracefully when the
                 header is not found (default ``False``).
             obs_date (bool, optional): Support obs-date formats according to
-                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
+                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT"
+                (default ``False``).
 
         Returns:
             datetime: The value of the specified header if it exists,
@@ -1068,7 +1069,7 @@ class Request(object):
                 if len(param) == 1:
                     continue
                 key, val = param
-                if key.lower() not in ('for', 'by'):
+                if key.lower() != 'for':
                     # we only want for/by params
                     continue
                 host, _ = parse_host(unquote_string(val))

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -107,8 +107,9 @@ def http_date_to_dt(http_date, obs_date=False):
     Args:
         http_date (str): An RFC 1123 date string, e.g.:
             "Tue, 15 Nov 1994 12:45:26 GMT".
-            obs_date (bool, optional): Support obs-date formats according to
-                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
+        obs_date (bool, optional): Support obs-date formats according to
+            RFC 7231, e.g.:
+            "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
     Returns:
         datetime: A UTC datetime instance corresponding to the given

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -394,5 +394,11 @@ def unquote_string(quoted):
     if tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
         # return original one, prevent side-effect
         return quoted
-    return '\\'.join([q.replace('\\', '')
-                      for q in tmp_quoted[1:-1].split(r'\\')])
+    tmp_quoted = tmp_quoted[1:-1]
+    if '\\' not in tmp_quoted:
+        return tmp_quoted
+    elif r'\\' not in tmp_quoted:
+        return tmp_quoted.replace('\\', '')
+    else:
+        return '\\'.join([q.replace('\\', '')
+                          for q in tmp_quoted.split(r'\\')])

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -376,3 +376,23 @@ def parse_host(host, default_port=None):
     # or a domain name plus a port
     name, _, port = host.partition(':')
     return (name, int(port))
+
+
+def unquote_string(quoted):
+    """unquote a rfc7320 "quoted-string" into normal one
+
+    Args:
+        quoted (str): Original quoted string
+
+    Returns:
+        str: unquoted string
+
+    Raises:
+        TypeError: `quoted` was not a ``str``.
+    """
+    tmp_quoted = quoted.strip()
+    if tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
+        # return original one, prevent side-effect
+        return quoted
+    return '\\'.join(q.replace('\\', '')
+                     for q in tmp_quoted[1:-1].split(r'\\'))

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -391,7 +391,9 @@ def unquote_string(quoted):
         TypeError: `quoted` was not a ``str``.
     """
     tmp_quoted = quoted.strip()
-    if tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
+    if len(tmp_quoted) < 2:
+        return quoted
+    elif tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
         # return original one, prevent side-effect
         return quoted
     tmp_quoted = tmp_quoted[1:-1]

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -394,5 +394,5 @@ def unquote_string(quoted):
     if tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
         # return original one, prevent side-effect
         return quoted
-    return '\\'.join(q.replace('\\', '')
-                     for q in tmp_quoted[1:-1].split(r'\\'))
+    return '\\'.join([q.replace('\\', '')
+                      for q in tmp_quoted[1:-1].split(r'\\')])

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -379,7 +379,7 @@ def parse_host(host, default_port=None):
 
 
 def unquote_string(quoted):
-    """unquote a rfc7320 "quoted-string" into normal one
+    """Unquote an RFC 7320 "quoted-string".
 
     Args:
         quoted (str): Original quoted string
@@ -396,7 +396,11 @@ def unquote_string(quoted):
     elif tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
         # return original one, prevent side-effect
         return quoted
+
     tmp_quoted = tmp_quoted[1:-1]
+    # PERF(philiptzou): Most header strings don't contain "quoted-pair" which
+    # defined by RFC 7320. We use this little trick (quick string search) to
+    # speed up string parsing by preventing unnecessary processes if possible.
     if '\\' not in tmp_quoted:
         return tmp_quoted
     elif r'\\' not in tmp_quoted:

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -1,0 +1,75 @@
+from falcon.request import Request
+import falcon.testing as testing
+
+
+class TestAccessRoute(testing.TestBase):
+
+    def test_remote_addr_only(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
+                              'for="unknown", by=_hidden,for="\\"\\\\",'
+                              'for=198.51.100.17:1236; by=203.0.113.60;'
+                              'proto=https;host=example.com')
+            }))
+        self.assertEqual(req.remote_addr, '127.0.0.1')
+
+    def test_rfc_forwarded(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
+                              'for="unknown", by=_hidden,for="\\"\\\\",'
+                              'for=198.51.100.17:1236; by=203.0.113.60;'
+                              'proto=https;host=example.com')
+            }))
+        self.assertEqual(req.access_route,
+                         ['192.0.2.43', '2001:db8:cafe::17',
+                          'unknown', '_hidden', '"\\',
+                          '198.51.100.17', '203.0.113.60'])
+        # test cached
+        self.assertEqual(req.access_route,
+                         ['192.0.2.43', '2001:db8:cafe::17',
+                          'unknown', '_hidden', '"\\',
+                          '198.51.100.17', '203.0.113.60'])
+
+    def test_malformed_rfc_forwarded(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': 'for'
+            }))
+        self.assertEqual(req.access_route, ['127.0.0.1'])
+        # test cached
+        self.assertEqual(req.access_route, ['127.0.0.1'])
+
+    def test_x_forwarded_for(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'X-Forwarded-For': ('192.0.2.43, 2001:db8:cafe::17,'
+                                    'unknown, _hidden, 203.0.113.60')
+            }))
+        self.assertEqual(req.access_route,
+                         ['192.0.2.43', '2001:db8:cafe::17',
+                          'unknown', '_hidden', '203.0.113.60'])
+
+    def test_x_real_ip(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'X-Real-IP': '2001:db8:cafe::17'
+            }))
+        self.assertEqual(req.access_route, ['2001:db8:cafe::17'])
+
+    def test_remote_addr(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route'))
+        self.assertEqual(req.access_route, ['127.0.0.1'])

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -24,16 +24,16 @@ class TestAccessRoute(testing.TestBase):
                 'Forwarded': ('for=192.0.2.43,for=,'
                               'for="[2001:db8:cafe::17]:555",'
                               'for="unknown", by=_hidden,for="\\"\\\\",'
+                              'for="_don\\\"t_\\try_this\\\\at_home_\\42",'
                               'for="198\\.51\\.100\\.17\\:1236";'
                               'proto=https;host=example.com')
             }))
-        self.assertEqual(req.access_route,
-                         ['192.0.2.43', '', '2001:db8:cafe::17',
-                          'unknown', '"\\', '198.51.100.17'])
+        compares = ['192.0.2.43', '', '2001:db8:cafe::17',
+                    'unknown', '"\\', '_don"t_try_this\\at_home_42',
+                    '198.51.100.17']
+        self.assertEqual(req.access_route, compares)
         # test cached
-        self.assertEqual(req.access_route,
-                         ['192.0.2.43', '', '2001:db8:cafe::17',
-                          'unknown', '"\\', '198.51.100.17'])
+        self.assertEqual(req.access_route, compares)
 
     def test_malformed_rfc_forwarded(self):
         req = Request(testing.create_environ(

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -21,17 +21,18 @@ class TestAccessRoute(testing.TestBase):
             host='example.com',
             path='/access_route',
             headers={
-                'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
+                'Forwarded': ('for=192.0.2.43,for=,'
+                              'for="[2001:db8:cafe::17]:555",'
                               'for="unknown", by=_hidden,for="\\"\\\\",'
                               'for="198\\.51\\.100\\.17\\:1236";'
                               'proto=https;host=example.com')
             }))
         self.assertEqual(req.access_route,
-                         ['192.0.2.43', '2001:db8:cafe::17',
+                         ['192.0.2.43', '', '2001:db8:cafe::17',
                           'unknown', '"\\', '198.51.100.17'])
         # test cached
         self.assertEqual(req.access_route,
-                         ['192.0.2.43', '2001:db8:cafe::17',
+                         ['192.0.2.43', '', '2001:db8:cafe::17',
                           'unknown', '"\\', '198.51.100.17'])
 
     def test_malformed_rfc_forwarded(self):

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -11,7 +11,7 @@ class TestAccessRoute(testing.TestBase):
             headers={
                 'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
                               'for="unknown", by=_hidden,for="\\"\\\\",'
-                              'for=198.51.100.17:1236; by=203.0.113.60;'
+                              'for="198\\.51\\.100\\.17\\:1236";'
                               'proto=https;host=example.com')
             }))
         self.assertEqual(req.remote_addr, '127.0.0.1')
@@ -23,18 +23,16 @@ class TestAccessRoute(testing.TestBase):
             headers={
                 'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
                               'for="unknown", by=_hidden,for="\\"\\\\",'
-                              'for=198.51.100.17:1236; by=203.0.113.60;'
+                              'for="198\\.51\\.100\\.17\\:1236";'
                               'proto=https;host=example.com')
             }))
         self.assertEqual(req.access_route,
                          ['192.0.2.43', '2001:db8:cafe::17',
-                          'unknown', '_hidden', '"\\',
-                          '198.51.100.17', '203.0.113.60'])
+                          'unknown', '"\\', '198.51.100.17'])
         # test cached
         self.assertEqual(req.access_route,
                          ['192.0.2.43', '2001:db8:cafe::17',
-                          'unknown', '_hidden', '"\\',
-                          '198.51.100.17', '203.0.113.60'])
+                          'unknown', '"\\', '198.51.100.17'])
 
     def test_malformed_rfc_forwarded(self):
         req = Request(testing.create_environ(


### PR DESCRIPTION
which is similar to Werkzeug but more powerful

Supported:

1. fetch from "Forwarded" header (defined by RFC7239)
2. fetch from "X-Forwarded-For" header
3. fetch from "X-Read-IP" header
4. fetch from wsgi "REMOTE_ADDR" header

Related to #539 and #598