### PR TITLE
test(req.client_accepts): Fix invalid assertion based on q=0.0

### DIFF
--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -297,11 +297,12 @@ class TestReqVars(testing.TestBase):
         req = Request(testing.create_environ(headers=headers))
         self.assertTrue(req.client_accepts('text/plain'))
         self.assertTrue(req.client_accepts('text/csv'))
-        self.assertTrue(req.client_accepts('application/xhtml+xml'))
+        self.assertFalse(req.client_accepts('application/xhtml+xml'))
 
         headers = {'Accept': 'text/*; q=0.1, application/xhtml+xml; q=0.5'}
         req = Request(testing.create_environ(headers=headers))
         self.assertTrue(req.client_accepts('text/plain'))
+        self.assertTrue(req.client_accepts('application/xhtml+xml'))
 
         headers = {'Accept': 'text/*,         application/*'}
         req = Request(testing.create_environ(headers=headers))
@@ -372,7 +373,7 @@ class TestReqVars(testing.TestBase):
         preferred_type = req.client_prefers(('application/xml',
                                              'application/json'))
 
-        # NOTE(kgriffs): If client doesn't care, "preferr" the first one
+        # NOTE(kgriffs): If client doesn't care, "prefer" the first one
         self.assertEqual(preferred_type, 'application/xml')
 
         headers = {'Accept': 'text/*; q=0.1, application/xhtml+xml; q=0.5'}


### PR DESCRIPTION
A bug was fixed in python-mimeparse that caused an assertion to fail. A quality setting of "0.0" is now (correctly) treated as indicating that the associated media type is "not acceptable" by the client.
Adjust the tests accordingly.