### PR TITLE
fix(Request): Improve various related aspects of stream handling

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -104,8 +104,8 @@ class API(object):
             See also: :ref:`Routing <routing>`.
 
     Attributes:
-        req_options (RequestOptions): A set of behavioral options related to
-            incoming requests.
+        req_options: A set of behavioral options related to incoming
+            requests. See also: :py:class:`~.RequestOptions`
     """
 
     # PERF(kgriffs): Reference via self since that is faster than

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -36,7 +36,7 @@ def header_property(wsgi_name):
     return property(fget)
 
 
-class Body(object):
+class BoundedStream(object):
     """Wrap *wsgi.input* streams to make them more robust.
 
     ``socket._fileobject`` and ``io.BufferedReader`` are sometimes used
@@ -74,11 +74,11 @@ class Body(object):
         """Helper function for proxing reads to the underlying stream.
 
         Args:
-            size (int): Maximum number of bytes/characters to read.
-                Will be coerced, if None or -1, to `self.stream_len`. Will
-                likewise be coerced if greater than `self.stream_len`, so
-                that if the stream doesn't follow standard io semantics,
-                the read won't block.
+            size (int): Maximum number of bytes to read. Will be
+                coerced, if None or -1, to the number of remaining bytes
+                in the stream. Will likewise be coerced if greater than
+                the number of remaining bytes, to avoid making a
+                blocking call to the wrapped stream.
             target (callable): Once `size` has been fixed up, this function
                 will be called to actually do the work.
 
@@ -137,3 +137,7 @@ class Body(object):
         """
 
         return self._read(hint, self.stream.readlines)
+
+
+# NOTE(kgriffs): Alias for backwards-compat
+Body = BoundedStream

--- a/falcon/testing/base.py
+++ b/falcon/testing/base.py
@@ -27,7 +27,10 @@ from falcon.testing.helpers import create_environ
 from falcon.testing.srmock import StartResponseMock
 
 
-class TestBase(unittest.TestCase):
+# NOTE(kgriffs): Since this class is deprecated and we will be using it
+# less and less for Falcon's own tests, coverage may be reduced, hence
+# the pragma to ignore coverage errors from now on.
+class TestBase(unittest.TestCase):  # pragma nocover
     """Extends :py:mod:`unittest` to support WSGI functional testing.
 
     Warning:

--- a/falcon/testing/resource.py
+++ b/falcon/testing/resource.py
@@ -66,9 +66,10 @@ class SimpleTestResource(object):
     as needed to test middleware, hooks, and the Falcon framework
     itself.
 
-    Only the ``on_get()`` responder is implemented; when adding
-    additional responders in child classes, they can be decorated
-    with the :py:meth:`falcon.testing.capture_responder_args` hook in
+    Only noop ``on_get()`` and ``on_post()`` responders are implemented;
+    when overriding these, or adding additional responders in child
+    classes, they can be decorated with the
+    :py:meth:`falcon.testing.capture_responder_args` hook in
     order to capture the *req*, *resp*, and *params* arguments that
     are passed to the responder. Responders may also be decorated with
     the :py:meth:`falcon.testing.set_resp_defaults` hook in order to
@@ -108,9 +109,18 @@ class SimpleTestResource(object):
         else:
             self._default_body = body
 
+        self.captured_req = None
+        self.captured_resp = None
+        self.captured_kwargs = None
+
     @falcon.before(capture_responder_args)
     @falcon.before(set_resp_defaults)
     def on_get(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(capture_responder_args)
+    @falcon.before(set_resp_defaults)
+    def on_post(self, req, resp, **kwargs):
         pass
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+
+import falcon
+
+
+# NOTE(kgriffs): Some modules actually run a wsgiref server, so
+# to ensure we reset the detection for the other modules, we just
+# run this fixture before each one is tested.
+@pytest.fixture(autouse=True, scope='module')
+def reset_request_stream_detection():
+    falcon.Request._wsgi_input_type_known = False
+    falcon.Request._always_wrap_wsgi_input = False

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -12,14 +12,14 @@ import falcon.testing as testing
 class _TestQueryParams(testing.TestBase):
 
     def before(self):
-        self.resource = testing.TestResource()
+        self.resource = testing.SimpleTestResource()
         self.api.add_route('/', self.resource)
 
     def test_none(self):
         query_string = ''
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         store = {}
         self.assertIs(req.get_param('marker'), None)
         self.assertIs(req.get_param('limit', store), None)
@@ -32,7 +32,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'marker='
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertIs(req.get_param('marker'), None)
 
         store = {}
@@ -43,7 +43,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'marker=deadbeef&limit=25'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         store = {}
         self.assertEqual(req.get_param('marker', store=store) or 'nada',
                          'deadbeef')
@@ -56,7 +56,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'id=23,42&q=%e8%b1%86+%e7%93%a3'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         # NOTE(kgriffs): For lists, get_param will return one of the
         # elements, but which one it will choose is undefined.
@@ -71,7 +71,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'id=23,42,,&id=2'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         self.assertEqual(req.params['id'], [u'23,42,,', u'2'])
         self.assertIn(req.get_param('id'), [u'23,42,,', u'2'])
@@ -83,7 +83,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'id=23,42,,&id=2'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         self.assertEqual(req.params['id'], [u'23', u'42', u'2'])
         self.assertIn(req.get_param('id'), [u'23', u'42', u'2'])
@@ -102,7 +102,7 @@ class _TestQueryParams(testing.TestBase):
 
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         self.assertIn(req.get_param('colors'), 'red,green,blue')
         self.assertEqual(req.get_param_as_list('colors'), [u'red,green,blue'])
@@ -124,7 +124,7 @@ class _TestQueryParams(testing.TestBase):
         self.simulate_request('/', query_string=query_string)
         self.assertEqual(self.srmock.status, falcon.HTTP_200)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param('x'), '% % %')
         self.assertEqual(req.get_param('y'), 'peregrine')
         self.assertEqual(req.get_param('z'), '%a%z%zz%1 e')
@@ -135,7 +135,7 @@ class _TestQueryParams(testing.TestBase):
                         '_thing=42&_charset_=utf-8')
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param('p'), '0')
         self.assertEqual(req.get_param('p1'), '23')
         self.assertEqual(req.get_param('2p'), 'foo')
@@ -153,7 +153,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = ''
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         try:
             getattr(req, method_name)('marker', required=True)
@@ -168,7 +168,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'marker=deadbeef&limit=25'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         try:
             req.get_param_as_int('marker')
@@ -230,7 +230,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'marker=deadbeef&pos=-7'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_int('pos'), -7)
 
         self.assertEqual(
@@ -260,7 +260,7 @@ class _TestQueryParams(testing.TestBase):
                         't1=True&f1=False&t2=yes&f2=no&blank&one=1&zero=0')
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertRaises(falcon.HTTPBadRequest, req.get_param_as_bool,
                           'bogus')
 
@@ -296,7 +296,7 @@ class _TestQueryParams(testing.TestBase):
             query_string='blank&blank2=',
         )
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param('blank'), '')
         self.assertEqual(req.get_param('blank2'), '')
         self.assertRaises(falcon.HTTPInvalidParam, req.get_param_as_bool,
@@ -316,7 +316,7 @@ class _TestQueryParams(testing.TestBase):
                         '&thing_two=1&thing_two=&thing_two=3')
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         # NOTE(kgriffs): For lists, get_param will return one of the
         # elements, but which one it will choose is undefined.
@@ -366,7 +366,7 @@ class _TestQueryParams(testing.TestBase):
             query_string=query_string
         )
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         # NOTE(kgriffs): For lists, get_param will return one of the
         # elements, but which one it will choose is undefined.
@@ -412,7 +412,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'coord=1.4,13,15.1&limit=100&things=4,,1'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
 
         # NOTE(kgriffs): For lists, get_param will return one of the
         # elements, but which one it will choose is undefined.
@@ -443,7 +443,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'ant=4&bee=3&cat=2&dog=1'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(
             sorted(req.params.items()),
             [('ant', '4'), ('bee', '3'), ('cat', '2'), ('dog', '1')])
@@ -452,7 +452,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'ant=1&ant=2&bee=3&cat=6&cat=5&cat=4'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         # By definition, we cannot guarantee which of the multiple keys will
         # be returned by .get_param().
         self.assertIn(req.get_param('ant'), ('1', '2'))
@@ -464,20 +464,20 @@ class _TestQueryParams(testing.TestBase):
     def test_multiple_keys_as_bool(self):
         query_string = 'ant=true&ant=yes&ant=True'
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_bool('ant'), True)
 
     def test_multiple_keys_as_int(self):
         query_string = 'ant=1&ant=2&ant=3'
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertIn(req.get_param_as_int('ant'), (1, 2, 3))
 
     def test_multiple_form_keys_as_list(self):
         query_string = 'ant=1&ant=2&bee=3&cat=6&cat=5&cat=4'
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         # There are two 'ant' keys.
         self.assertEqual(req.get_param_as_list('ant'), ['1', '2'])
         # There is only one 'bee' key..
@@ -489,14 +489,14 @@ class _TestQueryParams(testing.TestBase):
         date_value = '2015-04-20'
         query_string = 'thedate={0}'.format(date_value)
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_date('thedate'),
                          date(2015, 4, 20))
 
     def test_get_date_missing_param(self):
         query_string = 'notthedate=2015-04-20'
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_date('thedate'),
                          None)
 
@@ -505,7 +505,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'thedate={0}'.format(date_value)
         format_string = '%Y%m%d'
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_date('thedate',
                          format_string=format_string),
                          date(2015, 4, 20))
@@ -514,7 +514,7 @@ class _TestQueryParams(testing.TestBase):
         date_value = '2015-04-20'
         query_string = 'thedate={0}'.format(date_value)
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         store = {}
         req.get_param_as_date('thedate', store=store)
         self.assertNotEqual(len(store), 0)
@@ -524,7 +524,7 @@ class _TestQueryParams(testing.TestBase):
         query_string = 'thedate={0}'.format(date_value)
         format_string = '%Y%m%d'
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertRaises(HTTPInvalidParam, req.get_param_as_date,
                           'thedate', format_string=format_string)
 
@@ -532,7 +532,7 @@ class _TestQueryParams(testing.TestBase):
         payload_dict = {'foo': 'bar'}
         query_string = 'payload={0}'.format(json.dumps(payload_dict))
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_dict('payload'),
                          payload_dict)
 
@@ -540,7 +540,7 @@ class _TestQueryParams(testing.TestBase):
         payload_dict = {'foo': 'bar'}
         query_string = 'notthepayload={0}'.format(json.dumps(payload_dict))
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertEqual(req.get_param_as_dict('payload'),
                          None)
 
@@ -548,7 +548,7 @@ class _TestQueryParams(testing.TestBase):
         payload_dict = {'foo': 'bar'}
         query_string = 'payload={0}'.format(json.dumps(payload_dict))
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         store = {}
         req.get_param_as_dict('payload', store=store)
         self.assertNotEqual(len(store), 0)
@@ -557,7 +557,7 @@ class _TestQueryParams(testing.TestBase):
         payload_dict = 'foobar'
         query_string = 'payload={0}'.format(payload_dict)
         self.simulate_request('/', query_string=query_string)
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertRaises(HTTPInvalidParam, req.get_param_as_dict,
                           'payload')
 
@@ -568,23 +568,42 @@ class PostQueryParams(_TestQueryParams):
         self.api.req_options.auto_parse_form_urlencoded = True
 
     def simulate_request(self, path, query_string, **kwargs):
-        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+
+        headers = kwargs.setdefault('headers', {})
+        headers['Content-Type'] = 'application/x-www-form-urlencoded'
+
         super(PostQueryParams, self).simulate_request(
-            path, body=query_string, headers=headers, **kwargs)
+            path,
+            method='POST',
+            body=query_string,
+            **kwargs
+        )
 
     def test_non_ascii(self):
         value = u'\u8c46\u74e3'
         query_string = b'q=' + value.encode('utf-8')
         self.simulate_request('/', query_string=query_string)
 
-        req = self.resource.req
+        req = self.resource.captured_req
+        self.assertIs(req.get_param('q'), None)
+
+    def test_empty_body(self):
+        self.simulate_request('/', query_string=None)
+
+        req = self.resource.captured_req
+        self.assertIs(req.get_param('q'), None)
+
+    def test_empty_body_no_content_length(self):
+        self.simulate_request('/', query_string=None)
+
+        req = self.resource.captured_req
         self.assertIs(req.get_param('q'), None)
 
     def test_explicitly_disable_auto_parse(self):
         self.api.req_options.auto_parse_form_urlencoded = False
         self.simulate_request('/', query_string='q=42')
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertIs(req.get_param('q'), None)
 
 
@@ -596,11 +615,11 @@ class GetQueryParams(_TestQueryParams):
 
 class PostQueryParamsDefaultBehavior(testing.TestBase):
     def test_dont_auto_parse_by_default(self):
-        self.resource = testing.TestResource()
+        self.resource = testing.SimpleTestResource()
         self.api.add_route('/', self.resource)
 
         headers = {'Content-Type': 'application/x-www-form-urlencoded'}
         self.simulate_request('/', body='q=42', headers=headers)
 
-        req = self.resource.req
+        req = self.resource.captured_req
         self.assertIs(req.get_param('q'), None)

--- a/tests/test_wsgi_interface.py
+++ b/tests/test_wsgi_interface.py
@@ -1,0 +1,55 @@
+import re
+import sys
+
+import falcon
+import falcon.testing as testing
+
+
+class TestWSGIInterface(object):
+
+    def test_srmock(self):
+        mock = testing.StartResponseMock()
+        mock(falcon.HTTP_200, ())
+
+        assert mock.status == falcon.HTTP_200
+        assert mock.exc_info is None
+
+        mock = testing.StartResponseMock()
+        exc_info = sys.exc_info()
+        mock(falcon.HTTP_200, (), exc_info)
+
+        assert mock.exc_info == exc_info
+
+    def test_pep3333(self):
+        api = falcon.API()
+        mock = testing.StartResponseMock()
+
+        # Simulate a web request (normally done though a WSGI server)
+        response = api(testing.create_environ(), mock)
+
+        # Verify that the response is iterable
+        assert _is_iterable(response)
+
+        # Make sure start_response was passed a valid status string
+        assert mock.call_count == 1
+        assert isinstance(mock.status, str)
+        assert re.match('^\d+[a-zA-Z\s]+$', mock.status)
+
+        # Verify headers is a list of tuples, each containing a pair of strings
+        assert isinstance(mock.headers, list)
+        if len(mock.headers) != 0:
+            header = mock.headers[0]
+            assert isinstance(header, tuple)
+            assert len(header) == 2
+            assert isinstance(header[0], str)
+            assert isinstance(header[1], str)
+
+
+def _is_iterable(thing):
+    try:
+        for i in thing:
+            break
+
+        return True
+    except:
+        return False


### PR DESCRIPTION
* Add a new bounded_stream property that can be used for more
  predictable behavior vs. stream, albeit with a slight performance
  overhead (the app developer is free to decide whether or not to
  use it).
* Only automatically consume the incoming stream on POST requests,
  since that is the only time form-encoded params should be included
  in the body (vs. the query string). This guards against unexpected
  side-effects caused by misbehaving or even malicious clients.
* Check Content-Length to ensure a body is expected, before attempting
  to parse form-encoded POSTs. Also pass the Content-Length to
  stream.read as an extra safety measure to guard against differences
  in WSGI input read() behavior.
* Improve the documentation surrounding all of these behaviors.

Fixes #407