### PR TITLE
refactor(hooks): Remove deprecated global hooks feature

### DIFF
--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -15,18 +15,6 @@
 from falcon import util
 
 
-def prepare_global_hooks(hooks):
-    if hooks is not None:
-        if not isinstance(hooks, list):
-            hooks = [hooks]
-
-        for action in hooks:
-            if not callable(action):
-                raise TypeError('One or more hooks are not callable')
-
-    return hooks
-
-
 def prepare_middleware(middleware=None):
     """Check middleware interface and prepare it to iterate.
 

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -67,8 +67,7 @@ def before(action):
                         # variable that is shared between iterations of the
                         # for loop, above.
                         def let(responder=responder):
-                            do_before_all = _wrap_with_before(
-                                action, responder, resource, True)
+                            do_before_all = _wrap_with_before(action, responder)
 
                             setattr(resource, responder_name, do_before_all)
 
@@ -78,7 +77,7 @@ def before(action):
 
         else:
             responder = responder_or_resource
-            do_before_one = _wrap_with_before(action, responder, None, True)
+            do_before_one = _wrap_with_before(action, responder)
 
             return do_before_one
 
@@ -113,8 +112,7 @@ def after(action):
                     if callable(responder):
 
                         def let(responder=responder):
-                            do_after_all = _wrap_with_after(
-                                action, responder, resource, True)
+                            do_after_all = _wrap_with_after(action, responder)
 
                             setattr(resource, responder_name, do_after_all)
 
@@ -124,7 +122,7 @@ def after(action):
 
         else:
             responder = responder_or_resource
-            do_after_one = _wrap_with_after(action, responder, None, True)
+            do_after_one = _wrap_with_after(action, responder)
 
             return do_after_one
 
@@ -158,19 +156,13 @@ def _has_resource_arg(action):
     return 'resource' in spec.args
 
 
-def _wrap_with_after(action, responder, resource=None, is_method=False):
+def _wrap_with_after(action, responder):
     """Execute the given action function after a responder method.
 
     Args:
         action: A function with a signature similar to a resource responder
             method, taking the form ``func(req, resp, resource)``.
         responder: The responder method to wrap.
-        resource: The resource affected by `action` (default ``None``). If
-            ``None``, `is_method` MUST BE True, so that the resource can be
-            derived from the `self` param that is passed into the wrapper.
-        is_method: Whether or not `responder` is an unbound method
-            (default ``False``).
-
     """
 
     # NOTE(swistakm): create shim before checking what will be actually
@@ -185,37 +177,21 @@ def _wrap_with_after(action, responder, resource=None, is_method=False):
         def shim(req, resp, resource):
             action(req, resp)
 
-    # NOTE(swistakm): method must be decorated differently than
-    # normal function
-    if is_method:
-        @wraps(responder)
-        def do_after(self, req, resp, **kwargs):
-            responder(self, req, resp, **kwargs)
-            shim(req, resp, self)
-    else:
-        assert resource is not None
-
-        @wraps(responder)
-        def do_after(req, resp, **kwargs):
-            responder(req, resp, **kwargs)
-            shim(req, resp, resource)
+    @wraps(responder)
+    def do_after(self, req, resp, **kwargs):
+        responder(self, req, resp, **kwargs)
+        shim(req, resp, self)
 
     return do_after
 
 
-def _wrap_with_before(action, responder, resource=None, is_method=False):
+def _wrap_with_before(action, responder):
     """Execute the given action function before a responder method.
 
     Args:
         action: A function with a similar signature to a resource responder
             method, taking the form ``func(req, resp, resource, params)``.
         responder: The responder method to wrap
-        resource: The resource affected by `action` (default ``None``). If
-            ``None``, `is_method` MUST BE True, so that the resource can be
-            derived from the `self` param that is passed into the wrapper
-        is_method: Whether or not `responder` is an unbound method
-            (default ``False``)
-
     """
 
     # NOTE(swistakm): create shim before checking what will be actually
@@ -232,43 +208,9 @@ def _wrap_with_before(action, responder, resource=None, is_method=False):
             # since method is assumed to be bound.
             action(req, resp, kwargs)
 
-    # NOTE(swistakm): method must be decorated differently than
-    # normal function
-    if is_method:
-        @wraps(responder)
-        def do_before(self, req, resp, **kwargs):
-            shim(req, resp, self, kwargs)
-            responder(self, req, resp, **kwargs)
-    else:
-        assert resource is not None
-
-        @wraps(responder)
-        def do_before(req, resp, **kwargs):
-            shim(req, resp, resource, kwargs)
-            responder(req, resp, **kwargs)
+    @wraps(responder)
+    def do_before(self, req, resp, **kwargs):
+        shim(req, resp, self, kwargs)
+        responder(self, req, resp, **kwargs)
 
     return do_before
-
-
-def _wrap_with_hooks(before, after, responder, resource):
-    """Wrap responder on the given resource with "before" and "after" hooks.
-
-    Args:
-        before: An iterable of one or more "before" hooks
-        after: An iterable of one or more "after" hooks
-        responder: A method of a resource to wrap
-        resource: A reference to the resource instance providing the responder
-
-    """
-
-    if after is not None:
-        for action in after:
-            responder = _wrap_with_after(action, responder, resource)
-
-    if before is not None:
-        # Wrap in reversed order to achieve natural (first...last)
-        # execution order.
-        for action in reversed(before):
-            responder = _wrap_with_before(action, responder, resource)
-
-    return responder

--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -17,7 +17,6 @@ import re
 import six
 
 from falcon import HTTP_METHODS, responders
-from falcon.hooks import _wrap_with_hooks
 
 
 # NOTE(kgriffs): Published method; take care to avoid breaking changes.
@@ -80,7 +79,7 @@ def compile_uri_template(template):
     return fields, re.compile(pattern, re.IGNORECASE)
 
 
-def create_http_method_map(resource, before, after):
+def create_http_method_map(resource):
     """Maps HTTP methods (e.g., 'GET', 'POST') to methods of a resource object.
 
     Args:
@@ -89,10 +88,6 @@ def create_http_method_map(resource, before, after):
             supports. For example, if a resource supports GET and POST, it
             should define ``on_get(self, req, resp)`` and
             ``on_post(self, req, resp)``.
-        before: An action hook or ``list`` of hooks to be called before each
-            *on_\** responder defined by the resource.
-        after: An action hook or ``list`` of hooks to be called after each
-            *on_\** responder defined by the resource.
 
     Returns:
         dict: A mapping of HTTP methods to responders.
@@ -110,28 +105,21 @@ def create_http_method_map(resource, before, after):
         else:
             # Usually expect a method, but any callable will do
             if callable(responder):
-                responder = _wrap_with_hooks(
-                    before, after, responder, resource)
                 method_map[method] = responder
 
     # Attach a resource for unsupported HTTP methods
     allowed_methods = sorted(list(method_map.keys()))
 
-    # NOTE(sebasmagri): We want the OPTIONS and 405 (Not Allowed) methods
-    # responders to be wrapped on global hooks
     if 'OPTIONS' not in method_map:
         # OPTIONS itself is intentionally excluded from the Allow header
-        responder = responders.create_default_options(
-            allowed_methods)
-        method_map['OPTIONS'] = _wrap_with_hooks(
-            before, after, responder, resource)
+        opt_responder = responders.create_default_options(allowed_methods)
+        method_map['OPTIONS'] = opt_responder
         allowed_methods.append('OPTIONS')
 
     na_responder = responders.create_method_not_allowed(allowed_methods)
 
     for method in HTTP_METHODS:
         if method not in allowed_methods:
-            method_map[method] = _wrap_with_hooks(
-                before, after, na_responder, resource)
+            method_map[method] = na_responder
 
     return method_map

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -88,6 +88,14 @@ class MiscResource(object):
     def on_patch(self, req, resp):
         pass
 
+    def on_options(self, req, resp):
+        resp.status = falcon.HTTP_204
+
+        # NOTE(kgriffs): This is incorrect, but only return GET so
+        # that we can verify that the default OPTIONS responder has
+        # been overridden.
+        resp.set_header('allow', 'GET')
+
 
 class GetWithFaultyPutResource(object):
     def __init__(self):
@@ -184,12 +192,21 @@ class TestHttpMethodRouting(testing.TestBase):
 
             self.assertThat(headers, Contains(allow_header))
 
-    def test_default_on_options(self):
+    def test_on_options(self):
         self.simulate_request('/things/84/stuff/65', method='OPTIONS')
         self.assertEqual(self.srmock.status, falcon.HTTP_204)
 
         headers = self.srmock.headers
         allow_header = ('allow', 'GET, HEAD, PUT')
+
+        self.assertThat(headers, Contains(allow_header))
+
+    def test_default_on_options(self):
+        self.simulate_request('/misc', method='OPTIONS')
+        self.assertEqual(self.srmock.status, falcon.HTTP_204)
+
+        headers = self.srmock.headers
+        allow_header = ('allow', 'GET')
 
         self.assertThat(headers, Contains(allow_header))
 

--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -112,40 +112,9 @@ class TestHTTPStatus(testing.TestBase):
         self.assertEqual(body, '')
 
 
-class TestHTTPStatusWithGlobalHooks(testing.TestBase):
+class TestHTTPStatusWithMiddleware(testing.TestBase):
     def before(self):
         self.resource = TestHookResource()
-
-    def test_raise_status_in_before_hook(self):
-        """ Make sure we get the 200 raised by before hook """
-        self.api = falcon.API(before=[before_hook])
-        self.api.add_route('/status', self.resource)
-
-        body = self.simulate_request('/status', method='GET', decode='utf-8')
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertIn(('x-failed', 'False'), self.srmock.headers)
-        self.assertEqual(body, 'Pass')
-
-    def test_raise_status_runs_after_hooks(self):
-        """ Make sure we still run after hooks """
-        self.api = falcon.API(after=[after_hook])
-        self.api.add_route('/status', self.resource)
-
-        body = self.simulate_request('/status', method='GET', decode='utf-8')
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertIn(('x-failed', 'False'), self.srmock.headers)
-        self.assertEqual(body, 'Pass')
-
-    def test_raise_status_survives_after_hooks(self):
-        """ Make sure after hook doesn't overwrite our status """
-        self.api = falcon.API(after=[noop_after_hook])
-        self.api.add_route('/status', self.resource)
-
-        body = self.simulate_request('/status', method='DELETE',
-                                     decode='utf-8')
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertIn(('x-failed', 'False'), self.srmock.headers)
-        self.assertEqual(body, 'Pass')
 
     def test_raise_status_in_process_request(self):
         """ Make sure we can raise status from middleware process request """


### PR DESCRIPTION
Middleware components superseded global hooks in version 0.3 of the framework. By now, developers should have had enough time to migrate away from the deprecated feature. If not, they can continue using 0.3 until they are able to migrate.

BREAKING CHANGE

falcon.API no longer accepts `before` and `after` kwargs to specify global hooks. Applications should migrate any logic contained in global hooks to reside in middleware components instead.

Old:
```py
    def do_something(req, resp, resource, params):
        pass

    app = falcon.API(before=[do_something])
```
New:
```py
    class ExampleMiddlewareComponent(object):
        def process_resource(self, req, resp, resource):
            pass
```

Closes #384