### PR TITLE
doc: Convert readthedocs links from *.org to *.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,9 +149,9 @@ Just as in the **subject**, use the imperative, present tense: "change" not "cha
 The footer should contain any information about **Breaking Changes** and is also the place to reference GitHub issues that this commit **Closes**.
 
 [ajs]: https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#commit
-[docstrings]: http://sphinxcontrib-napoleon.readthedocs.org/en/latest/example_google.html#example-google-style-python-docstrings
+[docstrings]: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google-style-python-docstrings
 [goog-style]: http://google-styleguide.googlecode.com/svn/trunk/pyguide.html#Comments
-[rtd]: http://falcon.readthedocs.org
+[rtd]: https://falcon.readthedocs.io
 [coc]: https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md
 [freenode]: https://www.freenode.net/
 [ml-join]: mailto:users-join@mail.falconframework.org?subject=join

--- a/README.rst
+++ b/README.rst
@@ -15,8 +15,8 @@ effective <http://falconframework.org/index.html#Benefits>`__.
 Quick Links
 -----------
 
-* `Read the docs <http://falcon.readthedocs.org/en/stable>`__.
-* `Subscribe to the community mailing list <https://falcon.readthedocs.org/en/stable/community/help.html#mailing-list>`__.
+* `Read the docs <https://falcon.readthedocs.io/en/stable>`__.
+* `Subscribe to the community mailing list <https://falcon.readthedocs.io/en/stable/community/help.html#mailing-list>`__.
 * `Hang out in #falconframework on freenode <https://kiwiirc.com/client/irc.freenode.net/?#falconframework>`__.
 
 
@@ -143,7 +143,7 @@ The docstrings in the Falcon code base are quite extensive, and we
 recommend keeping a REPL running while learning the framework so that
 you can query the various modules and classes as you have questions.
 
-Online docs are available at: http://falcon.readthedocs.org
+Online docs are available at: https://falcon.readthedocs.io
 
 You can build the same docs locally as follows:
 
@@ -509,7 +509,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 .. |Docs| image:: https://readthedocs.org/projects/falcon/badge/?version=stable
-    :target: http://falcon.readthedocs.org/en/stable/?badge=stable
+    :target: https://falcon.readthedocs.io/en/stable/?badge=stable
     :alt: Falcon web framework docs
 .. |Runner| image:: https://a248.e.akamai.net/assets.github.com/images/icons/emoji/runner.png
     :width: 20

--- a/falcon/bench/nuts/nuts/model/__init__.py
+++ b/falcon/bench/nuts/nuts/model/__init__.py
@@ -10,6 +10,6 @@ def init_model():
     recommended place to do it.
 
     For more information working with databases, and some common recipes,
-    see http://pecan.readthedocs.org/en/latest/databases.html
+    see https://pecan.readthedocs.io/en/latest/databases.html
     """
     pass

--- a/falcon/bench/nuts/nuts/tests/test_functional.py
+++ b/falcon/bench/nuts/nuts/tests/test_functional.py
@@ -12,7 +12,7 @@ class TestRootController(FunctionalTest):
     def test_search(self):
         response = self.app.post('/', params={'q': 'RestController'})
         assert response.status_int == 302
-        assert response.headers['Location'] == ('http://pecan.readthedocs.org'
+        assert response.headers['Location'] == ('https://pecan.readthedocs.io'
                                                 '/en/latest/search.html'
                                                 '?q=RestController')
 


### PR DESCRIPTION
As per RTD's [blog post][1]:

> Starting today, Read the Docs will start hosting projects from
> subdomains on the domain readthedocs.io, instead of on
> readthedocs.org. This change addresses some security concerns around
> site cookies while hosting user generated data on the same domain as
> our dashboard.

[1]: https://blog.readthedocs.com/securing-subdomains/