### PR TITLE
doc(contrib-snip): Clarified mailing list subscription information

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -415,13 +415,14 @@ Community
 ---------
 
 The Falcon community maintains a mailing list that you can use to share
-your ideas and ask questions about the framework. We use the
-appropriately minimalistic `Librelist <http://librelist.com/>`__ to host
-the discussions. Subscribing is super easy and doesn't require any
-account setup. Simply send an email to falcon@librelist.com and follow
-the instructions in the reply. For more information about managing your
+your ideas and ask questions about the framework. We use the appropriately
+minimalistic `Librelist <http://librelist.com/>`_ to host the discussions.
+
+To join the mailing list, simply send your first email to falcon@librelist.com!
+This will automatically subscribe you to the mailing list *and* sends your email
+along to the rest of the subscribers. For more information about managing your
 subscription, check out the
-`Librelist help page <http://librelist.com/help.html>`__.
+`Librelist help page <http://librelist.com/help.html>`_.
 
 We expect everyone who participates on the mailing list to act
 professionally, and lead by example in encouraging constructive

--- a/doc/community/contrib-snip.rst
+++ b/doc/community/contrib-snip.rst
@@ -4,10 +4,11 @@ The Falcon community maintains a mailing list that you can use to share
 your ideas and ask questions about the framework. We use the appropriately
 minimalistic `Librelist <http://librelist.com/>`_ to host the discussions.
 
-Subscribing is super easy and doesn't require any account setup. Simply
-send an email to falcon@librelist.com and follow the instructions in the
-reply. For more information about managing your subscription, check out
-the `Librelist help page <http://librelist.com/help.html>`_.
+To join the mailing list, simply send your first email to falcon@librelist.com!
+This will automatically subscribe you to the mailing list *and* sends your email
+along to the rest of the subscribers. For more information about managing your
+subscription, check out the
+`Librelist help page <http://librelist.com/help.html>`_.
 
 All contributors and maintainers of this project are subject to our `Code
 of Conduct <https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md>`_.

--- a/doc/community/contribute.rst
+++ b/doc/community/contribute.rst
@@ -31,7 +31,7 @@ doesn't make pyflakes sad.
 **Additional Style Rules**
 
 * Docstrings are required for classes, attributes, methods, and functions.
-* Use `napolean-flavored`_ dosctrings to make them readable both when
+* Use `napolean-flavored`_ docstrings to make them readable both when
   using the *help* function within a REPL, and when browsing
   them on *Read the Docs*.
 * Format non-trivial comments using your GitHub nick and an appropriate


### PR DESCRIPTION
This PR simply clarifies what happens when you send your first e-mail to the mailing list.

(oh, and I also snuck a typo fix in there)