### PR TITLE
fix(response.py): Pylint/pep8 errors when default python is 3.X

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ commands = py3kwarn falcon
 
 [testenv:pep8]
 deps = flake8
+basepython = python2.7
 commands = flake8 \
              --max-complexity=15 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
@@ -78,6 +79,7 @@ commands = flake8 \
 
 [testenv:pylint]
 deps = pylint
+basepython = python2.7
 commands = pylint falcon \
              --ignore=bench,tests \
              -E \


### PR DESCRIPTION
When running tox on a machine with python3 as the default python,
pep8 and pylint would fail on a reference to unicode in response.py
The fix was simply to set the default python to 2.7 in tox.ini
for the pep8 and pylint environments

Fixes #607