### PR TITLE
test(mimeparse): Test for the correct version of mimeparse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,8 @@ Features
 -  CPython 2.6-2.7, PyPy, Jython 2.7, and CPython 3.3-3.5 support
 -  ~20% speed boost when Cython is available
 
-Install
--------
+Installation
+------------
 
 PyPy
 ^^^^
@@ -122,8 +122,19 @@ these issues by setting additional Clang C compiler flags as follows:
 
     $ export CFLAGS="-Qunused-arguments -Wno-unused-function"
 
-Test
-----
+
+Dependencies
+------------
+
+Falcon depends on six and `python-mimeparse`. `python-mimeparse` is a
+better-maintained fork of the similarly named `mimeparse` project.
+Normally the correct package will be selected by Falcon's ``setup.py``.
+However, if you are using an alternate strategy to manage dependencies,
+please take care to install the correct package in order to avoid
+errors.
+
+Tests
+-----
 
 .. code:: bash
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,8 @@ MYDIR = path.abspath(os.path.dirname(__file__))
 VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
-# NOTE(kgriffs): python-mimeparse is newer than mimeparse, supports Py3
-# TODO(kgriffs): Fork and optimize/modernize python-mimeparse
-REQUIRES = ['six>=1.4.0', 'python-mimeparse']
+# NOTE(kgriffs): python-mimeparse is better-maintained fork of mimeparse
+REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2']
 
 JYTHON = 'java' in sys.platform
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,0 +1,18 @@
+import mimeparse
+import testtools
+
+
+class TestDeps(testtools.TestCase):
+
+    def test_mimeparse_correct_package(self):
+        """Ensure we are dealing with python-mimeparse, not mimeparse."""
+
+        tokens = mimeparse.__version__.split('.')
+        msg = ('Incorrect dependency detected. Please install the '
+               '"python-mimeparse" package instead of the "mimeparse" '
+               'package.')
+
+        # NOTE(kgriffs): python-mimeparse starts at version 1.5.2,
+        # whereas the mimeparse package is at version 0.1.4 at the time
+        # of this writing.
+        self.assertGreater(int(tokens[0]), 0, msg)


### PR DESCRIPTION
Document the difference between python-mimeparse and mimeparse, and
add a test to ensure Linux package maintainers, et al., are pulling
python-mimeparse, not mimeparse.