### PR TITLE
fix(doc): Include RTD theme and force a full rebuild of docs

### DIFF
--- a/tools/doc-requires
+++ b/tools/doc-requires
@@ -1,6 +1,7 @@
-jinja2
-pygments
 docutils
+jinja2
 markupsafe
+pygments
 sphinx
 sphinxcontrib-napoleon
+sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -191,5 +191,5 @@ deps = -r{toxinidir}/tools/doc-requires
 whitelist_externals = rm
 basepython = python2.7
 commands =
-    rm -rf doc/_build/*
+    rm -rf doc/_build
     sphinx-build -b html doc doc/_build/html


### PR DESCRIPTION
Render docs using the RTD theme. Also, force a full rebuild of the docs
each time since sphinx sometimes doesn't detect docstring changes and
refuses to re-render them.