### PR TITLE
fix(setup.py): Fix test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     test_suite='nose.collector',
+    tests_require=['nose', 'ddt', 'testtools', 'requests', 'pyyaml'],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main'


### PR DESCRIPTION
Add a tests_require field to the setup call so that running "setup.py test" doesn't fail if some packages aren't installed.