### PR TITLE
test: Force pep8 to run under py27

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -548,7 +548,7 @@ class Response(object):
         lambda v: ', '.join(v))
 
     def _encode_header(self, name, value, py2=PY2):
-        if py2:  # pragma: no cover
+        if py2:
             if isinstance(name, unicode):
                 name = name.encode('ISO-8859-1')
 

--- a/tox.ini
+++ b/tox.ini
@@ -117,6 +117,12 @@ commands = py3kwarn falcon
 
 [testenv:pep8]
 deps = flake8
+
+# NOTE(kgriffs): Run with py27 since some code branches assume the
+#   unicode type is defined, and pep8 complains in those cases when
+#   running under py3.
+basepython = python2.7
+
 commands = flake8 \
              --max-complexity=15 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \


### PR DESCRIPTION
Run pep8 with py27 since some code branches assume the unicode type is defined, and pep8 complains in those cases when running under py3.