### PR TITLE
fix(URI template): allow complex vars coexist with simple var

### DIFF
--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -112,16 +112,20 @@ class CompiledRouter(object):
         level_indent = indent
         found_simple = False
 
-        # NOTE(kgriffs): Sort static nodes before var nodes so that
-        # none of them get masked. False sorts before True.
-        nodes = sorted(nodes, key=lambda node: node.is_var)
+        # NOTE(kgriffs & philiptzou): Sort nodes in this sequence:
+        # static nodes(0), complex var nodes(1) and simple var nodes(2).
+        # so that none of them get masked.
+        nodes = sorted(
+            nodes, key=lambda node: node.is_var + (node.is_var and
+                                                   not node.is_complex))
 
         for node in nodes:
             if node.is_var:
                 if node.is_complex:
-                    # NOTE(richardolsson): Complex nodes are nodes which contain
-                    # anything more than a single literal or variable, and they
-                    # need to be checked using a pre-compiled regular expression.
+                    # NOTE(richardolsson): Complex nodes are nodes which
+                    # contain anything more than a single literal or variable,
+                    # and they need to be checked using a pre-compiled regular
+                    # expression.
                     expression_idx = len(self._expressions)
                     self._expressions.append(node.var_regex)
 
@@ -143,7 +147,8 @@ class CompiledRouter(object):
                     #   /foo/{id}/bar
                     #   /foo/{name}/bar
                     #
-                    assert len([node for node in nodes if node.is_var]) == 1
+                    assert len([_node for _node in nodes
+                                if _node.is_var and not _node.is_complex]) == 1
                     found_simple = True
 
             else:
@@ -289,7 +294,8 @@ class CompiledRouterNode(object):
 
                 return False
             else:
-                # NOTE(kgriffs): Falcon does not support the following:
+                # NOTE(kgriffs & philiptzou): Falcon does not accept multiple
+                # simple var nodes exist at the same level as following:
                 #
                 #   /foo/{thing1}
                 #   /foo/{thing2}
@@ -298,8 +304,9 @@ class CompiledRouterNode(object):
                 #
                 #   /foo/{thing1}
                 #   /foo/all
+                #   /foo/{thing1}.{ext}
                 #
-                return other.is_var
+                return other.is_var and not other.is_complex
 
         # NOTE(kgriffs): If self is a static string match, then all the cases
         # for other are False, so no need to check.

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -211,6 +211,8 @@ class CompiledRouter(object):
 class CompiledRouterNode(object):
     """Represents a single URI segment in a URI."""
 
+    _regex_vars = re.compile('{([-_a-zA-Z0-9]+)}')
+
     def __init__(self, raw_segment, method_map=None, resource=None):
         self.children = []
 
@@ -224,7 +226,7 @@ class CompiledRouterNode(object):
 
         seg = raw_segment.replace('.', '\\.')
 
-        matches = list(re.finditer('{([-_a-zA-Z0-9]+)}', seg))
+        matches = list(self._regex_vars.finditer(seg))
         if matches:
             self.is_var = True
             # NOTE(richardolsson): if there is a single variable and it spans
@@ -273,10 +275,10 @@ class CompiledRouterNode(object):
         # NOTE(kgriffs): Possible combinations are as follows.
         #
         #   simple, simple ==> True
-        #   simple, complex ==> True
+        #   simple, complex ==> False
         #   simple, string ==> False
-        #   complex, simple ==> True
-        #   complex, complex ==> False
+        #   complex, simple ==> False
+        #   complex, complex ==> (Depend)
         #   complex, string ==> False
         #   string, simple ==> False
         #   string, complex ==> False
@@ -285,27 +287,31 @@ class CompiledRouterNode(object):
         other = CompiledRouterNode(segment)
 
         if self.is_var:
+            # NOTE(kgriffs & philiptzou): Falcon does not accept multiple
+            # simple var nodes exist at the same level as following:
+            #
+            #   /foo/{thing1}
+            #   /foo/{thing2}
+            #
+            # Nor two complex nodes like this:
+            #
+            #   /foo/{thing1}.{ext}
+            #   /foo/{thing2}.{ext}
+            #
+            # On the other hand, those are all OK:
+            #
+            #   /foo/{thing1}
+            #   /foo/all
+            #   /foo/{thing1}.{ext}
+            #   /foo/{thing2}.detail.{ext}
+            #
             if self.is_complex:
                 if other.is_complex:
-                    return False
-
-                if other.is_var:
-                    return True
+                    return (self._regex_vars.sub('v', self.raw_segment) ==
+                            self._regex_vars.sub('v', segment))
 
                 return False
             else:
-                # NOTE(kgriffs & philiptzou): Falcon does not accept multiple
-                # simple var nodes exist at the same level as following:
-                #
-                #   /foo/{thing1}
-                #   /foo/{thing2}
-                #
-                # On the other hand, this is OK:
-                #
-                #   /foo/{thing1}
-                #   /foo/all
-                #   /foo/{thing1}.{ext}
-                #
                 return other.is_var and not other.is_complex
 
         # NOTE(kgriffs): If self is a static string match, then all the cases

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -76,15 +76,23 @@ class TestStandaloneRouter(testing.TestBase):
         setup_routes(self.router)
 
     @ddt.data(
-        '/teams/{collision}',
-        '/repos/{org}/{repo}/compare/{simple-collision}',
-        '/emojis/signs/{id_too}',
+        '/teams/{collision}',  # simple vs simple
+        '/emojis/signs/{id_too}',  # another simple vs simple
+        '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}:{collision}',
     )
     def test_collision(self, template):
         self.assertRaises(
             ValueError,
             self.router.add_route, template, {}, ResourceWithId(-1)
         )
+
+    @ddt.data(
+        '/repos/{org}/{repo}/compare/{simple-vs-complex}',
+        '/repos/{complex}.{vs}.{simple}',
+        '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}/full',
+    )
+    def test_non_collision(self, template):
+        self.router.add_route(template, {}, ResourceWithId(-1))
 
     def test_dump(self):
         print(self.router._src)

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -39,6 +39,28 @@ class NameAndDigitResource(object):
         self.called = True
 
 
+class FileResource(object):
+    def __init__(self):
+        self.file_id = None
+        self.called = False
+
+    def on_get(self, req, resp, file_id):
+        self.file_id = file_id
+        self.called = True
+
+
+class FileDetailsResource(object):
+    def __init__(self):
+        self.file_id = None
+        self.ext = None
+        self.called = False
+
+    def on_get(self, req, resp, file_id, ext):
+        self.file_id = file_id
+        self.ext = ext
+        self.called = True
+
+
 class TestUriTemplates(testing.TestBase):
 
     def before(self):
@@ -219,3 +241,25 @@ class TestUriTemplates(testing.TestBase):
 
         self.assertRaises(ValueError, self.api.add_route,
                           'no/leading_slash', self.resource)
+
+    def test_same_level_complex_var(self):
+        resource = FileResource()
+        details_resource = FileDetailsResource()
+        self.api.add_route('/files/{file_id}', resource)
+        self.api.add_route('/files/{file_id}.{ext}', details_resource)
+
+        # dots cause ambiguous in filenames
+        file_id_1 = self.getUniqueString().replace('.', '-')
+        file_id_2 = self.getUniqueString().replace('.', '-')
+        ext = self.getUniqueString().replace('.', '-')
+        path_1 = '/files/' + file_id_1
+        path_2 = '/files/' + file_id_2 + '.' + ext
+
+        self.simulate_request(path_1)
+        self.assertTrue(resource.called)
+        self.assertEqual(resource.file_id, file_id_1)
+
+        self.simulate_request(path_2)
+        self.assertTrue(details_resource.called)
+        self.assertEqual(details_resource.file_id, file_id_2)
+        self.assertEqual(details_resource.ext, ext)

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -263,3 +263,25 @@ class TestUriTemplates(testing.TestBase):
         self.assertTrue(details_resource.called)
         self.assertEqual(details_resource.file_id, file_id_2)
         self.assertEqual(details_resource.ext, ext)
+
+    def test_same_level_complex_var_in_reverse_order(self):
+        resource = FileResource()
+        details_resource = FileDetailsResource()
+        self.api.add_route('/files/{file_id}.{ext}', details_resource)
+        self.api.add_route('/files/{file_id}', resource)
+
+        # dots cause ambiguous in filenames
+        file_id_1 = self.getUniqueString().replace('.', '-')
+        file_id_2 = self.getUniqueString().replace('.', '-')
+        ext = self.getUniqueString().replace('.', '-')
+        path_1 = '/files/' + file_id_1
+        path_2 = '/files/' + file_id_2 + '.' + ext
+
+        self.simulate_request(path_1)
+        self.assertTrue(resource.called)
+        self.assertEqual(resource.file_id, file_id_1)
+
+        self.simulate_request(path_2)
+        self.assertTrue(details_resource.called)
+        self.assertEqual(details_resource.file_id, file_id_2)
+        self.assertEqual(details_resource.ext, ext)


### PR DESCRIPTION
Allow situation like this:

```python
api.add_route('/files/{file_id}', resource_1)
api.add_route('/files/{file_id}.{ext}', resource_2)
```

Which ValueError was raised due to only one var node was allowed whether
other nodes are complex or not. This fix changes the behaviour so now it
only applys to simple vars.

See #564