### PR TITLE
chore: adds py35 environment to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@
 envlist = py26,
           py27,
           py34,
+          py35,
           pep8,
           pylint,
 


### PR DESCRIPTION
This patch adds Python 3.5 to the list of environments in tox.ini.