### PR TITLE
fix(pep8): fix pep8 errors detected by flak8 (F405 and F401)

### DIFF
--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -1,6 +1,6 @@
 # Hoist misc. utils
 from falcon.util import structures
 from falcon.util.misc import *  # NOQA
-from falcon.util.time import *
+from falcon.util.time import *  # NOQA
 
 CaseInsensitiveDict = structures.CaseInsensitiveDict


### PR DESCRIPTION
Pull requests are not passing in Travis due to failure of ```tox -e pep8```. This is due to
flake8 failing with F405 and F401 warnings. This pull request aims to fix the issue

Fixes #830