### PR TITLE
fix(API): Allow the router's find() method to just return None

### DIFF
--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -93,7 +93,7 @@ class CompiledRouter(object):
         if node is not None:
             return node.resource, node.method_map, params
         else:
-            return None, None, None
+            return None
 
     def _compile_tree(self, nodes, indent=1, level=0, fast_return=True):
         """Generates Python code for a routing tree or subtree."""

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -38,8 +38,8 @@ class TestRegressionCases(testing.TestBase):
         resource, method_map, params = self.router.find('/v1/messages')
         self.assertEqual(resource.resource_id, 2)
 
-        resource, method_map, params = self.router.find('/v1')
-        self.assertIs(resource, None)
+        route = self.router.find('/v1')
+        self.assertIs(route, None)
 
     def test_recipes(self):
         self.router.add_route(
@@ -53,8 +53,8 @@ class TestRegressionCases(testing.TestBase):
         resource, method_map, params = self.router.find('/recipes/baking')
         self.assertEqual(resource.resource_id, 2)
 
-        resource, method_map, params = self.router.find('/recipes/grilling')
-        self.assertIs(resource, None)
+        route = self.router.find('/recipes/grilling')
+        self.assertIs(route, None)
 
 
 @ddt.ddt
@@ -166,8 +166,8 @@ class TestComplexRouting(testing.TestBase):
         resource, method_map, params = self.router.find('/emojis/signs/42/small')
         self.assertEqual(resource.resource_id, 14.1)
 
-        resource, method_map, params = self.router.find('/emojis/signs/1/small')
-        self.assertEqual(resource, None)
+        route = self.router.find('/emojis/signs/1/small')
+        self.assertEqual(route, None)
 
     @ddt.data(
         '/teams',
@@ -176,17 +176,17 @@ class TestComplexRouting(testing.TestBase):
         '/gists/42',
     )
     def test_dead_segment(self, template):
-        resource, method_map, params = self.router.find(template)
-        self.assertIs(resource, None)
+        route = self.router.find(template)
+        self.assertIs(route, None)
 
     def test_malformed_pattern(self):
-        resource, method_map, params = self.router.find(
+        route = self.router.find(
             '/repos/racker/falcon/compare/foo')
-        self.assertIs(resource, None)
+        self.assertIs(route, None)
 
-        resource, method_map, params = self.router.find(
+        route = self.router.find(
             '/repos/racker/falcon/compare/foo/full')
-        self.assertIs(resource, None)
+        self.assertIs(route, None)
 
     def test_literal(self):
         resource, method_map, params = self.router.find('/user/memberships')
@@ -248,12 +248,12 @@ class TestComplexRouting(testing.TestBase):
         '/emojis/signs/78/undefined',
     )
     def test_not_found(self, path):
-        resource, method_map, params = self.router.find(path)
-        self.assertIs(resource, None)
+        route = self.router.find(path)
+        self.assertIs(route, None)
 
     def test_subsegment_not_found(self):
-        resource, method_map, params = self.router.find('/emojis/signs/0/x')
-        self.assertIs(resource, None)
+        route = self.router.find('/emojis/signs/0/x')
+        self.assertIs(route, None)
 
     def test_multivar(self):
         resource, method_map, params = self.router.find(


### PR DESCRIPTION
The documentation for custom routers states that the find() method of the router should return None when no route is found. However, the API only allows for the (None, None, None) tuple. Add support for a simple None return value as well.

Closes #750