### PR TITLE
Add `access_route` and `remote_addr` to Request object

### DIFF
--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -107,8 +107,9 @@ def http_date_to_dt(http_date, obs_date=False):
     Args:
         http_date (str): An RFC 1123 date string, e.g.:
             "Tue, 15 Nov 1994 12:45:26 GMT".
-            obs_date (bool, optional): Support obs-date formats according to
-                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
+        obs_date (bool, optional): Support obs-date formats according to
+            RFC 7231, e.g.:
+            "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
     Returns:
         datetime: A UTC datetime instance corresponding to the given

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -1,0 +1,74 @@
+from falcon.request import Request
+import falcon.testing as testing
+
+
+class TestAccessRoute(testing.TestBase):
+
+    def test_remote_addr_only(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
+                              'for="unknown", by=_hidden,for="\\"\\\\",'
+                              'for="198\\.51\\.100\\.17\\:1236";'
+                              'proto=https;host=example.com')
+            }))
+        self.assertEqual(req.remote_addr, '127.0.0.1')
+
+    def test_rfc_forwarded(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': ('for=192.0.2.43,for=,'
+                              'for="[2001:db8:cafe::17]:555",'
+                              'for="unknown", by=_hidden,for="\\"\\\\",'
+                              'for="_don\\\"t_\\try_this\\\\at_home_\\42",'
+                              'for="198\\.51\\.100\\.17\\:1236";'
+                              'proto=https;host=example.com')
+            }))
+        compares = ['192.0.2.43', '', '2001:db8:cafe::17',
+                    'unknown', '"\\', '_don"t_try_this\\at_home_42',
+                    '198.51.100.17']
+        self.assertEqual(req.access_route, compares)
+        # test cached
+        self.assertEqual(req.access_route, compares)
+
+    def test_malformed_rfc_forwarded(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'Forwarded': 'for'
+            }))
+        self.assertEqual(req.access_route, ['127.0.0.1'])
+        # test cached
+        self.assertEqual(req.access_route, ['127.0.0.1'])
+
+    def test_x_forwarded_for(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'X-Forwarded-For': ('192.0.2.43, 2001:db8:cafe::17,'
+                                    'unknown, _hidden, 203.0.113.60')
+            }))
+        self.assertEqual(req.access_route,
+                         ['192.0.2.43', '2001:db8:cafe::17',
+                          'unknown', '_hidden', '203.0.113.60'])
+
+    def test_x_real_ip(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route',
+            headers={
+                'X-Real-IP': '2001:db8:cafe::17'
+            }))
+        self.assertEqual(req.access_route, ['2001:db8:cafe::17'])
+
+    def test_remote_addr(self):
+        req = Request(testing.create_environ(
+            host='example.com',
+            path='/access_route'))
+        self.assertEqual(req.access_route, ['127.0.0.1'])


### PR DESCRIPTION
which is similar to Werkzeug but more powerful

Supported:

1. fetch from "Forwarded" header (defined by RFC7239)
2. fetch from "X-Forwarded-For" header
3. fetch from "X-Read-IP" header
4. fetch from wsgi "REMOTE_ADDR" header

Related to #539 and #598 


This pull-request is simply a duplicate of #599 but always rebased onto the latest origin/master. I don't want to lose any more comments due to the rebase. Please write your comment to #599.