### PR TITLE
fix(API): Skip process_resource() when no route is found

### DIFF
--- a/doc/api/middleware.rst
+++ b/doc/api/middleware.rst
@@ -30,14 +30,17 @@ Falcon's middleware interface is defined as follows:
         def process_resource(self, req, resp, resource):
             """Process the request after routing.
 
+            Note:
+                This method is only called when the request matches
+                a route to a resource.
+
             Args:
                 req: Request object that will be passed to the
                     routed responder.
                 resp: Response object that will be passed to the
                     responder.
                 resource: Resource object to which the request was
-                    routed. May be None if no route was found for
-                    the request.
+                    routed.
             """
 
         def process_response(self, req, resp, resource):
@@ -55,6 +58,11 @@ Falcon's middleware interface is defined as follows:
     Because *process_request* executes before routing has occurred, if a
     component modifies ``req.path`` in its *process_request* method,
     the framework will use the modified value to route the request.
+
+.. Tip::
+    The *process_resource* method is only called when the request matches
+    a route to a resource. To take action when a route is not found, a
+    :py:meth:`sink <falcon.API.add_sink>` may be used instead.
 
 Each component's *process_request*, *process_resource*, and
 *process_response* methods are executed hierarchically, as a stack, following

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -58,6 +58,10 @@ class API(object):
                     def process_resource(self, req, resp, resource):
                         \"""Process the request and resource *after* routing.
 
+                        Note:
+                            This method is only called when the request matches
+                            a route to a resource.
+
                         Args:
                             req: Request object that will be passed to the
                                 routed responder.
@@ -178,8 +182,12 @@ class API(object):
                 # e.g. a 404.
                 responder, params, resource = self._get_responder(req)
 
-                self._call_rsrc_mw(middleware_stack, req, resp, resource,
-                                   params)
+                # NOTE(kgriffs): If the request did not match any route,
+                # a default responder is returned and the resource is
+                # None.
+                if resource is not None:
+                    self._call_rsrc_mw(middleware_stack, req, resp, resource,
+                                       params)
 
                 responder(req, resp, **params)
                 self._call_resp_mw(middleware_stack, req, resp, resource)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -90,6 +90,18 @@ class TestMiddleware(testing.TestBase):
 
 class TestRequestTimeMiddleware(TestMiddleware):
 
+    def test_skip_process_resource(self):
+        global context
+        self.api = falcon.API(middleware=[RequestTimeMiddleware()])
+
+        self.api.add_route('/', MiddlewareClassResource())
+
+        self.simulate_request('/404')
+        self.assertEqual(self.srmock.status, falcon.HTTP_404)
+        self.assertIn('start_time', context)
+        self.assertNotIn('mid_time', context)
+        self.assertIn('end_time', context)
+
     def test_add_invalid_middleware(self):
         """Test than an invalid class can not be added as middleware"""
         class InvalidMiddleware():


### PR DESCRIPTION
Avoid the problem of having to include a `if resource is not None` check at the top of every process_resource() method body.

Closes #691