### PR TITLE
Remove mention of the Talons project from the tutorial, update FAQ

### DIFF
--- a/doc/community/faq.rst
+++ b/doc/community/faq.rst
@@ -18,39 +18,21 @@ simply wrap your api instance with a middleware app. For example:
 
 See also the `WSGI middleware example <http://legacy.python.org/dev/peps/pep-3333/#middleware-components-that-play-both-sides>`_ given in PEP-3333.
 
-
-Why doesn't Falcon include X?
------------------------------
-The Python ecosytem offers a bunch of great libraries that you
-are welcome to use from within your responder, hooks, and middleware.
-Falcon doesn't try to dictate what you should use, since that would take
-away your freedom to choose the best tool for the job.
-
-The Falcon framework lets you decide your own answers to questions like:
-
-* gevent or asyncio?
-* JSON or MessagePack?
-* konval or jsonschema?
-* Mongothon or Monk?
-* Storm, SQLAlchemy or peewee?
-* Jinja or Tenjin?
-* python-multipart or cgi.FieldStorage?
-
-
+Why doesn't Falcon come with batteries included?
+------------------------------------------------
+The Python ecosystem offers a bunch of great libraries that you are welcome
+to use from within your responders, hooks, and middleware components. Falcon
+doesn't try to dictate what you should use, since that would take away your
+freedom to choose the best tool for the job.
 
 How do I authenticate requests?
 -------------------------------
-Hooks and/or middleware components can be used to to authenticate and
-authorize requests. For example, you could create a middleware component
-that parses incoming credentials and places the result in ``req.context``.
-Downstream components or hooks could then use this info to authenticate
-the user, and then finally authorize the request, taking into account the
-user's role and the requested resource.
-
-.. Tip::
-
-    The `Talons project <https://github.com/talons/talons>`_ maintains a
-    collection of auth plugins for the Falcon framework.
+Hooks and middleware components can be used together to authenticate and
+authorize requests. For example, a middleware component could be used to
+parse incoming credentials and place the results in ``req.context``.
+Downstream components or hooks could then use this information to
+authorize the request, taking into account the user's role and the requested
+resource.
 
 Why doesn't Falcon create a new Resource instance for every request?
 --------------------------------------------------------------------

--- a/doc/user/tutorial.rst
+++ b/doc/user/tutorial.rst
@@ -578,12 +578,6 @@ authorized to access. In that case, you may wish to simply return
 ``404 Not Found`` with an empty body, in case a malicious user is fishing
 for information that will help them crack your API.
 
-.. tip:: Please take a look at our new sister project,
-   `Talons <https://github.com/talons/talons>`_, for a collection of
-   useful Falcon hooks contributed by the community. Also, If you create a
-   nifty hook that you think others could use, please consider
-   contributing to the project yourself.
-
 Error Handling
 --------------
 


### PR DESCRIPTION
The Talons project has not become a general repository for
community add-ons, as originally envisioned. Remove from the
the tutorial to avoid confusion (based on community feedback.)

Also update the FAQ as follows:

    * Remove mention of talons to allow for diversity in
      the Falcon ecosystem
    * Remove mention of specific "choices" that Falcon lets
      you make regarding complementary libraries, since in
      each case there are actually many more choices than
      given, and the list only seems to belabor the point.