### PR TITLE
style(pep8): Add flake8-import-order plugin with import order changes (#798)

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -14,16 +14,15 @@
 
 import inspect
 import re
+
 import six
 
-from falcon import api_helpers as helpers
-from falcon import DEFAULT_MEDIA_TYPE
+from falcon import api_helpers as helpers, DEFAULT_MEDIA_TYPE, routing
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
 from falcon.request import Request, RequestOptions
-from falcon.response import Response
 import falcon.responders
-from falcon import routing
+from falcon.response import Response
 import falcon.status_codes as status
 
 

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -14,10 +14,10 @@
 
 from datetime import datetime
 
+from falcon import util
 from falcon.http_error import HTTPError, NoRepresentation, \
     OptionalRepresentation
 import falcon.status_codes as status
-from falcon import util
 
 
 class HTTPBadRequest(HTTPError):

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -24,21 +24,20 @@ except AttributeError:
     import io
     NativeStream = io.BufferedReader
 
-import mimeparse
-import six
 from wsgiref.validate import InputWrapper
 
+import mimeparse
+import six
+from six.moves import http_cookies
+
 from falcon.errors import *  # NOQA
-from falcon import util
-from falcon.util.uri import parse_query_string, parse_host, unquote_string
-from falcon import request_helpers as helpers
+from falcon import request_helpers as helpers, util
+from falcon.util.uri import parse_host, parse_query_string, unquote_string
 
 # NOTE(tbug): In some cases, http_cookies is not a module
 # but a dict-like structure. This fixes that issue.
 # See issue https://github.com/falconry/falcon/issues/556
-from six.moves import http_cookies
 SimpleCookie = http_cookies.SimpleCookie
-
 
 DEFAULT_ERROR_LOG_FORMAT = (u'{0:%Y-%m-%d %H:%M:%S} [FALCON] [ERROR]'
                             u' {1} {2}{3} => ')

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -20,7 +20,7 @@ from six import string_types as STRING_TYPES
 # See issue https://github.com/falconry/falcon/issues/556
 from six.moves import http_cookies
 
-from falcon.response_helpers import header_property, format_range
+from falcon.response_helpers import format_range, header_property
 from falcon.response_helpers import is_ascii_encodable
 from falcon.util import dt_to_http, TimezoneGMT
 from falcon.util.uri import encode as uri_encode

--- a/falcon/testing/base.py
+++ b/falcon/testing/base.py
@@ -21,8 +21,8 @@ except ImportError:  # pragma: nocover
 
 import falcon
 import falcon.request
-from falcon.testing.srmock import StartResponseMock
 from falcon.testing.helpers import create_environ
+from falcon.testing.srmock import StartResponseMock
 
 
 class TestBase(unittest.TestCase):

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import cgi
-import random
 import io
+import random
 import sys
 
 import six
 
-from falcon.util import uri, http_now
+from falcon.util import http_now, uri
 
 # Constants
 DEFAULT_HOST = 'falconframework.org'

--- a/falcon/testing/test_case.py
+++ b/falcon/testing/test_case.py
@@ -22,9 +22,9 @@ except ImportError:  # pragma: nocover
 
 import falcon
 import falcon.request
-from falcon.util import CaseInsensitiveDict
-from falcon.testing.srmock import StartResponseMock
 from falcon.testing.helpers import create_environ, get_encoding_from_headers
+from falcon.testing.srmock import StartResponseMock
+from falcon.util import CaseInsensitiveDict
 
 
 class Result(object):

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -1,6 +1,6 @@
 # Hoist misc. utils
+from falcon.util import structures
 from falcon.util.misc import *  # NOQA
 from falcon.util.time import *
-from falcon.util import structures
 
 CaseInsensitiveDict = structures.CaseInsensitiveDict

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ import imp
 import io
 import os
 from os import path
-from setuptools import setup, find_packages, Extension
 import sys
+
+from setuptools import Extension, find_packages, setup
 
 MYDIR = path.abspath(os.path.dirname(__file__))
 

--- a/tests/test_before_hooks.py
+++ b/tests/test_before_hooks.py
@@ -1,6 +1,6 @@
 import functools
-import json
 import io
+import json
 
 import falcon
 import falcon.testing as testing

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -1,6 +1,6 @@
+from datetime import datetime, timedelta, tzinfo
 import re
 import sys
-from datetime import datetime, timedelta, tzinfo
 
 import ddt
 from six.moves.http_cookies import Morsel
@@ -8,7 +8,7 @@ from testtools.matchers import LessThan
 
 import falcon
 import falcon.testing as testing
-from falcon.util import TimezoneGMT, http_date_to_dt
+from falcon.util import http_date_to_dt, TimezoneGMT
 
 
 UNICODE_TEST_STRING = u'Unicode_\xc3\xa6\xc3\xb8'

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -3,8 +3,9 @@ import logging
 import uuid
 from wsgiref import simple_server
 
-import falcon
 import requests
+
+import falcon
 
 
 class StorageEngine(object):

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -1,10 +1,10 @@
+import io
+
 import ddt
+import six
 
 import falcon
-import io
 import falcon.testing as testing
-
-import six
 
 
 # NOTE(kgriffs): Concept from Gunicorn's source (wsgi.py)

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -5,11 +5,11 @@ import json
 import xml.etree.ElementTree as et
 
 import ddt
-from testtools.matchers import raises, Not
+from testtools.matchers import Not, raises
 import yaml
 
-import falcon.testing as testing
 import falcon
+import falcon.testing as testing
 
 
 class FaultyResource:

--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8
 
-import falcon.testing as testing
 import falcon
 from falcon.http_status import HTTPStatus
+import falcon.testing as testing
 
 
 def before_hook(req, resp, params):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,8 +1,8 @@
+from datetime import datetime
 import json
 
 import falcon
 import falcon.testing as testing
-from datetime import datetime
 
 _EXPECTED_BODY = {u'status': u'ok'}
 

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -3,8 +3,8 @@ from datetime import date
 import ddt
 
 import falcon
-import falcon.testing as testing
 from falcon.errors import HTTPInvalidParam
+import falcon.testing as testing
 
 
 @ddt.ddt

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -1,7 +1,7 @@
 import ddt
 
-import falcon.testing as testing
 import falcon
+import falcon.testing as testing
 
 
 class RedirectingResource(object):

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -1,8 +1,8 @@
 import datetime
-import six
-import testtools
 
 import ddt
+import six
+import testtools
 
 import falcon
 from falcon.request import Request

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -1,6 +1,5 @@
-import falcon.testing as testing
-
 from falcon.request import Request
+import falcon.testing as testing
 
 
 class TestRequestContext(testing.TestBase):

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -1,6 +1,7 @@
+import six
+
 import falcon
 import falcon.testing as testing
-import six
 
 
 class IDResource(object):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@ import json
 import random
 import sys
 
-import testtools
 import six
+import testtools
 
 import falcon
 from falcon import testing

--- a/tests/test_wsgi_errors.py
+++ b/tests/test_wsgi_errors.py
@@ -1,7 +1,8 @@
 import io
 
-import falcon.testing as testing
 import six
+
+import falcon.testing as testing
 
 unicode_message = u'Unicode: \x80'
 

--- a/tox.ini
+++ b/tox.ini
@@ -119,6 +119,7 @@ commands = py3kwarn falcon
 [testenv:pep8]
 deps = flake8
        flake8-quotes
+       flake8-import-order
 
 # NOTE(kgriffs): Run with py27 since some code branches assume the
 #   unicode type is defined, and pep8 complains in those cases when
@@ -130,6 +131,8 @@ commands = flake8 \
              --exclude=./build,.venv,.tox,dist,doc,./falcon/bench/nuts \
              --ignore=F403 \
              --max-line-length=99 \
+             --import-order-style=google \
+             --application-import-names=falcon \
              []
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
PyCon 2016 sprint! Addresses #798.

Adds `flake8-import-order` plugin to the tox configuration file, along with all the reordering of existing imports in order to pass. Using the [Google import order style](https://github.com/public/flake8-import-order#configuration) as requested by @kgriffs.

Also adds `--application-import-names=falcon` as specified in #798.