### PR TITLE
feat(request,response) add __dict__ to __slots__

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -243,6 +243,7 @@ class Request(object):
         'options',
         '_cookies',
         '_cached_access_route',
+        '__dict__',
     )
 
     # Child classes may override this

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -116,6 +116,7 @@ class Response(object):
         'stream',
         'stream_len',
         'context',
+        '__dict__',
     )
 
     # Child classes may override this

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,0 +1,22 @@
+from falcon import Request, Response
+import falcon.testing as testing
+
+
+class TestSlots(testing.TestBase):
+
+    def test_slots_request(self):
+        env = testing.create_environ()
+        req = Request(env)
+
+        try:
+            req.doesnt = 'exist'
+        except AttributeError:
+            self.fail('Unable to add additional variables dynamically')
+
+    def test_slots_response(self):
+        resp = Response()
+
+        try:
+            resp.doesnt = 'exist'
+        except AttributeError:
+            self.fail('Unable to add additional variables dynamically')


### PR DESCRIPTION
Add `__dict__` to the `__slots__` methods to the Request and Response classes
to make it them extensible via subclassing and adding custom attributes. I have
also added tests to make sure adding custom attributes do not break and raise
an `AttributeError`.

Fixes #785