### PR TITLE
feat(Request): Add support for 'application/msgpack'

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -353,7 +353,8 @@ class Request(object):
 
     @property
     def client_accepts_msgpack(self):
-        return self.client_accepts('application/x-msgpack')
+        return (self.client_accepts('application/x-msgpack')
+                or self.client_accepts('application/msgpack'))
 
     @property
     def client_accepts_xml(self):

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -348,6 +348,12 @@ class TestReqVars(testing.TestBase):
         self.assertFalse(req.client_accepts_json)
         self.assertTrue(req.client_accepts_msgpack)
 
+        headers = {'Accept': 'application/msgpack'}
+        req = Request(testing.create_environ(headers=headers))
+        self.assertFalse(req.client_accepts_xml)
+        self.assertFalse(req.client_accepts_json)
+        self.assertTrue(req.client_accepts_msgpack)
+
         headers = {
             'Accept': 'application/json,application/xml,application/x-msgpack'
         }


### PR DESCRIPTION
In addition to 'application/x-msgpack', add support to Request.client_accepts_msgpack() for 'application/msgpack'.

Rebased version of #603

Closes #544