### PR TITLE
feat(request): add support to parse request body as json

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -11,6 +11,7 @@
 # limitations under the License.
 
 from datetime import datetime
+import json
 
 try:
     # NOTE(kgrifs): In Python 2.6 and 2.7, socket._fileobject is a
@@ -188,6 +189,9 @@ class Request(object):
             A dict of name/value cookie pairs.
             See also: :ref:`Getting Cookies <getting-cookies>`
 
+        json (dict): Attempts to parse the request stream as a Json string.
+            If called, it'll leave the request stream at EOF.
+
     """
 
     __slots__ = (
@@ -206,6 +210,7 @@ class Request(object):
         'options',
         '_cookies',
         '_cached_access_route',
+        '_json',
     )
 
     # Allow child classes to override this
@@ -292,6 +297,11 @@ class Request(object):
             # pylint will detect this as not-callable because it only sees the
             # declaration of None, not whatever type a subclass may have set.
             self.context = self.context_type()  # pylint: disable=not-callable
+
+        # NOTE(jmvrbanac): To preserve performance, we don't want to
+        # automatically parse the body as Json so we're just going to leave
+        # self._json empty until self.json is called
+        self._json = None
 
     # ------------------------------------------------------------------------
     # Properties
@@ -522,6 +532,12 @@ class Request(object):
             self._cookies = cookies
 
         return self._cookies.copy()
+
+    @property
+    def json(self):
+        if self._json is None:
+            self._parse_application_json()
+        return self._json
 
     @property
     def access_route(self):
@@ -1095,6 +1111,20 @@ class Request(object):
             )
 
             self._params.update(extra_params)
+
+    def _parse_application_json(self):
+        raw_body = self.stream.read()
+
+        body = None
+        try:
+            body = json.loads(raw_body.decode('utf-8'))
+        except UnicodeDecodeError:
+            self.log_error('Non-UTF8 characters found in the request body')
+        except ValueError as e:
+            msg = 'Could not parse the body as Json: {0}. Ignoring.'.format(e)
+            self.log_error(msg)
+
+        self._json = body
 
     def _parse_rfc_forwarded(self):
         """Parse RFC 7239 "Forwarded" header.

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -159,3 +159,31 @@ class TestRequestBody(testing.TestBase):
         body = request_helpers.Body(stream, expected_len)
         for i, line in enumerate(body):
             self.assertEqual(line, expected_lines[i])
+
+    def test_parsing_json_body(self):
+        self.simulate_request('/', body='{"sample": "yes"}')
+
+        # Make sure we don't pre-parse the JSON
+        self.assertIsNone(self.resource.req._json)
+
+        json = self.resource.req.json
+        self.assertEqual(json.get('sample'), 'yes')
+
+    def test_caching_of_parsed_json_body(self):
+        self.simulate_request('/', body='{"sample": "yes"}')
+
+        # Force set the json cache variable
+        self.resource.req._json = {'thing': 'something'}
+
+        json = self.resource.req.json
+        self.assertEqual(json.get('thing'), 'something')
+
+    def test_parsing_json_body_w_utf16(self):
+        self.simulate_request('/', body='{"sample": "yes"}'.encode('utf-16'))
+        self.assertIsNone(self.resource.req.json)
+
+    def test_calling_json_without_a_valid_body(self):
+        self.simulate_request('/', body='{"}')
+
+        result = self.resource.req._parse_application_json()
+        self.assertIsNone(result)


### PR DESCRIPTION
Adding in the ability to easily get the request body as a json dictionary. I tend to do this operation in nearly every Falcon project I create, so it seems appropriate to upstream this into the request itself.