### PR TITLE
chore: Remove pylint test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
           env: TOXENV=pypy3
         - python: 2.7
           env: TOXENV=pep8
-        - python: 2.7
-          env: TOXENV=pylint
         - python: 2.6
           env: TOXENV=py26
         - python: 2.7

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -232,9 +232,4 @@ class OptionalRepresentation(object):
     """
     @property
     def has_representation(self):
-        # NOTE(kgriffs): pylint has no way of knowing this class is a mixin
-        # that expects to be used along with HTTPError (which will provide
-        # the description attribute).
-        #
-        # pylint: disable=no-member
         return super(OptionalRepresentation, self).description is not None

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -17,7 +17,7 @@ try:
     # standard way of exposing a socket as a file-like object, and
     # is used by wsgiref for wsgi.input.
     import socket
-    NativeStream = socket._fileobject  # pylint: disable=E1101
+    NativeStream = socket._fileobject
 except AttributeError:
     # NOTE(kgriffs): In Python 3.3, wsgiref implements wsgi.input
     # using _io.BufferedReader which is an alias of io.BufferedReader
@@ -323,9 +323,7 @@ class Request(object):
             # Literal syntax is more efficient than using dict()
             self.context = {}
         else:
-            # pylint will detect this as not-callable because it only sees the
-            # declaration of None, not whatever type a subclass may have set.
-            self.context = self.context_type()  # pylint: disable=not-callable
+            self.context = self.context_type()
 
     # ------------------------------------------------------------------------
     # Properties
@@ -1065,7 +1063,7 @@ class Request(object):
         if six.PY3:
             self._wsgierrors.write(log_line + message + '\n')
         else:
-            if isinstance(message, unicode):  # pylint: disable=E0602
+            if isinstance(message, unicode):
                 message = message.encode('utf-8')
 
             self._wsgierrors.write(log_line.encode('utf-8'))

--- a/falcon/testing/test_case.py
+++ b/falcon/testing/test_case.py
@@ -135,7 +135,7 @@ class TestCase(unittest.TestCase):
         if self.api_class is None:
             self.api = falcon.API()
         else:
-            self.api = self.api_class()  # pylint: disable=not-callable
+            self.api = self.api_class()
 
         # Reset to simulate "restarting" the WSGI container
         falcon.request._maybe_wrap_wsgi_stream = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ envlist = py26,
           py27,
           py34,
           pep8,
-          pylint,
           docs
 
 [testenv]
@@ -130,13 +129,6 @@ commands = flake8 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
              --ignore=F403 \
              --max-line-length=99 \
-             []
-
-[testenv:pylint]
-deps = pylint
-commands = pylint falcon \
-             --ignore=bench,tests \
-             -E \
              []
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
pylint has not been catching anything that flake8 wouldn't also catch, and flake8 continues to improve, yielding pylint somewhat obsolete.