### PR TITLE
testing(tox): Adds missing posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
 whitelist_externals = bash
                       mv
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests --with-coverage
+           nosetests --with-coverage []
            bash -c "if [ ! -d .coverage_data ]; then mkdir .coverage_data; fi"
            mv {toxinidir}/.coverage {toxinidir}/.coverage_data/.coverage.{envname}
 


### PR DESCRIPTION
For non-debug environments, we were not passing posargs through to nosetests.  This PR adds the option to pass arguments through to nosetests (for example, to run specific unit tests).

For example, to run the `TestHelloWorld` test case on py27, here's some sample output:
```bash
$ tox -e py27 -- test_hello:TestHelloWorld
GLOB sdist-make: /Users/fxfitz/github/falcon/setup.py
py27 inst-nodeps: /Users/fxfitz/github/falcon/.tox/dist/falcon-1.1.0.dev0.zip
py27 installed: You are using pip version 8.0.2, however version 8.1.2 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,coverage==4.0.3,ddt==1.0.1,extras==0.0.3,falcon==1.1.0.dev0,fixtures==1.4.0,linecache2==1.0.0,nose==1.3.7,pbr==1.8.1,pyrsistent==0.11.12,python-mimeparse==1.5.1,PyYAML==3.11,requests==2.9.1,six==1.10.0,testtools==2.0.0,traceback2==1.4.0,unittest2==1.1.0,wheel==0.29.0
py27 runtests: PYTHONHASHSEED='4127826989'
py27 runtests: commands[0] | /Users/fxfitz/github/falcon/tools/clean.sh /Users/fxfitz/github/falcon/falcon
py27 runtests: commands[1] | nosetests --with-coverage test_hello:TestHelloWorld
test_hello.TestHelloWorld.test_body_1 ... ok
test_hello.TestHelloWorld.test_body_2 ... ok
test_hello.TestHelloWorld.test_body_3 ... ok
test_hello.TestHelloWorld.test_env_headers_list_of_tuples ... ok
test_hello.TestHelloWorld.test_filelike ... ok
test_hello.TestHelloWorld.test_filelike_using_helper ... ok
test_hello.TestHelloWorld.test_no_body_on_head ... ok
test_hello.TestHelloWorld.test_no_route ... ok
test_hello.TestHelloWorld.test_root_route ... ok
test_hello.TestHelloWorld.test_status_not_set ... ok
test_hello.TestHelloWorld.test_stream_chunked ... ok
test_hello.TestHelloWorld.test_stream_known_len ... ok

Name                         Stmts   Miss Branch BrPart  Cover   Missing
------------------------------------------------------------------------
falcon.py                       13      0      0      0   100%   
falcon/api.py                  155     45     64     11    66%   194-199, 218-219, 240, 313, 316, 319, 357-364, 397-408, 453-455, 501-502, 507-512, 524-531, 539, 542, 548-553, 559-561, 567-569, 193->194, 239->240, 312->313, 315->316, 318->319, 506->507, 538->539, 541->542, 547->548, 558->559, 566->567
falcon/api_helpers.py           39     30     20      2    19%   35-36, 39-50, 81-114, 127-133, 32->35, 38->39
falcon/errors.py               100     51     14      0    43%   39, 62-67, 92, 123-129, 151, 188, 208, 231, 262-269, 289, 304-305, 323, 352-359, 381, 397, 414, 434-441, 458-462, 476-479, 497-500, 517-520
falcon/hooks.py                 70     44     20      4    33%   51-76, 98-129, 144, 154, 170-185, 206-209, 50->51, 140->144, 146->154, 199->206
falcon/http_error.py            58     34     20      1    32%   20-21, 104-107, 113, 130-146, 156-157, 168-187, 212, 103->104
falcon/http_status.py            6      3      0      0    50%   44-46
falcon/redirects.py             17      5      0      0    71%   39, 65, 96, 122, 145
falcon/request.py              379    273    140      9    22%   21-25, 266, 269, 273, 280, 289-290, 313, 321, 327, 344, 348, 353, 359-362, 377-390, 394, 398, 402, 406-438, 443-453, 457, 461, 465-499, 505-516, 521-522, 526-533, 539-553, 557, 561-572, 576-600, 604, 622-633, 649-656, 677-700, 724-733, 774-794, 829-860, 897-924, 964-996, 1026-1040, 1054-1071, 1099-1119, 1128-1146, 262->273, 263->266, 268->269, 276->289, 279->280, 306->318, 307->313, 318->321, 323->327
falcon/request_helpers.py       28     13      2      0    50%   29-32, 64, 67, 91-95, 109, 123, 137
falcon/responders.py            20      5      0      0    75%   28, 42-43, 59-60
falcon/response.py             125     75     64      5    29%   186-240, 250-260, 273, 292-295, 317-323, 348-356, 435-469, 558-565, 591, 602, 471->-480, 538->-555, 583->586, 586->591, 593->602
falcon/response_helpers.py      29     19      4      0    36%   31-34, 38, 41, 44, 59-62, 67-80
falcon/routing.py                4      0      0      0   100%   
falcon/routing/compiled.py     139     54     52     12    55%   47, 50, 56-69, 82, 129-132, 136-164, 180-181, 245-271, 278, 287-333, 46->47, 49->50, 55->56, 78->82, 125->134, 126->129, 135->136, 171->177, 179->180, 189->192, 194->-98, 244->245
falcon/routing/util.py          37     14     18      2    56%   55-79, 107->99, 113->119
falcon/status_codes.py         147      0      0      0   100%   
falcon/util.py                   4      0      0      0   100%   
falcon/util/misc.py             54     38     18      0    22%   57-75, 86, 101, 122-145, 163-181, 202-212
falcon/util/structures.py        1      0      0      0   100%   
falcon/util/time.py              9      3      0      0    67%   20, 32, 44
falcon/util/uri.py             110     75     60      3    26%   55-70, 161, 169-246, 285-330, 362-379, 395-411, 132->198, 160->161, 164->169
falcon/version.py                2      0      0      0   100%   
------------------------------------------------------------------------
TOTAL                         1546    781    496     49    42%   
----------------------------------------------------------------------
Ran 12 tests in 0.011s

OK
py27 runtests: commands[2] | bash -c if [ ! -d .coverage_data ]; then mkdir .coverage_data; fi
py27 runtests: commands[3] | mv /Users/fxfitz/github/falcon/.coverage /Users/fxfitz/github/falcon/.coverage_data/.coverage.py27
_________________________________________________________ summary __________________________________________________________
  py27: commands succeeded
  congratulations :)
```
