### PR TITLE
feat(API): Change error responders to raise instances of HTTPError

### DIFF
--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from falcon.errors import HTTPBadRequest
+from falcon.errors import HTTPNotFound
 from falcon.status_codes import HTTP_204
-from falcon.status_codes import HTTP_400
-from falcon.status_codes import HTTP_404
 from falcon.status_codes import HTTP_405
 
 
 def path_not_found(req, resp, **kwargs):
-    """Simply sets responseto "404 Not Found", no body."""
-    resp.status = HTTP_404
+    """Raise 404 HTTPNotFound error"""
+    raise HTTPNotFound()
 
 
 def bad_request(req, resp, **kwargs):
-    """Sets response to "400 Bad Request", no body."""
-    resp.status = HTTP_400
+    """Raise 400 HTTPBadRequest error"""
+    raise HTTPBadRequest('Bad request', 'Invalid HTTP method')
 
 
 def create_method_not_allowed(allowed_methods):


### PR DESCRIPTION
When an invalid HTTP method is requested, or a path is requested for which there is no route configured, raise instances of HTTPError instead of directly manipulating the Response object. This makes it easier for applications to customize behavior in these cases.