### PR TITLE
fix(falcon.routing.DefaultRouter): Do not mask variable path segments

### DIFF
--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -1,5 +1,6 @@
 import ddt
 
+from falcon.routing import DefaultRouter
 import falcon.testing as testing
 
 
@@ -14,66 +15,115 @@ class ResourceWithId(object):
         resp.body = self.resource_id
 
 
-def setup_routes(router_interface):
-    router_interface.add_route(
-        '/repos', {}, ResourceWithId(1))
-    router_interface.add_route(
-        '/repos/{org}', {}, ResourceWithId(2))
-    router_interface.add_route(
-        '/repos/{org}/{repo}', {}, ResourceWithId(3))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/commits', {}, ResourceWithId(4))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
-        {}, ResourceWithId(5))
-    router_interface.add_route(
-        '/teams/{id}', {}, ResourceWithId(6))
-    router_interface.add_route(
-        '/teams/{id}/members', {}, ResourceWithId(7))
-    router_interface.add_route(
-        '/user/memberships', {}, ResourceWithId(8))
-    router_interface.add_route(
-        '/emojis', {}, ResourceWithId(9))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
-        {}, ResourceWithId(10))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
+class TestRegressionCases(testing.TestBase):
+    """Test specific repros reported by users of the framework."""
 
-    # NOTE(kgriffs): The ordering of these calls is significant; we
-    # need to test that the {id} field does not match the other routes,
-    # regardless of the order they are added.
-    router_interface.add_route(
-        '/emojis/signs/0', {}, ResourceWithId(12))
-    router_interface.add_route(
-        '/emojis/signs/{id}', {}, ResourceWithId(13))
-    router_interface.add_route(
-        '/emojis/signs/42', {}, ResourceWithId(14))
-    router_interface.add_route(
-        '/emojis/signs/42/small', {}, ResourceWithId(14.1))
-    router_interface.add_route(
-        '/emojis/signs/78/small', {}, ResourceWithId(14.1))
+    def before(self):
+        self.router = DefaultRouter()
 
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
-        {}, ResourceWithId(15))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
-        {}, ResourceWithId(16))
-    router_interface.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
-        {}, ResourceWithId(17))
+    def test_versioned_url(self):
+        self.router.add_route('/{version}/messages', {}, ResourceWithId(2))
 
-    router_interface.add_route(
-        '/gists/{id}/raw', {}, ResourceWithId(18))
+        resource, method_map, params = self.router.find('/v2/messages')
+        self.assertEqual(resource.resource_id, 2)
+
+        self.router.add_route('/v2', {}, ResourceWithId(1))
+
+        resource, method_map, params = self.router.find('/v2')
+        self.assertEqual(resource.resource_id, 1)
+
+        resource, method_map, params = self.router.find('/v2/messages')
+        self.assertEqual(resource.resource_id, 2)
+
+        resource, method_map, params = self.router.find('/v1/messages')
+        self.assertEqual(resource.resource_id, 2)
+
+        resource, method_map, params = self.router.find('/v1')
+        self.assertIs(resource, None)
+
+    def test_recipes(self):
+        self.router.add_route(
+            '/recipes/{activity}/{type_id}', {}, ResourceWithId(1))
+        self.router.add_route(
+            '/recipes/baking', {}, ResourceWithId(2))
+
+        resource, method_map, params = self.router.find('/recipes/baking/4242')
+        self.assertEqual(resource.resource_id, 1)
+
+        resource, method_map, params = self.router.find('/recipes/baking')
+        self.assertEqual(resource.resource_id, 2)
+
+        resource, method_map, params = self.router.find('/recipes/grilling')
+        self.assertIs(resource, None)
 
 
 @ddt.ddt
-class TestStandaloneRouter(testing.TestBase):
+class TestComplexRouting(testing.TestBase):
     def before(self):
-        from falcon.routing import DefaultRouter
         self.router = DefaultRouter()
-        setup_routes(self.router)
+
+        self.router.add_route(
+            '/repos', {}, ResourceWithId(1))
+        self.router.add_route(
+            '/repos/{org}', {}, ResourceWithId(2))
+        self.router.add_route(
+            '/repos/{org}/{repo}', {}, ResourceWithId(3))
+        self.router.add_route(
+            '/repos/{org}/{repo}/commits', {}, ResourceWithId(4))
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
+            {}, ResourceWithId(5))
+
+        self.router.add_route(
+            '/teams/{id}', {}, ResourceWithId(6))
+        self.router.add_route(
+            '/teams/{id}/members', {}, ResourceWithId(7))
+
+        self.router.add_route(
+            '/teams/default', {}, ResourceWithId(19))
+        self.router.add_route(
+            '/teams/default/members/thing', {}, ResourceWithId(19))
+
+        self.router.add_route(
+            '/user/memberships', {}, ResourceWithId(8))
+        self.router.add_route(
+            '/emojis', {}, ResourceWithId(9))
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
+            {}, ResourceWithId(10))
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
+
+        # NOTE(kgriffs): The ordering of these calls is significant; we
+        # need to test that the {id} field does not match the other routes,
+        # regardless of the order they are added.
+        self.router.add_route(
+            '/emojis/signs/0', {}, ResourceWithId(12))
+        self.router.add_route(
+            '/emojis/signs/{id}', {}, ResourceWithId(13))
+        self.router.add_route(
+            '/emojis/signs/42', {}, ResourceWithId(14))
+        self.router.add_route(
+            '/emojis/signs/42/small', {}, ResourceWithId(14.1))
+        self.router.add_route(
+            '/emojis/signs/78/small', {}, ResourceWithId(22))
+
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
+            {}, ResourceWithId(15))
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
+            {}, ResourceWithId(16))
+        self.router.add_route(
+            '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
+            {}, ResourceWithId(17))
+
+        self.router.add_route(
+            '/gists/{id}/{representation}', {}, ResourceWithId(21))
+        self.router.add_route(
+            '/gists/{id}/raw', {}, ResourceWithId(18))
+        self.router.add_route(
+            '/gists/first', {}, ResourceWithId(20))
 
     @ddt.data(
         '/teams/{collision}',  # simple vs simple
@@ -102,20 +152,6 @@ class TestStandaloneRouter(testing.TestBase):
 
         resource, method_map, params = self.router.find('/emojis/signs/0')
         self.assertEqual(resource.resource_id, -1)
-
-    def test_missing(self):
-        resource, method_map, params = self.router.find('/this/does/not/exist')
-        self.assertIs(resource, None)
-
-        resource, method_map, params = self.router.find('/user/bogus')
-        self.assertIs(resource, None)
-
-        resource, method_map, params = self.router.find('/teams/1234/bogus')
-        self.assertIs(resource, None)
-
-        resource, method_map, params = self.router.find(
-            '/repos/racker/falcon/compare/johndoe:master...janedoe:dev/bogus')
-        self.assertIs(resource, None)
 
     def test_literal_segment(self):
         resource, method_map, params = self.router.find('/emojis/signs/0')
@@ -167,6 +203,54 @@ class TestStandaloneRouter(testing.TestBase):
         resource, method_map, params = self.router.find('/gists/42/raw')
         self.assertEqual(params, {'id': '42'})
 
+    @ddt.data(
+        ('/teams/default', 19),
+        ('/teams/default/members', 7),
+        ('/teams/foo', 6),
+        ('/teams/foo/members', 7),
+        ('/gists/first', 20),
+        ('/gists/first/raw', 18),
+        ('/gists/first/pdf', 21),
+        ('/gists/1776/pdf', 21),
+        ('/emojis/signs/78', 13),
+        ('/emojis/signs/78/small', 22),
+    )
+    @ddt.unpack
+    def test_literal_vs_variable(self, path, expected_id):
+        resource, method_map, params = self.router.find(path)
+        self.assertEqual(resource.resource_id, expected_id)
+
+    @ddt.data(
+        # Misc.
+        '/this/does/not/exist',
+        '/user/bogus',
+        '/repos/racker/falcon/compare/johndoe:master...janedoe:dev/bogus',
+
+        # Literal vs variable (teams)
+        '/teams',
+        '/teams/42/members/undefined',
+        '/teams/42/undefined',
+        '/teams/42/undefined/segments',
+        '/teams/default/members/undefined',
+        '/teams/default/members/thing/undefined',
+        '/teams/default/members/thing/undefined/segments',
+        '/teams/default/undefined',
+        '/teams/default/undefined/segments',
+
+        # Literal vs variable (emojis)
+        '/emojis/signs',
+        '/emojis/signs/0/small',
+        '/emojis/signs/0/undefined',
+        '/emojis/signs/0/undefined/segments',
+        '/emojis/signs/20/small',
+        '/emojis/signs/20/undefined',
+        '/emojis/signs/42/undefined',
+        '/emojis/signs/78/undefined',
+    )
+    def test_not_found(self, path):
+        resource, method_map, params = self.router.find(path)
+        self.assertIs(resource, None)
+
     def test_subsegment_not_found(self):
         resource, method_map, params = self.router.find('/emojis/signs/0/x')
         self.assertIs(resource, None)
@@ -195,7 +279,7 @@ class TestStandaloneRouter(testing.TestBase):
             'usr0': 'johndoe',
             'branch0': 'master',
             'usr1': 'janedoe',
-            'branch1': 'dev'
+            'branch1': 'dev',
         })
 
     @ddt.data(('', 16), ('/full', 17))


### PR DESCRIPTION
fix(falcon.routing.DefaultRouter): Do not mask variable path segments

When a single segment in a requested path can match more than one node at that branch in the routing tree, and the first branch taken happens to be the wrong one (i.e., the subsequent nodes do not match, but they would have under a different branch), do not mask the other branches that could result in a successful resolution of the requested path.

I chose to implement this by not immediately returning None when a branch prediction turns out to be false. Alternatively, I could have introduced functions but that would likely incur more overhead vs. performing a few additional node comparisons on the way back up the routing tree. I did, however, include a simple optimization that allows a "fast return" when only simple nodes are involved in the branching, since in that case there is only one possible route.

More advanced optimizations are possible, and may be attempted in the future. For example:

* Graft the alternate branches directly into each point where the
  routing tree would otherwise 'return None'. This would balloon the
  size of the generated code, but would be akin to inline expansion
  of a routing representing the traversal of each branch where
  branch mispredictions are possible.
* Introspect competing regular expressions to determine whether it
  is actually possible for them to match the same string given in
  the path.
* Set a flag that can be referenced when returning from a branch
  misprediction in order to short-circuit checks. This may or may
  not be faster that some of the checks (i.e., those that check
  path length would not benefit from this flag, while those that
  index into the path list and perform a string comparison may be).

Fixes #702