### PR TITLE
feat(Request): Allow 1 and 0 as valid boolean values in query string parsing

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -43,8 +43,8 @@ SimpleCookie = http_cookies.SimpleCookie
 DEFAULT_ERROR_LOG_FORMAT = (u'{0:%Y-%m-%d %H:%M:%S} [FALCON] [ERROR]'
                             u' {1} {2}{3} => ')
 
-TRUE_STRINGS = ('true', 'True', 'yes')
-FALSE_STRINGS = ('false', 'False', 'no')
+TRUE_STRINGS = ('true', 'True', 'yes', '1')
+FALSE_STRINGS = ('false', 'False', 'no', '0')
 WSGI_CONTENT_HEADERS = ('CONTENT_TYPE', 'CONTENT_LENGTH')
 
 
@@ -865,8 +865,8 @@ class Request(object):
 
         The following boolean strings are supported::
 
-            TRUE_STRINGS = ('true', 'True', 'yes')
-            FALSE_STRINGS = ('false', 'False', 'no')
+            TRUE_STRINGS = ('true', 'True', 'yes', '1')
+            FALSE_STRINGS = ('false', 'False', 'no', '0')
 
         Args:
             name (str): Parameter name, case-sensitive (e.g., 'detailed').

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -201,8 +201,8 @@ class _TestQueryParams(testing.TestBase):
             req.get_param_as_int, 'pos', min=0, max=10)
 
     def test_boolean(self):
-        query_string = ('echo=true&doit=false&bogus=0&bogus2=1&'
-                        't1=True&f1=False&t2=yes&f2=no&blank')
+        query_string = ('echo=true&doit=false&bogus=bar&bogus2=foo&'
+                        't1=True&f1=False&t2=yes&f2=no&blank&one=1&zero=0')
         self.simulate_request('/', query_string=query_string)
 
         req = self.resource.req
@@ -226,6 +226,8 @@ class _TestQueryParams(testing.TestBase):
         self.assertEqual(req.get_param_as_bool('t2'), True)
         self.assertEqual(req.get_param_as_bool('f1'), False)
         self.assertEqual(req.get_param_as_bool('f2'), False)
+        self.assertEqual(req.get_param_as_bool('one'), True)
+        self.assertEqual(req.get_param_as_bool('zero'), False)
         self.assertEqual(req.get_param('blank'), None)
 
         store = {}


### PR DESCRIPTION
Fix #684

Thanks :)