### PR TITLE
chore: Remove portion of build.sh that deals with binary Darwin wheels

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -93,25 +93,3 @@ _open_env 2.7.11
 python setup.py bdist_wheel -d $DIST_DIR
 
 _close_env
-
-#----------------------------------------------------------------------
-# Build platform-specific wheel
-#----------------------------------------------------------------------
-
-if [ "$(uname)" == "Darwin" ]; then
-
-    # Disable spurious warnings when cythonizing
-    CFLAGS="-Qunused-arguments -Wno-unused-function"
-
-    for PY_VERSION in 2.6.9 2.7.11 3.3.6 3.4.4 3.5.1; do
-        _echo_task "Building OS X wheel for $PY_VERSION"
-        _open_env $PY_VERSION
-
-        pip install cython
-
-        python setup.py bdist_wheel -d $DIST_DIR
-
-        _close_env
-    done
-
-fi


### PR DESCRIPTION
Don't build binary wheels for Darwin (OS X) since it isn't really
necessary to have cythonized code in a development environment, and
using the pyenv-installed Pythons results in compatibility issues
that just aren't worth it in any case.