### PR TITLE
feat(Response): add support to Response for the Accept-Ranges header

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -567,16 +567,17 @@ class Response(object):
     accept_ranges = header_property(
         'Accept-Ranges',
         """
-        Sets the Accept-Ranges headers.
+        Sets the Accept-Ranges header.
 
-        The "Accept-Ranges" header field allows a server to indicate that it
-        supports range requests for the target resource.
+        The Accept-Ranges header field allows a server to indicate that it
+        supports range requests for the target resource. The value of this
+        header indicates what range units are supported (e.g. "bytes").
 
         If the server does not support any kind of range request for the
-        target resource, then set the header to ``none``
+        target resource, then set the header to "none"
 
         Note:
-            ``none`` is the literal string, not Python's built-in type ``None``
+            "none" is the literal string, not Python's built-in type ``None``
 
         """)
 

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -564,6 +564,22 @@ class Response(object):
         """,
         lambda v: ', '.join(v))
 
+    accept_ranges = header_property(
+        'Accept-Ranges',
+        """
+        Sets the Accept-Ranges headers.
+
+        The "Accept-Ranges" header field allows a server to indicate that it
+        supports range requests for the target resource.
+
+        If the server does not support any kind of range request for the
+        target resource, then set the header to ``none``
+
+        Note:
+            ``none`` is the literal string, not Python's built-in type ``None``
+
+        """)
+
     def _encode_header(self, name, value, py2=PY2):
         if py2:
             if isinstance(name, unicode):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -50,6 +50,8 @@ class HeaderHelpersResource(object):
         else:
             resp.content_range = (0, 25, 100, req.range_unit)
 
+        resp.accept_ranges = 'bytes'
+
         self.resp = resp
 
     def on_head(self, req, resp):
@@ -320,6 +322,9 @@ class TestHeaders(testing.TestCase):
 
         resp.content_range = (1, 499, 10 * 1024, 'bytes')
         self.assertEqual(resp.content_range, 'bytes 1-499/10240')
+
+        self.assertEqual(resp.accept_ranges, 'bytes')
+        self.assertEqual(result.headers['Accept-Ranges'], 'bytes')
 
         req_headers = {'Range': 'items=0-25'}
         result = self.simulate_get(headers=req_headers)


### PR DESCRIPTION
add support to Response class for Accept-Ranges header
(https://tools.ietf.org/html/rfc7233#section-2.3)

Fixes 646