### PR TITLE
(chore) Adding dockerfiles for falcon-bench

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,6 @@
+all: build-benchmark-images
+
+build-benchmark-images:
+	sudo docker build -t falconry/falcon-bench:py27-pip -f bench_py27_pip.Dockerfile ./
+	sudo docker build -t falconry/falcon-bench:py35-pip -f bench_py35_pip.Dockerfile ./
+	sudo docker build -t falconry/falcon-bench:pypy2-pip -f bench_pypy2_pip.Dockerfile ./

--- a/docker/bench_py27_pip.Dockerfile
+++ b/docker/bench_py27_pip.Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+MAINTAINER Falcon Framework Maintainers
+
+RUN pip install falcon flask pecan bottle cherrypy
+COPY ./benchmark.sh /benchmark.sh
+
+CMD /benchmark.sh

--- a/docker/bench_py35_pip.Dockerfile
+++ b/docker/bench_py35_pip.Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.5
+MAINTAINER Falcon Framework Maintainers
+
+RUN pip install falcon flask pecan bottle cherrypy
+COPY ./benchmark.sh /benchmark.sh
+
+CMD /benchmark.sh

--- a/docker/bench_pypy2_pip.Dockerfile
+++ b/docker/bench_pypy2_pip.Dockerfile
@@ -1,0 +1,7 @@
+FROM pypy:2
+MAINTAINER Falcon Framework Maintainers
+
+RUN pip install falcon flask pecan bottle cherrypy
+COPY ./benchmark.sh benchmark.sh
+
+CMD /benchmark.sh

--- a/docker/benchmark.sh
+++ b/docker/benchmark.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Installed Packages:\n=================="
+pip list
+
+echo "\nBenchmark:\n=================="
+falcon-bench


### PR DESCRIPTION
The dockerfiles used to build the ``falconry/falcon-bench`` images on Docker Hub