### PR TITLE
doc: Add code of conduct

### DIFF
--- a/CODEOFCONDUCT.md
+++ b/CODEOFCONDUCT.md
@@ -1,0 +1,56 @@
+# Code of Conduct
+
+All contributors and maintainers of this project are subject to this Code of Conduct.
+
+We pledge to respect everyone who contributes to the *Falcon* project or other associated activities by (including but not limited to) creating project issues, submitting pull requests, and providing feedback on the same. We also pledge to respect everyone who participates in discussions on the project's mailing list, in the project's chat channel, and at meetups and conferences.
+
+Unacceptable behavior includes (but is not limited to) offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+If anyone within the *Falcon* community fails to adhere to this Code of Conduct, they can expect to face action by way of: removing comments, removing issues, deleting pull requests, and generally being banned from participating in the *Falcon* community.
+
+
+## Do This
+
+* Act professionally
+* Treat others as friends and family
+* [Seek first to understand][covey]
+* Be honest, transparent, and constructive
+* Use clear, concise language
+* Assume good intent
+
+
+## Don't Do This
+* Use indecent, profane, or degrading language of any kind
+* Hold a patch hostage for some ulterior motive
+* Take part in gossiping or backbiting
+* Engage in bullying behaviors, including but not limited to:
+    * Belittling others' opinions
+    * Persistent teasing or sarcasm
+    * Insulting, threatening, or yelling at someone
+    * Accusing someone of being incompetent
+    * Setting someone up to fail
+    * Humiliating someone
+    * Isolating someone from others
+    * Withholding information to gain an advantage
+    * Falsely accusing someone of errors
+    * Sabotaging someone's work
+
+
+## Moderation
+
+Discussing things "in the open" is important. But it does not necessarily engender trust in a community, especially in the absence of cognizant moderation.
+
+Unfortunately, open discussions sometimes lead to a culture of distrust. This happens when individuals in power publicly humiliate, intimidate, or even bully others in the community. Often this happens unconsciously or as a result of a poor choice of words. Regardless of whether the intent is actual or perceived, the damage to the community is the same, and must be quickly dealt with before it festers into a culture of enmity.
+
+The project maintainer, with the support of the core reviewers, pledges to lead by example, as well as to hold contributors accountable for creating a positive, constructive, and productive culture. Inappropriate behavior will not be tolerated.
+
+If a member of the *Falcon* community behaves unacceptably toward you or another individual, please contact Kurt Griffiths at <a href="mailto:inbox@kgriffs.com">inbox@kgriffs.com</a>.
+
+<br>
+---
+
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This <span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/Text" property="dct:title" rel="dct:type">Code of Conduct</span>, created by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/falconry/falcon" property="cc:attributionName" rel="cc:attributionURL">Falcon Contributors</a> and inspired by [yourfirstpr][yfp], is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
+[covey]: https://www.stephencovey.com/7habits/7habits-habit5.php
+[yfp]: https://github.com/yourfirstpr/yourfirstpr.github.io/blob/master/CODEOFCONDUCT.MD
+

--- a/doc/community/contrib-snip.rst
+++ b/doc/community/contrib-snip.rst
@@ -9,11 +9,12 @@ send an email to falcon@librelist.com and follow the instructions in the
 reply. For more information about managing your subscription, check out
 the `Librelist help page <http://librelist.com/help.html>`_.
 
-While we don't have an official code of conduct, we do expect everyone
-who participates on the mailing list to act professionally, and lead
-by example in encouraging constructive discussions. Each individual in
-the community is responsible for creating a positive, constructive, and
-productive culture.
+All contributors and maintainers of this project are subject to our `Code
+of Conduct <https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md>`_.
+We expect everyone who participates on the mailing list to act
+professionally, and lead by example in encouraging constructive
+discussions. Each individual in the community is responsible for creating
+a positive, constructive, and productive culture.
 
 `Discussions are archived <http://librelist.com/browser/falcon>`_
 for posterity.
@@ -33,3 +34,8 @@ questions in IRC, and to peer-review
 `pull requests <https://github.com/racker/falcon/pulls>`_. If you use the
 Chrome browser, we recommend installing the
 `NotHub extension <http://nothub.org/>`_ to stay up to date with PRs.
+
+Code of Conduct
+---------------
+All contributors and maintainers of this project are subject to our `Code
+of Conduct <https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md>`_.


### PR DESCRIPTION
Add an official code of conduct, and reference it in the docs.