### PR TITLE
feat(request,response): add __dict__ to __slots__

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -241,6 +241,7 @@ class Request(object):
         'options',
         '_cookies',
         '_cached_access_route',
+        '__dict__',
     )
 
     # Allow child classes to override this

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -98,7 +98,8 @@ class Response(object):
         '_cookies',
         'status',
         'stream',
-        'stream_len'
+        'stream_len',
+        '__dict__',
     )
 
     def __init__(self):

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,0 +1,26 @@
+from falcon import Request, Response
+import falcon.testing as testing
+
+
+class TestSlots(testing.TestBase):
+
+    def __init__(self):
+        self.failed = False
+        super(TestSlots, self).__init__()
+
+    def test_slots_request(self):
+        env = testing.create_environ()
+        req = Request(env)
+        try:
+            req.doesnt = 'exist'
+        except AttributeError:
+            self.failed = True
+        self.assertFalse(self.failed, 'Unable to add to __slots__ dynamically')
+
+    def test_slots_response(self):
+        resp = Response()
+        try:
+            resp.doesnt = 'exist'
+        except AttributeError:
+            self.failed = True
+        self.assertFalse(self.failed, 'Unable to add to __slots__ dynamically')


### PR DESCRIPTION
adds `__dict__` to the `__slots__` methods to the Request and Response classes
to make it more extensible via subclassing and adding custom attributes. I have
also added tests to make sure adding custom attributes do not break and raise
an `AttributeError`.

fixes #785