### PR TITLE
feat(Request): Expose the URI template that was matched for the request

### DIFF
--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -24,14 +24,15 @@ A custom router is any class that implements the following interface:
             """
 
         def find(self, uri):
-            """Search for a route that matches the given URI.
+            """Search for a route that matches the given partial URI.
 
             Args:
-                uri (str): Request URI to match to a route.
+                uri(str): The requested path to route
 
             Returns:
-                tuple: A 3-member tuple composed of (resource, method_map, params)
-                    or ``None`` if no route is found.
+                tuple: A 4-member tuple composed of (resource, method_map,
+                    params, uri_template), or ``None`` if no route matches
+                    the requested path
             """
 
 A custom routing engine may be specified when instantiating

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -184,7 +184,7 @@ class API(object):
                 # next-hop child resource. In that case, the object
                 # being asked to dispatch to its child will raise an
                 # HTTP exception signalling the problem, e.g. a 404.
-                responder, params, resource = self._get_responder(req)
+                responder, params, resource, req.uri_template = self._get_responder(req)
             except Exception as ex:
                 if not self._handle_exception(ex, req, resp, params):
                     raise
@@ -500,11 +500,18 @@ class API(object):
 
         path = req.path
         method = req.method
+        uri_template = None
 
         route = self._router.find(path)
 
         if route is not None:
-            resource, method_map, params = route
+            try:
+                resource, method_map, params, uri_template = route
+            except ValueError:
+                # NOTE(kgriffs): Older routers may not return the
+                # template. But for performance reasons they should at
+                # least return None if they don't support it.
+                resource, method_map, params = route
         else:
             # NOTE(kgriffs): Older routers may indicate that no route
             # was found by returning (None, None, None). Therefore, we
@@ -530,7 +537,7 @@ class API(object):
             else:
                 responder = falcon.responders.path_not_found
 
-        return (responder, params, resource)
+        return (responder, params, resource, uri_template)
 
     def _compose_status_response(self, req, resp, http_status):
         """Composes a response for the given HTTPStatus instance."""

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -68,6 +68,8 @@ class Request(object):
     Args:
         env (dict): A WSGI environment dict passed in from the server. See
             also PEP-3333.
+
+    Keyword Arguments
         options (dict): Set of global options passed from the API handler.
 
     Attributes:
@@ -140,7 +142,6 @@ class Request(object):
                 opposed to a class), the function is called like a method of
                 the current Request instance. Therefore the first argument is
                 the Request instance itself (self).
-
         uri (str): The fully-qualified URI for the request.
         url (str): alias for `uri`.
         relative_uri (str): The path + query string portion of the full URI.
@@ -148,6 +149,13 @@ class Request(object):
             string).
         query_string (str): Query string portion of the request URL, without
             the preceding '?' character.
+        uri_template (str): The template for the route that was matched for
+            this request. May be ``None`` if the request has not yet been
+            routed, as would be the case for `process_request()` middleware
+            methods. May also be ``None`` if your app uses a custom routing
+            engine and the engine does not provide the URI template when
+            resolving a route.
+
         user_agent (str): Value of the User-Agent header, or ``None`` if the
             header is missing.
         accept (str): Value of the Accept header, or '*/*' if the header is
@@ -244,6 +252,7 @@ class Request(object):
         '_cookies',
         '_cached_access_route',
         '__dict__',
+        'uri_template',
     )
 
     # Child classes may override this
@@ -258,6 +267,8 @@ class Request(object):
         self._wsgierrors = env['wsgi.errors']
         self.stream = env['wsgi.input']
         self.method = env['REQUEST_METHOD']
+
+        self.uri_template = None
 
         # Normalize path
         path = env['PATH_INFO']


### PR DESCRIPTION
This has been requested by several members of the community who would
like a way to access the URI template in middleware, etc. (e.g., for
logging).

Fixes #619