### PR TITLE
fix(Request): Improve access_route perf and error handling

### DIFF
--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -386,14 +386,15 @@ def unquote_string(quoted):
     Raises:
         TypeError: `quoted` was not a ``str``.
     """
-    tmp_quoted = quoted.strip()
-    if len(tmp_quoted) < 2:
+
+    if len(quoted) < 2:
         return quoted
-    elif tmp_quoted[0] != '"' or tmp_quoted[-1] != '"':
+    elif quoted[0] != '"' or quoted[-1] != '"':
         # return original one, prevent side-effect
         return quoted
 
-    tmp_quoted = tmp_quoted[1:-1]
+    tmp_quoted = quoted[1:-1]
+
     # PERF(philiptzou): Most header strings don't contain "quoted-pair" which
     # defined by RFC 7320. We use this little trick (quick string search) to
     # speed up string parsing by preventing unnecessary processes if possible.

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -29,7 +29,7 @@ def _is_iterable(thing):
 def _run_server(stop_event):
     class Things(object):
         def on_get(self, req, resp):
-            pass
+            resp.body = req.remote_addr
 
         def on_post(self, req, resp):
             resp.body = req.stream.read(1000)
@@ -127,6 +127,7 @@ class TestWSGIReference(testing.TestBase):
     def test_wsgiref_get(self):
         resp = requests.get(_SERVER_BASE_URL)
         self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.text, '127.0.0.1')
 
     def test_wsgiref_put(self):
         body = '{}'


### PR DESCRIPTION
Tune performance of the Request.access_route property, while also
making error handling more consistent, in the case that a header value
is malformed. Also, add a test to ensure that wsgiref passes
REMOTE_ADDR in the environment dict, as has been observed in production
WSGI servers. This is necessary to ensure that Request.access_route's
fallback to REMOTE_ADDR makes sense.