### PR TITLE
chore: Optimize Travis test order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ cache:
     directories:
         - $HOME/.cache/pip
 env:
+  - JYTHON=true
   - TOXENV=py26
+  - TOXENV=pep8
+  - TOXENV=pylint
   - TOXENV=py27
   - TOXENV=py27_cython
   - TOXENV=py33
@@ -14,11 +17,8 @@ env:
   - TOXENV=py34_cython
   - TOXENV=pypy
   - TOXENV=pypy3
-  - TOXENV=pep8
-  - TOXENV=pylint
   - TOXENV=py27_smoke
   - TOXENV=py27_smoke_cython
-  - JYTHON=true
 
 script: travis_scripts/run_tests.sh
 notifications:


### PR DESCRIPTION
Start the slow Jython test first since it takes the longest to
complete; other tests can run in parallel. Also, run the relatively
quick pep8 and pylint jobs in parallel with the slower Jython and
py26 jobs.