### PR TITLE
feat(Response): Add context property to the Response class

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -126,14 +126,12 @@ class Request(object):
         context (dict): Dictionary to hold any data about the request which is
             specific to your app (e.g. session object). Falcon itself will
             not interact with this attribute after it has been initialized.
-        context_type (class): Class variable that determines the
-            factory or type to use for initializing the
-            `context` attribute. By default, the framework will
-            instantiate standard
-            ``dict`` objects. However, You may override this behavior
-            by creating a custom child class of ``falcon.Request``, and
-            then passing that new class to `falcon.API()` by way of the
-            latter's `request_type` parameter.
+        context_type (class): Class variable that determines the factory or
+            type to use for initializing the `context` attribute. By default,
+            the framework will instantiate standard ``dict`` objects. However,
+            you may override this behavior by creating a custom child class of
+            ``falcon.Request``, and then passing that new class to
+            `falcon.API()` by way of the latter's `request_type` parameter.
 
             Note:
                 When overriding `context_type` with a factory function (as
@@ -245,7 +243,7 @@ class Request(object):
         '_cached_access_route',
     )
 
-    # Allow child classes to override this
+    # Child classes may override this
     context_type = None
 
     def __init__(self, env, options=None):

--- a/tests/test_response_context.py
+++ b/tests/test_response_context.py
@@ -1,0 +1,39 @@
+from falcon import Response
+import falcon.testing as testing
+
+
+class TestRequestContext(testing.TestBase):
+
+    def test_default_response_context(self):
+        resp = Response()
+        self.assertIsInstance(resp.context, dict)
+
+    def test_custom_response_context(self):
+
+        class MyCustomContextType(object):
+            pass
+
+        class MyCustomResponse(Response):
+            context_type = MyCustomContextType
+
+        resp = MyCustomResponse()
+        self.assertIsInstance(resp.context, MyCustomContextType)
+
+    def test_custom_response_context_failure(self):
+
+        class MyCustomResponse(Response):
+            context_type = False
+
+        self.assertRaises(TypeError, MyCustomResponse)
+
+    def test_custom_response_context_factory(self):
+
+        def create_context(resp):
+            return {'resp': resp}
+
+        class MyCustomResponse(Response):
+            context_type = create_context
+
+        resp = MyCustomResponse()
+        self.assertIsInstance(resp.context, dict)
+        self.assertIs(resp.context['resp'], resp)


### PR DESCRIPTION
Add a context property to the Response class, to mirror the context property that is already available on the Request class.