### PR TITLE
feat(util): Make it easier to reference uri module and TimezoneGMT class

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -6,14 +6,22 @@ Utilities
 URI Functions
 -------------
 
-.. automodule:: falcon.util.uri
-    :members:
+.. NOTE(kgriffs): Due to the way we have been hoisting uri into falcon,
+.. sphinx can't import just falcon.uri (root cause TBD). Whether or not
+.. the way we are hoisting things is legit (hint: probably not, this
+.. is something to address in Falcon 2.0), sphinx can't handle it
+.. by default so we have a custom extension to fix things up.
+
+.. automodule:: falcon.uri
+    :members: encode, encode_value, decode, parse_host,
+        parse_query_string, unquote_string
 
 Miscellaneous
 -------------
 
 .. automodule:: falcon
-    :members: deprecated, http_now, dt_to_http, http_date_to_dt, to_query_str
+    :members: deprecated, http_now, dt_to_http, http_date_to_dt,
+        to_query_str, get_http_status, get_bound_method
 
-.. autoclass:: falcon.util.TimezoneGMT
+.. autoclass:: falcon.TimezoneGMT
     :members:

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -47,7 +47,13 @@ from falcon.errors import *  # NOQA
 from falcon.redirects import *  # NOQA
 from falcon.http_error import HTTPError  # NOQA
 from falcon.http_status import HTTPStatus  # NOQA
+
+# NOTE(kgriffs): Explicitly import uri since the star import doesn't
+# grab modules by default. This is simpler and easier to maintain
+# vs. a large __all__ list in util/__init__.py
+import falcon.util.uri as uri  # NOQA
 from falcon.util import *  # NOQA
+
 from falcon.hooks import before, after  # NOQA
 from falcon.request import Request, RequestOptions  # NOQA
 from falcon.response import Response  # NOQA

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -13,7 +13,7 @@ imported directly into the front-door `falcon` module for convenience::
 
 Conversely, the `uri` module must be imported explicitly::
 
-    from falcon.util import uri
+    from falcon import uri
 
     some_uri = '...'
     decoded_uri = uri.decode(some_uri)


### PR DESCRIPTION
Previously "from falcon import uri" worked but "import falcon.uri" did
not. TimezoneGMT is already available from the front-door falcon
module, but the documentation referenced falcon.util.TimezoneGTM.

Fix this up and update the docs to suit.