### PR TITLE
Add error class for HTTP 414  URI Too Long

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -272,6 +272,30 @@ class HTTPRequestEntityTooLarge(HTTPError):
                                                         **kwargs)
 
 
+class HTTPUriTooLong(HTTPError):
+    """414 URI Too Long.
+
+    The server is refusing to process a request because the request-target is
+    longer than the server is willing to interpret.
+
+    This usually occurs when the client is sending a GET request with long
+    query information, when the client has descended in a redirection loop
+    that points to a suffix of itself or when the server is under attack by a
+    client.
+
+    (RFC 7231)
+
+    Args:
+      title (str): Error title (e.g., 'Request Body Limit Exceeded').
+      description (str): Human-friendly description of the error, along with
+            a helpful suggestion or two.
+      kwargs (optional): Same as for ``HTTPError``.
+    """
+
+    def __init__(self, title=None, description=None, **kwargs):
+        super(HTTPUriTooLong, self).__init__(status.HTTP_414, title, description, **kwargs)
+
+
 class HTTPUnsupportedMediaType(HTTPError):
     """415 Unsupported Media Type.
 

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -650,6 +650,32 @@ class TestHTTPError(testing.TestBase):
         self.assertIn(('retry-after', falcon.util.dt_to_http(date)),
                       self.srmock.headers)
 
+    def test_414(self):
+        self.api.add_route('/414', UriTooLongResource())
+        self.simulate_request('/414')
+        self.assertEqual(self.srmock.status, falcon.HTTP_414)
+
+    def test_414_with_title(self):
+        title = 'Argh! Error!'
+        self.api.add_route('/414', UriTooLongResource(title=title))
+        body = self.simulate_request('/414', headers={})
+        parsed_body = json.loads(body[0].decode())
+        self.assertEqual(parsed_body['title'], title)
+
+    def test_414_with_description(self):
+        description = 'Be short please.'
+        self.api.add_route('/414', UriTooLongResource(description=description))
+        body = self.simulate_request('/414', headers={})
+        parsed_body = json.loads(body[0].decode())
+        self.assertEqual(parsed_body['description'], description)
+
+    def test_414_with_custom_kwargs(self):
+        code = 'someid'
+        self.api.add_route('/414', UriTooLongResource(code=code))
+        body = self.simulate_request('/414', headers={})
+        parsed_body = json.loads(body[0].decode())
+        self.assertEqual(parsed_body['code'], code)
+
     def test_416(self):
         self.api = falcon.API()
         self.api.add_route('/416', RangeNotSatisfiableResource())

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -153,6 +153,19 @@ class TemporaryRequestEntityTooLongResource:
                                                retry_after=self.retry_after)
 
 
+class UriTooLongResource:
+
+    def __init__(self, title=None, description=None, code=None):
+        self.title = title
+        self.description = description
+        self.code = code
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPUriTooLong(self.title,
+                                    self.description,
+                                    code=self.code)
+
+
 class RangeNotSatisfiableResource:
 
     def on_get(self, req, resp):


### PR DESCRIPTION
As mentioned in #561, some status codes do not have an error class. This PR adds a class for HTTP 414.