### PR TITLE
feat(RequestOptions): Add option to opt-out from comma separated value

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -280,6 +280,7 @@ class Request(object):
                 self._params = parse_query_string(
                     self.query_string,
                     keep_blank_qs_values=self.options.keep_blank_qs_values,
+                    parse_csv_qs_values_as_list=self.options.parse_csv_qs_values_as_list
                 )
 
             else:
@@ -1114,6 +1115,7 @@ class Request(object):
             extra_params = parse_query_string(
                 body,
                 keep_blank_qs_values=self.options.keep_blank_qs_values,
+                parse_csv_qs_values_as_list=self.options.parse_csv_qs_values_as_list
             )
 
             self._params.update(extra_params)
@@ -1173,8 +1175,10 @@ class RequestOptions(object):
     __slots__ = (
         'keep_blank_qs_values',
         'auto_parse_form_urlencoded',
+        'parse_csv_qs_values_as_list'
     )
 
     def __init__(self):
         self.keep_blank_qs_values = False
         self.auto_parse_form_urlencoded = False
+        self.parse_csv_qs_values_as_list = True

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -246,7 +246,8 @@ else:
         return decoded_uri.decode('utf-8', 'replace')
 
 
-def parse_query_string(query_string, keep_blank_qs_values=False):
+def parse_query_string(query_string, keep_blank_qs_values=False,
+                       parse_csv_qs_values_as_list=True):
     """Parse a query string into a dict.
 
     Query string parameters are assumed to use standard form-encoding. Only
@@ -271,6 +272,8 @@ def parse_query_string(query_string, keep_blank_qs_values=False):
         query_string (str): The query string to parse.
         keep_blank_qs_values (bool): If set to ``True``, preserves boolean
             fields and fields with no content as blank strings.
+        parse_csv_qs_values_as_list (bool): If set to ``True``, parses query string
+            as a list.
 
     Returns:
         dict: A dictionary of (*name*, *value*) pairs, one per query
@@ -309,7 +312,7 @@ def parse_query_string(query_string, keep_blank_qs_values=False):
                 params[k] = [old_value, decode(v)]
 
         else:
-            if ',' in v:
+            if ',' in v and parse_csv_qs_values_as_list:
                 # NOTE(kgriffs): Falcon supports a more compact form of
                 # lists, in which the elements are comma-separated and
                 # assigned to a single param instance. If it turns out that

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -11,6 +11,8 @@ class TestRequestOptions(testing.TestBase):
         self.assertTrue(options.keep_blank_qs_values)
         options.keep_blank_qs_values = False
         self.assertFalse(options.keep_blank_qs_values)
+        options.parse_csv_qs_values_as_list = True
+        self.assertTrue(options.parse_csv_qs_values_as_list)
 
     def test_incorrect_options(self):
         options = RequestOptions()

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -384,6 +384,48 @@ class _TestQueryParams(testing.TestBase):
                              'The value is not formatted correctly.')
             self.assertEqual(ex.description, expected_desc)
 
+    def test_list_as_string_option(self):
+        query_string = ('colors=red,green,blue&limit=1'
+                        '&list-ish1=f,,x&list-ish2=,0&list-ish3=a,,,b'
+                        '&empty1=&empty2=,&empty3=,,'
+                        '&thing_one=1,,3'
+                        '&thing_two=1&thing_two=&thing_two=3')
+        self.api.req_options.parse_csv_qs_values_as_list = False
+
+        self.simulate_request('/', query_string=query_string)
+
+        req = self.resource.req
+
+        self.assertIn(req.get_param('colors'), 'red,green,blue')
+
+        self.assertNotEqual(req.get_param_as_list('colors'),
+                            ['red', 'green', 'blue'])
+
+        self.assertEqual(req.get_param_as_list('limit'), ['1'])
+        self.assertIs(req.get_param_as_list('marker'), None)
+
+        self.assertEqual(req.get_param_as_list('empty1'), None)
+        self.assertNotEqual(req.get_param_as_list('empty2'), [])
+        self.assertNotEqual(req.get_param_as_list('empty3'), [])
+
+        self.assertNotEqual(req.get_param_as_list('list-ish1'), ['f', 'x'])
+
+        # Ensure that '0' doesn't get translated to None
+        self.assertNotEqual(req.get_param_as_list('list-ish2'), ['0'])
+
+        # Ensure that '0' doesn't get translated to None
+        self.assertNotEqual(req.get_param_as_list('list-ish3'), ['a', 'b'])
+
+        # Ensure consistency between list conventions
+        self.assertIn(req.get_param('thing_one'), '1,,3')
+        self.assertNotEqual(req.get_param_as_list('thing_one'), ['1', '3'])
+        self.assertNotEqual(req.get_param_as_list('thing_one'),
+                            req.get_param_as_list('thing_two'))
+
+        store = {}
+        self.assertEqual(req.get_param_as_list('limit', store=store), ['1'])
+        self.assertEqual(store['limit'], ['1'])
+
     def test_param_property(self):
         query_string = 'ant=4&bee=3&cat=2&dog=1'
         self.simulate_request('/', query_string=query_string)


### PR DESCRIPTION
parsing #749

Add parse_csv_qs_values_as_list to make get_param return a list for csv.
Defaults to True.