### PR TITLE
fix(Response): Instruct browser to remove cookies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ below in order of date of first contribution:
 * Carl George (carlgeorge)
 * Adam Yala (adamyala)
 * Grigory Bakunov (bobuk)
+* Vincent Raiken (Freezerburn)

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -251,9 +251,24 @@ class Response(object):
             self._cookies[name]["httponly"] = http_only
 
     def unset_cookie(self, name):
-        """Unset a cookie in the response."""
-        if self._cookies is not None and name in self._cookies:
-            del self._cookies[name]
+        """Unset a cookie in the response
+
+        Note:
+            This will clear the contents of the cookie, and instruct
+            the browser to immediately expire its own copy of the
+            cookie, if any.
+        """
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
+
+        self._cookies[name] = ""
+
+        # NOTE(Freezerburn): SimpleCookie apparently special cases the
+        # expires attribute to automatically use strftime and set the
+        # time as a delta from the current time. We use -1 here to
+        # basically tell the browser to immediately expire the cookie,
+        # thus removing it from future request objects.
+        self._cookies[name]["expires"] = -1
 
     def get_header(self, name):
         """Retrieve the raw string value for the given header.

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -128,6 +128,7 @@ def http_date_to_dt(http_date, obs_date=False):
 
     time_formats = (
         '%a, %d %b %Y %H:%M:%S %Z',
+        '%a, %d-%b-%Y %H:%M:%S %Z',
         '%A, %d-%b-%y %H:%M:%S %Z',
         '%a %b %d %H:%M:%S %Y',
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,15 @@ class TestFalconUtils(testtools.TestCase):
 
         self.assertRaises(
             ValueError,
+            falcon.http_date_to_dt, 'Thu, 04-Apr-2013 10:28:54 GMT')
+
+        self.assertEqual(
+            falcon.http_date_to_dt('Thu, 04-Apr-2013 10:28:54 GMT',
+                                   obs_date=True),
+            datetime(2013, 4, 4, 10, 28, 54))
+
+        self.assertRaises(
+            ValueError,
             falcon.http_date_to_dt, 'Sun Nov  6 08:49:37 1994')
 
         self.assertRaises(


### PR DESCRIPTION
Modify the Response object to actually set the expires token for the cookie that is being unset to a point in the past, causing the browser to immediately remove the now-expired cookie, which will remove the cookie from future Request objects.

The previous behavior of Response's unset_cookie function was just to delete the given name from the SimpleCookie object if it existed. However, this causes a problem in that the browser is not told to remove the cookie on its side, causing all future Request objects to still contain the cookie that was supposed to have been unset/removed.

Co-Authored-By: Kurt Griffiths <mail@kgriffs.com>