### PR TITLE
doc(Cookies): Improve user guide, docstring, and FAQ

### DIFF
--- a/doc/api/cookies.rst
+++ b/doc/api/cookies.rst
@@ -20,33 +20,34 @@ request attribute:
 
             cookies = req.cookies
 
-            if "my_cookie" in cookies:
-                my_cookie_value = cookies["my_cookie"]
+            if 'my_cookie' in cookies:
+                my_cookie_value = cookies['my_cookie']
             # ....
 
 The :py:attr:`~.Request.cookies` attribute is a regular
 :py:class:`dict` object.
 
-.. tip :: :py:attr:`~.Request.cookies` returns a
-    copy of the response cookie dict. Assign it to a variable as in the above example
-    for better performance.
+.. tip ::
+
+    The :py:attr:`~.Request.cookies` attribute returns a
+    copy of the response cookie dictionary. Assign it to a variable, as
+    shown in the above example, to improve performance when you need to
+    look up more than one cookie.
 
 .. _setting-cookies:
 
 Setting Cookies
 ~~~~~~~~~~~~~~~
 
-Setting cookies on a response is done via the :py:meth:`~.Response.set_cookie`.
+Setting cookies on a response is done via :py:meth:`~.Response.set_cookie`.
 
-You should use :py:meth:`~.Response.set_cookie` instead of
+The :py:meth:`~.Response.set_cookie` method should be used instead of
 :py:meth:`~.Response.set_header` or :py:meth:`~.Response.append_header`.
-
 With :py:meth:`~.Response.set_header` you cannot set multiple headers
 with the same name (which is how multiple cookies are sent to the client).
-
-:py:meth:`~.Response.append_header` appends multiple values to the same
-header field, which is not compatible with the format used by `Set-Cookie`
-headers to send cookies to clients.
+Furthermore, :py:meth:`~.Response.append_header` appends multiple values
+to the same header field in a way that is not compatible with the special
+format required by the `Set-Cookie` header.
 
 Simple example:
 
@@ -54,8 +55,9 @@ Simple example:
 
     class Resource(object):
         def on_get(self, req, resp):
-            # Set the cookie "my_cookie" to the value "my cookie value"
-            resp.set_cookie("my_cookie", "my cookie value")
+
+            # Set the cookie 'my_cookie' to the value 'my cookie value'
+            resp.set_cookie('my_cookie', 'my cookie value')
 
 
 You can of course also set the domain, path and lifetime of the cookie.
@@ -64,19 +66,38 @@ You can of course also set the domain, path and lifetime of the cookie.
 
     class Resource(object):
         def on_get(self, req, resp):
-            # Set the 'max-age' of the cookie to 10 minutes (600 seconds)
-            # and the cookies domain to "example.com"
-            resp.set_cookie("my_cookie", "my cookie value",
-                            max_age=600, domain="example.com")
+            # Set the maximum age of the cookie to 10 minutes (600 seconds)
+            # and the cookie's domain to 'example.com'
+            resp.set_cookie('my_cookie', 'my cookie value',
+                            max_age=600, domain='example.com')
 
 
-If you set a cookie and want to get rid of it again, you can
-use the :py:meth:`~.Response.unset_cookie`:
+You can also instruct the client to remove a cookie with the
+:py:meth:`~.Response.unset_cookie` method:
 
 .. code:: python
 
     class Resource(object):
         def on_get(self, req, resp):
-            resp.set_cookie("bad_cookie", ":(")
-            # clear the bad cookie
-            resp.unset_cookie("bad_cookie")
+            resp.set_cookie('bad_cookie', ':(')
+
+            # Clear the bad cookie
+            resp.unset_cookie('bad_cookie')
+
+.. _cookie-secure-atribute:
+
+The Secure Attribute
+~~~~~~~~~~~~~~~~~~~~
+
+By default, Falcon sets the `secure` attribute for cookies. This instructs the client to never transmit the cookie in the clear over HTTP, in order to protect any sensitive data that cookie might contain. If a cookie is set, and a subsequent request is made over HTTP (rather than HTTPS), the client will not include that cookie in the request.
+
+.. warning::
+
+    For this attribute to be effective, your application will need to enforce HTTPS when setting the cookie, as well as in all subsequent requests that require the cookie to be sent back from the client.
+
+When running your application in a development environment, you can disable this behavior by passing `secure=False` to :py:meth:`~.Response.set_cookie`. This lets you test your app locally without having to set up TLS. You can make this option configurable to easily switch between development and production environments.
+
+See also: `RFC 6265, Section 4.1.2.5`_
+
+.. _RFC 6265, Section 4.1.2.5:
+    https://tools.ietf.org/html/rfc6265#section-4.1.2.5

--- a/doc/community/faq.rst
+++ b/doc/community/faq.rst
@@ -120,6 +120,12 @@ If you have another case where you body isn't being returned to the
 client, it's probably a bug! Let us know in IRC or on the mailing list so
 we can help.
 
+My app is setting a cookie, but it isn't being passed back in subsequent requests.
+----------------------------------------------------------------------------------
+By default, Falcon enables the `secure` cookie attribute. Therefore, if you are
+testing your app over HTTP (instead of HTTPS), the client will not send the
+cookie in subsequent requests. See also :ref:`the cookie documentation <cookie-secure-attribute>`
+
 Why does raising an error inside a resource crash my app?
 ---------------------------------------------------------
 Generally speaking, Falcon assumes that resource responders (such as *on_get*,

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -193,10 +193,12 @@ class Response(object):
                 A value of 0 means the cookie should be discarded immediately.
             path (str): Specifies the subset of URLs to
                 which this cookie applies.
-            secure (bool): Direct the client to use only secure means to
-                contact the origin server whenever it sends back this cookie
-                (default: ``True``). Warning: You will also need to enforce
-                HTTPS for the cookies to be transfered securely.
+            secure (bool): Direct the client to only return the cookie in
+                subsequent requests if they are made over HTTPS
+                (default: ``True``). This prevents attackers from reading
+                sensitive cookie data. Note that for the `secure` cookie
+                attribute to be effective, your application will need to
+                enforce HTTPS. See also: `RFC 6265, Section 4.1.2.5`_.
             http_only (bool): Direct the client to only transfer the cookie
                 with unscripted HTTP requests (default: ``True``). This is
                 intended to mitigate some forms of cross-site scripting.
@@ -207,6 +209,9 @@ class Response(object):
 
         .. _RFC 6265:
             http://tools.ietf.org/html/rfc6265
+
+        .. _RFC 6265, Section 4.1.2.5:
+            https://tools.ietf.org/html/rfc6265#section-4.1.2.5
 
         """
 


### PR DESCRIPTION
Improve the documentation regarding cookies, esp. with respect to using the secure cookie attribute. Edit the prose for clarity and correctness. Replace double-quotes with single-quotes in code samples.