### PR TITLE
chore(docs): Work around sphinx not always detecting modified *.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -187,4 +187,4 @@ commands = falcon-bench []
 deps = -r{toxinidir}/tools/doc-requires
 whitelist_externals = rm
 commands =
-    sphinx-build -j 2 -ab html docs docs/_build/html
+    sphinx-build -j4 -E -b html docs docs/_build/html


### PR DESCRIPTION
Sometimes sphinx doesn't detect that a module has changed and needs
to be re-autodoc'd. Work around this by just forcing sphinx to
read everything each time.

Also bump up the number of workers to speed things along (reduces the
build time to 8 sec vs. 11 sec. on my MBP).