### PR TITLE
feat(req+resp): Add support for Content-Range units other than 'bytes'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,3 +56,4 @@ below in order of date of first contribution:
 * hooblei
 * Abhilash Raj (maxking)
 * Philip Tzou (philiptzou)
+* Peter Adam (p3dda)

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -509,10 +509,11 @@ class Response(object):
         'Content-Range',
         """A tuple to use in constructing a value for the Content-Range header.
 
-        The tuple has the form (*start*, *end*, *length*), where *start* and
-        *end* designate the byte range (inclusive), and *length* is the
-        total number of bytes, or '\*' if unknown. You may pass ``int``'s for
-        these numbers (no need to convert to ``str`` beforehand).
+        The tuple has the form (*start*, *end*, *length*, [*unit*]), where *start* and
+        *end* designate the range (inclusive), and *length* is the
+        total length, or '\*' if unknown. You may pass ``int``'s for
+        these numbers (no need to convert to ``str`` beforehand). The optional value
+        *unit* describes the range unit and defaults to 'bytes'
 
         Note:
             You only need to use the alternate form, 'bytes \*/1234', for

--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -51,12 +51,16 @@ def format_range(value):
 
     Args:
         value: ``tuple`` passed to `req.range`
-
     """
 
     # PERF: Concatenation is faster than % string formatting as well
     #       as ''.join() in this case.
-    return ('bytes ' +
+    if len(value) == 4:
+        unit = value[3] + ' '
+    else:
+        unit = 'bytes '
+
+    return (unit +
             str(value[0]) + '-' +
             str(value[1]) + '/' +
             str(value[2]))

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -403,6 +403,24 @@ class TestReqVars(testing.TestBase):
         req = Request(testing.create_environ())
         self.assertIs(req.range, None)
 
+    def test_range_unit(self):
+        headers = {'Range': 'bytes=10-'}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertEqual(req.range, (10, -1))
+        self.assertEqual(req.range_unit, 'bytes')
+
+        headers = {'Range': 'items=10-'}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertEqual(req.range, (10, -1))
+        self.assertEqual(req.range_unit, 'items')
+
+        headers = {'Range': ''}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertRaises(falcon.HTTPInvalidHeader, lambda: req.range_unit)
+
+        req = Request(testing.create_environ())
+        self.assertIs(req.range_unit, None)
+
     def test_range_invalid(self):
         headers = {'Range': 'bytes=10240'}
         req = Request(testing.create_environ(headers=headers))
@@ -410,7 +428,7 @@ class TestReqVars(testing.TestBase):
 
         headers = {'Range': 'bytes=-'}
         expected_desc = ('The value provided for the Range header is '
-                         'invalid. The byte offsets are missing.')
+                         'invalid. The range offsets are missing.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value', expected_desc)
@@ -461,8 +479,8 @@ class TestReqVars(testing.TestBase):
 
         headers = {'Range': 'bytes=x-y'}
         expected_desc = ('The value provided for the Range header is '
-                         'invalid. It must be a byte range formatted '
-                         'according to RFC 2616.')
+                         'invalid. It must be a range formatted '
+                         'according to RFC 7233.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value', expected_desc)
@@ -470,7 +488,7 @@ class TestReqVars(testing.TestBase):
         headers = {'Range': 'bytes=0-0,-1'}
         expected_desc = ('The value provided for the Range '
                          'header is invalid. The value must be a '
-                         'continuous byte range.')
+                         'continuous range.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value', expected_desc)
@@ -478,7 +496,7 @@ class TestReqVars(testing.TestBase):
         headers = {'Range': '10-'}
         expected_desc = ("The value provided for the Range "
                          "header is invalid. The value must be "
-                         "prefixed with 'bytes='")
+                         "prefixed with a range unit, e.g. 'bytes='")
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value', expected_desc)


### PR DESCRIPTION
Rebased and squashed version of #570 