### PR TITLE
feat(middleware) Pass params to process_resource

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -178,7 +178,8 @@ class API(object):
                 # e.g. a 404.
                 responder, params, resource = self._get_responder(req)
 
-                self._call_rsrc_mw(middleware_stack, req, resp, resource)
+                self._call_rsrc_mw(middleware_stack, req, resp, resource,
+                                   params)
 
                 responder(req, resp, **params)
                 self._call_resp_mw(middleware_stack, req, resp, resource)
@@ -537,13 +538,13 @@ class API(object):
             # Put executed component on the stack
             stack.append(component)  # keep track from outside
 
-    def _call_rsrc_mw(self, stack, req, resp, resource):
+    def _call_rsrc_mw(self, stack, req, resp, resource, params):
         """Run process_resource middleware methods."""
 
         for component in self._middleware:
             _, process_resource, _ = component
             if process_resource is not None:
-                process_resource(req, resp, resource)
+                process_resource(req, resp, resource, params)
 
     def _call_resp_mw(self, stack, req, resp, resource):
         """Run process_response middleware."""

--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -166,7 +166,7 @@ class TestHTTPStatusWithGlobalHooks(testing.TestBase):
     def test_raise_status_in_process_resource(self):
         """ Make sure we can raise status from middleware process resource """
         class TestMiddleware:
-            def process_resource(self, req, resp, resource):
+            def process_resource(self, req, resp, resource, params):
                 raise HTTPStatus(falcon.HTTP_200,
                                  headers={"X-Failed": "False"},
                                  body="Pass")


### PR DESCRIPTION
This allows middlewares to interact with route parameters.

BREAKING CHANGE: `process_resource` must now accept `params`
argument. Fix #612

I've arbitrated in favour of an API breaking change, because I think it's better to break API now (before 1.0) than to support useless legacy tricks, but of course this is to be discussed :)