### PR TITLE
perf(Response): Optimize response body processing

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from six import PY2
-from six import text_type as TEXT_TYPE
 from six import string_types as STRING_TYPES
 
 # NOTE(tbug): In some cases, http_cookies is not a module
@@ -57,7 +56,6 @@ class Response(object):
             Unicode, Falcon will encode as UTF-8 in the response. If
             data is already a byte string, use the data attribute
             instead (it's faster).
-        body_encoded (bytes): Returns a UTF-8 encoded version of `body`.
         data (bytes): Byte string representing response content.
 
             Use this attribute in lieu of `body` when your content is
@@ -94,8 +92,7 @@ class Response(object):
     """
 
     __slots__ = (
-        '_body',  # Stuff
-        '_body_encoded',  # Stuff
+        'body',
         'data',
         '_headers',
         '_cookies',
@@ -112,41 +109,10 @@ class Response(object):
         # when cookie is set via set_cookie
         self._cookies = None
 
-        self._body = None
-        self._body_encoded = None
+        self.body = None
         self.data = None
         self.stream = None
         self.stream_len = None
-
-    def _get_body(self):
-        return self._body
-
-    def _set_body(self, value):
-        self._body = value
-        self._body_encoded = None
-
-    # NOTE(flaper87): Lets use a property
-    # for the body in case its content was
-    # encoded and then modified.
-    body = property(_get_body, _set_body)
-
-    @property
-    def body_encoded(self):
-        # NOTE(flaper87): Notice this property
-        # is not thread-safe. If body is modified
-        # before this property returns, we might
-        # end up returning None.
-        body = self._body
-        if body and self._body_encoded is None:
-
-            # NOTE(flaper87): Assume it is an
-            # encoded str, then check and encode
-            # if it isn't.
-            self._body_encoded = body
-            if isinstance(body, TEXT_TYPE):
-                self._body_encoded = body.encode('utf-8')
-
-        return self._body_encoded
 
     def set_stream(self, stream, stream_len):
         """Convenience method for setting both `stream` and `stream_len`.

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -133,7 +133,7 @@ class TestHelloWorld(testing.TestBase):
 
         self.assertEqual(self.srmock.status, self.resource.sample_status)
         self.assertEqual(resp.status, self.resource.sample_status)
-        self.assertEqual(resp.body_encoded, self.resource.sample_utf8)
+        self.assertEqual(resp.body.encode('utf-8'), self.resource.sample_utf8)
         self.assertEqual(body, [self.resource.sample_utf8])
 
     def test_body_bytes(self):
@@ -145,7 +145,7 @@ class TestHelloWorld(testing.TestBase):
 
         self.assertEqual(self.srmock.status, self.resource.sample_status)
         self.assertEqual(resp.status, self.resource.sample_status)
-        self.assertEqual(resp.body_encoded, self.resource.sample_utf8)
+        self.assertEqual(resp.body, self.resource.sample_utf8)
         self.assertEqual(body, [self.resource.sample_utf8])
 
     def test_data(self):


### PR DESCRIPTION
**Please review carefully** before merging. This is a significant change to the way the framework processes the response body.

---

Remove overhead from response body processing in API and Response.

BREAKING CHANGE: Response.body_encoded has been removed. The property was only intended to be used by the framework itself, so there should not be many apps using it.

To migrate the code, follow the example below:

Before:

```py
    body = resp.body_encoded
```

After:

```py
    if resp.body:
        body = resp.body.encode('utf-8')
    else:
        body = b''
```