### PR TITLE
test: Migrate several test modules away from the deprecated framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ matrix:
     include:
         - python: 2.7  # these are just to make travis's UI a bit prettier
           env: JYTHON=true
-        - python: pypy
+        - python: pypy-5.3
           env: TOXENV=pypy
-        - python: pypy3
-          env: TOXENV=pypy3
+        # - python: pypy3
+        #   env: TOXENV=pypy3
         - python: 2.7
           env: TOXENV=pep8
         - python: 2.6

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -4,7 +4,7 @@ Testing
 =======
 
 .. automodule:: falcon.testing
-    :members: Result,
+    :members: Result, Cookie,
         simulate_request, simulate_get, simulate_head, simulate_post,
         simulate_put, simulate_options, simulate_patch, simulate_delete,
         TestClient, TestCase, SimpleTestResource, StartResponseMock,

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -14,6 +14,8 @@
 
 """Utilities for the Request class."""
 
+import io
+
 
 def header_property(wsgi_name):
     """Creates a read-only header property.
@@ -36,7 +38,7 @@ def header_property(wsgi_name):
     return property(fget)
 
 
-class BoundedStream(object):
+class BoundedStream(io.IOBase):
     """Wrap *wsgi.input* streams to make them more robust.
 
     ``socket._fileobject`` and ``io.BufferedReader`` are sometimes used
@@ -96,6 +98,18 @@ class BoundedStream(object):
         self._bytes_remaining -= size
         return target(size)
 
+    def readable(self):
+        """Always returns ``True``."""
+        return True
+
+    def seekable(self):
+        """Always returns ``False``."""
+        return False
+
+    def writeable(self):
+        """Always returns ``False``."""
+        return False
+
     def read(self, size=None):
         """Read from the stream.
 
@@ -137,6 +151,11 @@ class BoundedStream(object):
         """
 
         return self._read(hint, self.stream.readlines)
+
+    def write(self, data):
+        """Always raises IOError; writing is not supported."""
+
+        raise IOError('Stream is not writeable')
 
 
 # NOTE(kgriffs): Alias for backwards-compat

--- a/tests/test_access_route.py
+++ b/tests/test_access_route.py
@@ -2,81 +2,98 @@ from falcon.request import Request
 import falcon.testing as testing
 
 
-class TestAccessRoute(testing.TestBase):
+def test_remote_addr_only():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route',
+        headers={
+            'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
+                          'for="unknown", by=_hidden,for="\\"\\\\",'
+                          'for="198\\.51\\.100\\.17\\:1236";'
+                          'proto=https;host=example.com')
+        }))
 
-    def test_remote_addr_only(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route',
-            headers={
-                'Forwarded': ('for=192.0.2.43, for="[2001:db8:cafe::17]:555",'
-                              'for="unknown", by=_hidden,for="\\"\\\\",'
-                              'for="198\\.51\\.100\\.17\\:1236";'
-                              'proto=https;host=example.com')
-            }))
-        self.assertEqual(req.remote_addr, '127.0.0.1')
+    assert req.remote_addr == '127.0.0.1'
 
-    def test_rfc_forwarded(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route',
-            headers={
-                'Forwarded': ('for=192.0.2.43,for=,'
-                              'for="[2001:db8:cafe::17]:555",'
-                              'for=x,'
-                              'for="unknown", by=_hidden,for="\\"\\\\",'
-                              'for="_don\\\"t_\\try_this\\\\at_home_\\42",'
-                              'for="198\\.51\\.100\\.17\\:1236";'
-                              'proto=https;host=example.com')
-            }))
-        compares = ['192.0.2.43', '2001:db8:cafe::17', 'x',
-                    'unknown', '"\\', '_don"t_try_this\\at_home_42',
-                    '198.51.100.17']
-        self.assertEqual(req.access_route, compares)
-        # test cached
-        self.assertEqual(req.access_route, compares)
 
-    def test_malformed_rfc_forwarded(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route',
-            headers={
-                'Forwarded': 'for'
-            }))
-        self.assertEqual(req.access_route, [])
-        # test cached
-        self.assertEqual(req.access_route, [])
+def test_rfc_forwarded():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route',
+        headers={
+            'Forwarded': ('for=192.0.2.43,for=,'
+                          'for="[2001:db8:cafe::17]:555",'
+                          'for=x,'
+                          'for="unknown", by=_hidden,for="\\"\\\\",'
+                          'for="_don\\\"t_\\try_this\\\\at_home_\\42",'
+                          'for="198\\.51\\.100\\.17\\:1236";'
+                          'proto=https;host=example.com')
+        }))
 
-    def test_x_forwarded_for(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route',
-            headers={
-                'X-Forwarded-For': ('192.0.2.43, 2001:db8:cafe::17,'
-                                    'unknown, _hidden, 203.0.113.60')
-            }))
-        self.assertEqual(req.access_route,
-                         ['192.0.2.43', '2001:db8:cafe::17',
-                          'unknown', '_hidden', '203.0.113.60'])
+    compares = ['192.0.2.43', '2001:db8:cafe::17', 'x',
+                'unknown', '"\\', '_don"t_try_this\\at_home_42',
+                '198.51.100.17']
 
-    def test_x_real_ip(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route',
-            headers={
-                'X-Real-IP': '2001:db8:cafe::17'
-            }))
-        self.assertEqual(req.access_route, ['2001:db8:cafe::17'])
+    req.access_route == compares
 
-    def test_remote_addr(self):
-        req = Request(testing.create_environ(
-            host='example.com',
-            path='/access_route'))
-        self.assertEqual(req.access_route, ['127.0.0.1'])
+    # test cached
+    req.access_route == compares
 
-    def test_remote_addr_missing(self):
-        env = testing.create_environ(host='example.com', path='/access_route')
-        del env['REMOTE_ADDR']
 
-        req = Request(env)
-        self.assertEqual(req.access_route, [])
+def test_malformed_rfc_forwarded():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route',
+        headers={
+            'Forwarded': 'for'
+        }))
+
+    req.access_route == []
+
+    # test cached
+    req.access_route == []
+
+
+def test_x_forwarded_for():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route',
+        headers={
+            'X-Forwarded-For': ('192.0.2.43, 2001:db8:cafe::17,'
+                                'unknown, _hidden, 203.0.113.60')
+        }))
+
+    assert req.access_route == [
+        '192.0.2.43',
+        '2001:db8:cafe::17',
+        'unknown',
+        '_hidden',
+        '203.0.113.60'
+    ]
+
+
+def test_x_real_ip():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route',
+        headers={
+            'X-Real-IP': '2001:db8:cafe::17'
+        }))
+
+    assert req.access_route == ['2001:db8:cafe::17']
+
+
+def test_remote_addr():
+    req = Request(testing.create_environ(
+        host='example.com',
+        path='/access_route'))
+
+    assert req.access_route == ['127.0.0.1']
+
+
+def test_remote_addr_missing():
+    env = testing.create_environ(host='example.com', path='/access_route')
+    del env['REMOTE_ADDR']
+
+    req = Request(env)
+    assert req.access_route == []

--- a/tests/test_boundedstream.py
+++ b/tests/test_boundedstream.py
@@ -1,0 +1,17 @@
+import io
+
+import pytest
+
+from falcon.request_helpers import BoundedStream
+
+
+@pytest.fixture
+def bounded_stream():
+    return BoundedStream(io.BytesIO(), 1024)
+
+
+def test_not_writeable(bounded_stream):
+    assert not bounded_stream.writeable()
+
+    with pytest.raises(IOError):
+        bounded_stream.write(b'something something')

--- a/tox.ini
+++ b/tox.ini
@@ -58,6 +58,7 @@ deps = -r{toxinidir}/tools/test-requires
 
 [testenv:py27_debug]
 deps = {[with-debug-tools]deps}
+       funcsigs
 
 [testenv:py34_debug]
 deps = {[with-debug-tools]deps}


### PR DESCRIPTION
* Migrate additional test modules away from the deprecated framework,
  taking care to demonstrate both unittest- and pytest-style testing.
* Add an additional Cookie class and parse cookies in the Result object
  to facilitate cookie testing.
* Extend BoundStream to implement more of the IO protocol so that
  it works with mock WSGI input objects (and potentially improves
  compatibility as a drop-in replacement for the native WSGI input
  object).
* Disable pypy3 testing on Travis, since it uses a buggy cookie impl,
  and also we don't support pypy3 (yet) since overall it isn't fully
  baked.
* Specify latest pypy version for Travis testing, which has improved
  cookie handling.