### PR TITLE
chore(tox): Switch test runner from nose to pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,4 @@
 [run]
-parallel = True
 branch = True
 source = falcon
 omit = falcon/tests*,falcon/cmd*,falcon/bench*

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ pip-log.txt
 nosetests.xml
 htmlcov
 *.dat
+.cache
+
 
 # Docs
 doc/_build

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,3 @@ tag_build = dev
 
 [wheel]
 universal = 1
-
-[nosetests]
-where = tests
-verbosity = 2
-
-cover-package = falcon
-cover-erase = true
-cover-inclusive = true
-cover-branches = true

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -1,6 +1,7 @@
 coverage>=4.1
 ddt
-nose
+pytest>=3.0.1
+pytest-sugar
 pyyaml
 requests
 six

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist = py26,
 [testenv]
 deps = -r{toxinidir}/tools/test-requires
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests []
+           pytest tests []
 
 # --------------------------------------------------------------------
 # Coverage
@@ -27,20 +27,24 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
 whitelist_externals = bash
                       mv
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests --with-coverage []
+           coverage run -m pytest tests []
            bash -c "if [ ! -d .coverage_data ]; then mkdir .coverage_data; fi"
            mv {toxinidir}/.coverage {toxinidir}/.coverage_data/.coverage.{envname}
 
-
 [testenv:py26]
+# NOTE(kgriffs): pytest-randomly is not compatible with py26
 whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
 [testenv:py27]
+deps = {[testenv]deps}
+       pytest-randomly
 whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
 [testenv:py34]
+deps = {[testenv]deps}
+       pytest-randomly
 whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
@@ -50,7 +54,6 @@ commands = {[with-coverage]commands}
 
 [with-debug-tools]
 deps = -r{toxinidir}/tools/test-requires
-       ipdb
        pdbpp
 
 [testenv:py27_debug]
@@ -58,17 +61,6 @@ deps = {[with-debug-tools]deps}
 
 [testenv:py34_debug]
 deps = {[with-debug-tools]deps}
-
-[testenv:py27_profile]
-deps = -r{toxinidir}/tools/test-requires
-       nose-cprof
-commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           nosetests \
-               --with-cprofile \
-               --cprofile-stats-erase \
-               --cprofile-stats-file=cprofile.dat \
-               -s \
-               []
 
 # --------------------------------------------------------------------
 # Cython


### PR DESCRIPTION
Use pytest instead of nose since it has a better ecosystem and will
allow us to write pytest-style tests in the future.