### PR TITLE
test(tox): Add debug envs and organize into sections

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,37 +1,24 @@
 [tox]
+# NOTE(kgriffs): The py26, py27, and py34 evns are required when
+# checking combined coverage. After running all three envs, execute
+# "tools/combine_coverage.sh" to create a combined coverage report
+# that can be viewed by opening ".coverage_html/index.html".
 envlist = py26,
           py27,
-          py27_cython,
-          ; py33,
-          ; py33_cython,
           py34,
-          py34_cython,
-          ; py35,
-          ; py35_cython,
-          pypy,
-          ; pypy3,
           pep8,
           pylint,
-          py27_smoke,
-          py27_smoke_cython,
-          ; py26_bench,
-          ; py27_bench,
-          ; py27_bench_cython,
-          ; py33_bench,
-          ; py33_bench_cython,
-          ; py34_bench,
-          ; py34_bench_cython,
-          ; py35_bench,
-          ; py35_bench_cython,
-          ; pypy_bench
-          ; pypy3_bench
 
 [testenv]
 deps = -r{toxinidir}/tools/test-requires
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests {posargs}
+           nosetests []
 
-[testenv:py26]
+# --------------------------------------------------------------------
+# Coverage
+# --------------------------------------------------------------------
+
+[with-coverage]
 whitelist_externals = bash
                       mv
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
@@ -39,48 +26,86 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            bash -c "if [ ! -d .coverage_data ]; then mkdir .coverage_data; fi"
            mv {toxinidir}/.coverage {toxinidir}/.coverage_data/.coverage.{envname}
 
+
+[testenv:py26]
+whitelist_externals = {[with-coverage]whitelist_externals}
+commands = {[with-coverage]commands}
+
 [testenv:py27]
-whitelist_externals = bash
-                      mv
-commands = {[testenv:py26]commands}
+whitelist_externals = {[with-coverage]whitelist_externals}
+commands = {[with-coverage]commands}
 
 [testenv:py34]
-whitelist_externals = bash
-                      mv
-commands = {[testenv:py26]commands}
+whitelist_externals = {[with-coverage]whitelist_externals}
+commands = {[with-coverage]commands}
+
+# --------------------------------------------------------------------
+# Debugging
+# --------------------------------------------------------------------
+
+[with-debug-tools]
+deps = -r{toxinidir}/tools/test-requires
+       ipdb
+       pdbpp
+
+[testenv:py27_debug]
+deps = {[with-debug-tools]deps}
+
+[testenv:py34_debug]
+deps = {[with-debug-tools]deps}
 
 [testenv:py27_profile]
 deps = -r{toxinidir}/tools/test-requires
        nose-cprof
-basepython = python2.7
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            nosetests \
                --with-cprofile \
                --cprofile-stats-erase \
                --cprofile-stats-file=cprofile.dat \
-               {posargs}
+               -s \
+               []
 
-[testenv:py27_cython]
+# --------------------------------------------------------------------
+# Cython
+# --------------------------------------------------------------------
+
+[with-cython]
 deps = -r{toxinidir}/tools/test-requires
        cython
-basepython = python2.7
-commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests
+
+[testenv:py27_cython]
+deps = {[with-cython]deps}
 
 [testenv:py33_cython]
-deps = {[testenv:py27_cython]deps}
-basepython = python3.3
-commands = {[testenv:py27_cython]commands}
+deps = {[with-cython]deps}
 
 [testenv:py34_cython]
-deps = {[testenv:py27_cython]deps}
-basepython = python3.4
-commands = {[testenv:py27_cython]commands}
+deps = {[with-cython]deps}
 
 [testenv:py35_cython]
-deps = {[testenv:py27_cython]deps}
-basepython = python3.5
-commands = {[testenv:py27_cython]commands}
+deps = {[with-cython]deps}
+
+# --------------------------------------------------------------------
+# Smoke testing
+# --------------------------------------------------------------------
+
+[smoke-test]
+commands = falcon-bench -t 1 -b falcon-ext
+
+[testenv:py27_smoke]
+# This test smoke-tests a basic Falcon app
+deps = -r{toxinidir}/tools/bench-requires
+commands = {[smoke-test]commands}
+
+[testenv:py27_smoke_cython]
+# This test ensures that a falcon app will run fine under Cython
+deps = -r{toxinidir}/tools/bench-requires
+       cython
+commands = {[smoke-test]commands}
+
+# --------------------------------------------------------------------
+# Lint
+# --------------------------------------------------------------------
 
 [testenv:py3kwarn]
 deps = py3kwarn
@@ -88,90 +113,68 @@ commands = py3kwarn falcon
 
 [testenv:pep8]
 deps = flake8
-basepython = python2.7
 commands = flake8 \
              --max-complexity=15 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
              --ignore=F403 \
              --max-line-length=99 \
-             {posargs}
+             []
 
 [testenv:pylint]
 deps = pylint
-basepython = python2.7
 commands = pylint falcon \
              --ignore=bench,tests \
              -E \
-             {posargs}
+             []
+
+# --------------------------------------------------------------------
+# Benchmarking
+# --------------------------------------------------------------------
 
 [testenv:py26_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = python2.6
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py27_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = python2.7
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py27_bench_cython]
 deps = -r{toxinidir}/tools/bench-requires
        cython
-basepython = python2.7
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py33_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = python3.3
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py33_bench_cython]
 deps = -r{toxinidir}/tools/bench-requires
        cython
-basepython = python3.3
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py34_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = python3.4
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py34_bench_cython]
 deps = -r{toxinidir}/tools/bench-requires
        cython
-basepython = python3.4
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py35_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = python3.5
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:py35_bench_cython]
 deps = -r{toxinidir}/tools/bench-requires
        cython
-basepython = python3.5
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:pypy_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = pypy
-commands = falcon-bench {posargs}
+commands = falcon-bench []
 
 [testenv:pypy3_bench]
 deps = -r{toxinidir}/tools/bench-requires
-basepython = pypy3
-commands = falcon-bench {posargs}
-
-[testenv:py27_smoke]
-# This test smoke-tests a basic Falcon app
-deps = -r{toxinidir}/tools/bench-requires
-basepython = python2.7
-commands = falcon-bench -t 1 -b falcon-ext
-
-[testenv:py27_smoke_cython]
-# This test ensures that a falcon app will run fine under Cython
-deps = -r{toxinidir}/tools/bench-requires
-       cython
-basepython = python2.7
-commands = falcon-bench -t 1 -b falcon-ext
+commands = falcon-bench []


### PR DESCRIPTION
Add debug environments that accept pos args for specifying individual tests to run, and for passing options such as -s for use with pdb, ipdb, etc.

Also organize envs into sections with headers, and clean up the default envlist.