### PR TITLE
feat: change API._get_responder() 404 behavior to raise falcon.HTTPNotFound()

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -494,8 +494,7 @@ class API(object):
 
                     break
             else:
-                responder = falcon.responders.path_not_found
-
+                raise falcon.HTTPNotFound()
         return (responder, params, resource)
 
     def _compose_status_response(self, req, resp, http_status):

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -466,8 +466,7 @@ class API(object):
         Note:
             If a responder was matched to the given URI, but the HTTP
             method was not found in the method_map for the responder,
-            the responder callable element of the returned tuple will be
-            `falcon.responder.bad_request`.
+            falcon.HTTPBadRequest() error will be raised.
         """
 
         path = req.path
@@ -490,7 +489,8 @@ class API(object):
 
                     break
             else:
-                raise falcon.HTTPNotFound()
+                responder = falcon.responders.path_not_found
+
         return (responder, params, resource)
 
     def _compose_status_response(self, req, resp, http_status):

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -453,20 +453,21 @@ class API(object):
 
     def _get_responder(self, req):
         """Searches routes for a matching responder.
-
         Args:
             req: The request object.
-
         Returns:
             A 3-member tuple consisting of a responder callable,
             a ``dict`` containing parsed path fields (if any were specified in
             the matching route's URI template), and a reference to the
             responder's resource instance.
-
         Note:
             If a responder was matched to the given URI, but the HTTP
             method was not found in the method_map for the responder,
-            falcon.HTTPBadRequest() error will be raised.
+            the responder callable element of the returned tuple will be
+            `falcon.responder.bad_request`.
+            Likewise, if no responder was matched for the given URI, then
+            the responder callable element of the returned tuple will be
+            `falcon.responder.path_not_found`
         """
 
         path = req.path

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -468,10 +468,6 @@ class API(object):
             method was not found in the method_map for the responder,
             the responder callable element of the returned tuple will be
             `falcon.responder.bad_request`.
-
-            Likewise, if no responder was matched for the given URI, then
-            the responder callable element of the returned tuple will be
-            `falcon.responder.path_not_found`
         """
 
         path = req.path

--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -18,11 +18,6 @@ from falcon.status_codes import HTTP_404
 from falcon.status_codes import HTTP_405
 
 
-def path_not_found(req, resp, **kwargs):
-    """Simply sets responseto "404 Not Found", no body."""
-    resp.status = HTTP_404
-
-
 def bad_request(req, resp, **kwargs):
     """Sets response to "400 Bad Request", no body."""
     resp.status = HTTP_400

--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -13,14 +13,19 @@
 # limitations under the License.
 
 from falcon.status_codes import HTTP_204
-from falcon.status_codes import HTTP_400
-from falcon.status_codes import HTTP_404
 from falcon.status_codes import HTTP_405
+from falcon.errors import HTTPNotFound
+from falcon.errors import HTTPBadRequest
+
+
+def path_not_found(req, resp, **kwargs):
+    """Raise 404 HTTPNotFound error"""
+    raise HTTPNotFound()
 
 
 def bad_request(req, resp, **kwargs):
-    """Sets response to "400 Bad Request", no body."""
-    resp.status = HTTP_400
+    """Raise 400 HTTPBadRequest error"""
+    raise HTTPBadRequest('Bad request', 'Invalid HTTP method')
 
 
 def create_method_not_allowed(allowed_methods):

--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -14,8 +14,8 @@
 
 from falcon.status_codes import HTTP_204
 from falcon.status_codes import HTTP_405
-from falcon.errors import HTTPNotFound
 from falcon.errors import HTTPBadRequest
+from falcon.errors import HTTPNotFound
 
 
 def path_not_found(req, resp, **kwargs):


### PR DESCRIPTION
feat: change API._get_responder() 404 behavior to raise falcon.HTTPNotFound()

Class API() currenlty accepts optional method add_error_handler() to override raised exceptions.
By default, API._get_responder() method returns a tuple including
responder = falcon.responders.path_not_found. Change made to API._get_responder() to raise
falcon.HTTPNotFound() in place of returning falcon.responders.path_not_found
This change allows easy override of 404 behavior in the application.