### PR TITLE
fix(HTTPError): Remove asserts for self.has_representation

### DIFF
--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -135,8 +135,6 @@ class HTTPError(Exception):
 
         """
 
-        assert self.has_representation
-
         obj = obj_type()
 
         obj['title'] = self.title
@@ -171,8 +169,6 @@ class HTTPError(Exception):
             An XML document for the error.
 
         """
-
-        assert self.has_representation
 
         error_element = et.Element('error')
 


### PR DESCRIPTION
Even if an error should not result in a representation being returned
in the body of the HTTP response, it may still be useful to serialize
the error for purposes of logging, without having to check the
representation flag first.