### PR TITLE
(refactor) Make the title and description optional for most error classes

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -153,7 +153,7 @@ class HTTPUnauthorized(HTTPError):
 
     """
 
-    def __init__(self, title, description, challenges, **kwargs):
+    def __init__(self, title=None, description=None, challenges=None, **kwargs):
         headers = kwargs.setdefault('headers', {})
 
         if challenges:
@@ -219,7 +219,7 @@ class HTTPForbidden(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPForbidden, self).__init__(status.HTTP_403, title,
                                             description, **kwargs)
 
@@ -458,7 +458,7 @@ class HTTPConflict(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPConflict, self).__init__(status.HTTP_409, title,
                                            description, **kwargs)
 
@@ -573,7 +573,7 @@ class HTTPLengthRequired(HTTPError):
             support request or to help them when searching for knowledge
             base articles related to this error (default ``None``).
     """
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPLengthRequired, self).__init__(status.HTTP_411,
                                                  title, description, **kwargs)
 
@@ -626,7 +626,7 @@ class HTTPPreconditionFailed(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPPreconditionFailed, self).__init__(status.HTTP_412, title,
                                                      description, **kwargs)
 
@@ -685,7 +685,7 @@ class HTTPRequestEntityTooLarge(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, retry_after=None, **kwargs):
+    def __init__(self, title=None, description=None, retry_after=None, **kwargs):
         headers = kwargs.setdefault('headers', {})
 
         if isinstance(retry_after, datetime):
@@ -801,7 +801,7 @@ class HTTPUnsupportedMediaType(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, description, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super(HTTPUnsupportedMediaType, self).__init__(
             status.HTTP_415, 'Unsupported media type', description, **kwargs)
 
@@ -884,7 +884,7 @@ class HTTPUnprocessableEntity(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPUnprocessableEntity, self).__init__(status.HTTP_422, title,
                                                       description, **kwargs)
 
@@ -942,7 +942,7 @@ class HTTPTooManyRequests(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, retry_after=None, **kwargs):
+    def __init__(self, title=None, description=None, retry_after=None, **kwargs):
         headers = kwargs.setdefault('headers', {})
 
         if isinstance(retry_after, datetime):
@@ -1014,7 +1014,7 @@ class HTTPUnavailableForLegalReasons(OptionalRepresentation, HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, **kwargs):
+    def __init__(self, title=None, **kwargs):
         super(HTTPUnavailableForLegalReasons, self).__init__(status.HTTP_451,
                                                              title, **kwargs)
 
@@ -1063,7 +1063,7 @@ class HTTPInternalServerError(HTTPError):
 
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPInternalServerError, self).__init__(status.HTTP_500, title,
                                                       description, **kwargs)
 
@@ -1113,7 +1113,7 @@ class HTTPBadGateway(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPBadGateway, self).__init__(status.HTTP_502, title,
                                              description, **kwargs)
 
@@ -1174,7 +1174,7 @@ class HTTPServiceUnavailable(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, retry_after, **kwargs):
+    def __init__(self, title=None, description=None, retry_after=None, **kwargs):
         headers = kwargs.setdefault('headers', {})
 
         if isinstance(retry_after, datetime):
@@ -1275,7 +1275,7 @@ class HTTPMissingHeader(HTTPBadRequest):
     """
 
     def __init__(self, header_name, **kwargs):
-        description = ('The {0} header is required.')
+        description = 'The {0} header is required.'
         description = description.format(header_name)
 
         super(HTTPMissingHeader, self).__init__('Missing header value',

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -88,7 +88,7 @@ class HTTPBadRequest(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, title, description, **kwargs):
+    def __init__(self, title=None, description=None, **kwargs):
         super(HTTPBadRequest, self).__init__(status.HTTP_400, title,
                                              description, **kwargs)
 

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -53,12 +53,10 @@ class HTTPBadRequest(HTTPError):
 
     (See also: RFC 7231, Section 6.5.1)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'TTL Out of Range').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -114,7 +112,7 @@ class HTTPUnauthorized(HTTPError):
 
     (See also: RFC 7235, Section 3.1)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Authentication Required').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
@@ -122,7 +120,6 @@ class HTTPUnauthorized(HTTPError):
             challenges to use as the value of the WWW-Authenticate header in
             the response (see also RFC 7235, Section 2.1).
 
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -184,12 +181,10 @@ class HTTPForbidden(HTTPError):
 
     (See also: RFC 7231, Section 6.5.4)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Permission Denied').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -362,11 +357,9 @@ class HTTPNotAcceptable(HTTPError):
 
     (See also: RFC 7231, Section 6.5.6)
 
-    Args:
+    Keyword Args:
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -396,7 +389,7 @@ class HTTPNotAcceptable(HTTPError):
             base articles related to this error (default ``None``).
     """
 
-    def __init__(self, description, **kwargs):
+    def __init__(self, description=None, **kwargs):
         super(HTTPNotAcceptable, self).__init__(status.HTTP_406,
                                                 'Media type not acceptable',
                                                 description, **kwargs)
@@ -423,12 +416,10 @@ class HTTPConflict(HTTPError):
 
     (See also: RFC 7231, Section 6.5.8)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Editing Conflict').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -539,12 +530,10 @@ class HTTPLengthRequired(HTTPError):
 
     (See also: RFC 7231, Section 6.5.10)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Missing Content-Length').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -591,12 +580,10 @@ class HTTPPreconditionFailed(HTTPError):
 
     (See also: RFC 7232, Section 4.2)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Image Not Modified').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -646,12 +633,12 @@ class HTTPRequestEntityTooLarge(HTTPError):
 
     (See also: RFC 7231, Section 6.5.11)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Request Body Limit Exceeded').
+
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
 
-    Keyword Args:
         retry_after (datetime or int): Value for the Retry-After
             header. If a ``datetime`` object, will serialize as an HTTP date.
             Otherwise, a non-negative ``int`` is expected, representing the
@@ -767,11 +754,9 @@ class HTTPUnsupportedMediaType(HTTPError):
 
     (See also: RFC 7231, Section 6.5.13)
 
-    Args:
+    Keyword Args:
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -849,12 +834,10 @@ class HTTPUnprocessableEntity(HTTPError):
 
     (See also: RFC 4918, Section 11.2)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Missing title field').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -903,12 +886,10 @@ class HTTPTooManyRequests(HTTPError):
 
     (See also: RFC 6585, Section 4)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Too Many Requests').
         description (str): Human-friendly description of the rate limit that
             was exceeded.
-
-    Keyword Args:
         retry_after (datetime or int): Value for the Retry-After
             header. If a ``datetime`` object, will serialize as an HTTP date.
             Otherwise, a non-negative ``int`` is expected, representing the
@@ -979,10 +960,8 @@ class HTTPUnavailableForLegalReasons(OptionalRepresentation, HTTPError):
 
     (See also: RFC 7725, Section 3)
 
-    Args:
-        title (str): Error title (e.g., 'Legal reason: <reason>').
-
     Keyword Args:
+        title (str): Error title (e.g., 'Legal reason: <reason>').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two (default ``None``).
         headers (dict or list): A ``dict`` of header names and values
@@ -1027,12 +1006,10 @@ class HTTPInternalServerError(HTTPError):
 
     (See also: RFC 7231, Section 6.6.1)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'This Should Never Happen').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -1077,13 +1054,11 @@ class HTTPBadGateway(HTTPError):
 
     (See also: RFC 7231, Section 6.6.3)
 
-    Args:
+    Keyword Args:
         title (str): Error title, for
             example: 'Upstream Server is Unavailable'.
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -1135,7 +1110,7 @@ class HTTPServiceUnavailable(HTTPError):
 
     (See also: RFC 7231, Section 6.6.4)
 
-    Args:
+    Keyword Args:
         title (str): Error title (e.g., 'Temporarily Unavailable').
         description (str): Human-friendly description of the error, along with
             a helpful suggestion or two.
@@ -1143,8 +1118,6 @@ class HTTPServiceUnavailable(HTTPError):
             ``datetime`` object, will serialize as an HTTP date. Otherwise,
             a non-negative ``int`` is expected, representing the number of
             seconds to wait.
-
-    Keyword Args:
         headers (dict or list): A ``dict`` of header names and values
             to set, or a ``list`` of (*name*, *value*) tuples. Both *name* and
             *value* must be of type ``str`` or ``StringType``, and only
@@ -1179,7 +1152,7 @@ class HTTPServiceUnavailable(HTTPError):
 
         if isinstance(retry_after, datetime):
             headers['Retry-After'] = util.dt_to_http(retry_after)
-        else:
+        elif retry_after is not None:
             headers['Retry-After'] = str(retry_after)
 
         super(HTTPServiceUnavailable, self).__init__(status.HTTP_503,

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
     cmdclass=cmdclass,
     ext_modules=ext_modules,
     test_suite='nose.collector',
-    tests_require=['nose', 'ddt', 'testtools', 'requests', 'pyyaml'],
+    tests_require=['nose', 'ddt', 'testtools', 'requests', 'pyyaml', 'pytest'],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main',

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -241,7 +241,7 @@ class TestError(testtools.TestCase):
                              'The title should be ' + status.HTTP_502 + ', but it is: ' + e.title)
             self.assertEqual(None, e.description, 'The description should be None')
 
-    def test_http_unprocessable_with_title_and_desc_and_challenges(self):
+    def test_http_bad_gateway_entity_with_title_and_desc_and_challenges(self):
         try:
             raise falcon.HTTPBadGateway(title="Test", description="Testdescription")
         except falcon.HTTPBadGateway as e:

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,247 @@
+import testtools
+import falcon
+import falcon.status_codes as status
+
+
+class TestError(testtools.TestCase):
+    def test_http_bad_request_no_title_and_desc(self):
+        try:
+            raise falcon.HTTPBadRequest()
+        except falcon.HTTPBadRequest as e:
+            self.assertEqual(status.HTTP_400, e.title,
+                             'The title should be ' + status.HTTP_400 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_bad_request_with_title_and_desc(self):
+        try:
+            raise falcon.HTTPBadRequest(title="Test", description="Testdescription")
+        except falcon.HTTPBadRequest as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_unauthorized_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnauthorized()
+        except falcon.HTTPUnauthorized as e:
+            self.assertEqual(status.HTTP_401, e.title,
+                             'The title should be ' + status.HTTP_401 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+            self.assertNotIn('WWW-Authenticate', e.headers, 'Challenges should not be found in headers')
+
+    def test_http_unauthorized_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnauthorized(title="Test", description="Testdescription", challenges=['Testch'])
+        except falcon.HTTPUnauthorized as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testch', e.headers['WWW-Authenticate'], 'Challenges should be None')
+
+    def test_http_forbidden_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPForbidden()
+        except falcon.HTTPForbidden as e:
+            self.assertEqual(status.HTTP_403, e.title,
+                             'The title should be ' + status.HTTP_403 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_forbidden_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPForbidden(title="Test", description="Testdescription")
+        except falcon.HTTPForbidden as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_not_acceptable_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPNotAcceptable()
+        except falcon.HTTPNotAcceptable as e:
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_not_acceptable_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPNotAcceptable(description="Testdescription")
+        except falcon.HTTPNotAcceptable as e:
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_conflict_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPConflict()
+        except falcon.HTTPConflict as e:
+            self.assertEqual(status.HTTP_409, e.title,
+                             'The title should be ' + status.HTTP_409 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_conflict_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPConflict(title="Test", description="Testdescription")
+        except falcon.HTTPConflict as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_length_required_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPLengthRequired()
+        except falcon.HTTPLengthRequired as e:
+            self.assertEqual(status.HTTP_411, e.title,
+                             'The title should be ' + status.HTTP_411 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_length_required_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPLengthRequired(title="Test", description="Testdescription")
+        except falcon.HTTPLengthRequired as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_precondition_failed_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPPreconditionFailed()
+        except falcon.HTTPPreconditionFailed as e:
+            self.assertEqual(status.HTTP_412, e.title,
+                             'The title should be ' + status.HTTP_412 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_precondition_faild_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPPreconditionFailed(title="Test", description="Testdescription")
+        except falcon.HTTPPreconditionFailed as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_request_entity_too_large_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPRequestEntityTooLarge()
+        except falcon.HTTPRequestEntityTooLarge as e:
+            self.assertEqual(status.HTTP_413, e.title,
+                             'The title should be ' + status.HTTP_413 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+            self.assertNotIn('Retry-After', e.headers, 'Retry-After should not be in the headers')
+
+    def test_http_request_entity_too_large_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPRequestEntityTooLarge(title="Test", description="Testdescription", retry_after=123)
+        except falcon.HTTPRequestEntityTooLarge as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
+
+    def test_http_uri_too_long_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUriTooLong()
+        except falcon.HTTPUriTooLong as e:
+            self.assertEqual(status.HTTP_414, e.title,
+                             'The title should be ' + status.HTTP_414 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_uri_too_long_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUriTooLong(title="Test", description="Testdescription")
+        except falcon.HTTPUriTooLong as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_unsupported_media_type_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnsupportedMediaType()
+        except falcon.HTTPUnsupportedMediaType as e:
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_unsupported_media_type_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnsupportedMediaType(description="Testdescription")
+        except falcon.HTTPUnsupportedMediaType as e:
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_unprocessable_entity_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnprocessableEntity()
+        except falcon.HTTPUnprocessableEntity as e:
+            self.assertEqual(status.HTTP_422, e.title,
+                             'The title should be ' + status.HTTP_422 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_unprocessable_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnprocessableEntity(title="Test", description="Testdescription")
+        except falcon.HTTPUnprocessableEntity as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_too_many_requests_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPTooManyRequests()
+        except falcon.HTTPTooManyRequests as e:
+            self.assertEqual(status.HTTP_429, e.title,
+                             'The title should be ' + status.HTTP_429 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+            self.assertNotIn('Retry-After', e.headers, 'Retry-After should not be in the headers')
+
+    def test_http_too_many_requests_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPTooManyRequests(title="Test", description="Testdescription", retry_after=123)
+        except falcon.HTTPTooManyRequests as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
+
+    def test_http_unavailable_for_legal_reasons_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnavailableForLegalReasons()
+        except falcon.HTTPUnavailableForLegalReasons as e:
+            self.assertEqual(status.HTTP_451, e.title,
+                             'The title should be ' + status.HTTP_451 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_unavailable_for_legal_reasons_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPUnavailableForLegalReasons(title="Test", description="Testdescription")
+        except falcon.HTTPUnavailableForLegalReasons as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_internal_server_error_entity_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPInternalServerError()
+        except falcon.HTTPInternalServerError as e:
+            self.assertEqual(status.HTTP_500, e.title,
+                             'The title should be ' + status.HTTP_500 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_internal_server_error_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPInternalServerError(title="Test", description="Testdescription")
+        except falcon.HTTPInternalServerError as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_bad_gateway_entity_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPBadGateway()
+        except falcon.HTTPBadGateway as e:
+            self.assertEqual(status.HTTP_502, e.title,
+                             'The title should be ' + status.HTTP_502 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+
+    def test_http_unprocessable_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPBadGateway(title="Test", description="Testdescription")
+        except falcon.HTTPBadGateway as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+
+    def test_http_service_unavailable_no_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPServiceUnavailable()
+        except falcon.HTTPServiceUnavailable as e:
+            self.assertEqual(status.HTTP_503, e.title,
+                             'The title should be ' + status.HTTP_503 + ', but it is: ' + e.title)
+            self.assertEqual(None, e.description, 'The description should be None')
+            self.assertNotIn('Retry-After', e.headers, 'Retry-After should not be in the headers')
+
+    def test_http_service_unavailable_with_title_and_desc_and_challenges(self):
+        try:
+            raise falcon.HTTPServiceUnavailable(title="Test", description="Testdescription", retry_after=123)
+        except falcon.HTTPServiceUnavailable as e:
+            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -17,7 +17,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPBadRequest(title="Test", description="Testdescription")
         except falcon.HTTPBadRequest as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_unauthorized_no_title_and_desc_and_challenges(self):
         try:
@@ -26,14 +27,17 @@ class TestError(testtools.TestCase):
             self.assertEqual(status.HTTP_401, e.title,
                              'The title should be ' + status.HTTP_401 + ', but it is: ' + e.title)
             self.assertEqual(None, e.description, 'The description should be None')
-            self.assertNotIn('WWW-Authenticate', e.headers, 'Challenges should not be found in headers')
+            self.assertNotIn('WWW-Authenticate', e.headers,
+                             'Challenges should not be found in headers')
 
     def test_http_unauthorized_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnauthorized(title="Test", description="Testdescription", challenges=['Testch'])
+            raise falcon.HTTPUnauthorized(title="Test", description="Testdescription",
+                                          challenges=['Testch'])
         except falcon.HTTPUnauthorized as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
             self.assertEqual('Testch', e.headers['WWW-Authenticate'], 'Challenges should be None')
 
     def test_http_forbidden_no_title_and_desc_and_challenges(self):
@@ -49,7 +53,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPForbidden(title="Test", description="Testdescription")
         except falcon.HTTPForbidden as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_not_acceptable_no_title_and_desc_and_challenges(self):
         try:
@@ -61,7 +66,8 @@ class TestError(testtools.TestCase):
         try:
             raise falcon.HTTPNotAcceptable(description="Testdescription")
         except falcon.HTTPNotAcceptable as e:
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_conflict_no_title_and_desc_and_challenges(self):
         try:
@@ -76,7 +82,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPConflict(title="Test", description="Testdescription")
         except falcon.HTTPConflict as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_length_required_no_title_and_desc_and_challenges(self):
         try:
@@ -91,7 +98,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPLengthRequired(title="Test", description="Testdescription")
         except falcon.HTTPLengthRequired as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_precondition_failed_no_title_and_desc_and_challenges(self):
         try:
@@ -106,7 +114,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPPreconditionFailed(title="Test", description="Testdescription")
         except falcon.HTTPPreconditionFailed as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_request_entity_too_large_no_title_and_desc_and_challenges(self):
         try:
@@ -119,10 +128,12 @@ class TestError(testtools.TestCase):
 
     def test_http_request_entity_too_large_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPRequestEntityTooLarge(title="Test", description="Testdescription", retry_after=123)
+            raise falcon.HTTPRequestEntityTooLarge(title="Test", description="Testdescription",
+                                                   retry_after=123)
         except falcon.HTTPRequestEntityTooLarge as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
 
     def test_http_uri_too_long_no_title_and_desc_and_challenges(self):
@@ -138,7 +149,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPUriTooLong(title="Test", description="Testdescription")
         except falcon.HTTPUriTooLong as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_unsupported_media_type_no_title_and_desc_and_challenges(self):
         try:
@@ -150,7 +162,8 @@ class TestError(testtools.TestCase):
         try:
             raise falcon.HTTPUnsupportedMediaType(description="Testdescription")
         except falcon.HTTPUnsupportedMediaType as e:
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_unprocessable_entity_no_title_and_desc_and_challenges(self):
         try:
@@ -165,7 +178,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPUnprocessableEntity(title="Test", description="Testdescription")
         except falcon.HTTPUnprocessableEntity as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_too_many_requests_no_title_and_desc_and_challenges(self):
         try:
@@ -178,10 +192,12 @@ class TestError(testtools.TestCase):
 
     def test_http_too_many_requests_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPTooManyRequests(title="Test", description="Testdescription", retry_after=123)
+            raise falcon.HTTPTooManyRequests(title="Test", description="Testdescription",
+                                             retry_after=123)
         except falcon.HTTPTooManyRequests as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
 
     def test_http_unavailable_for_legal_reasons_no_title_and_desc_and_challenges(self):
@@ -194,10 +210,12 @@ class TestError(testtools.TestCase):
 
     def test_http_unavailable_for_legal_reasons_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnavailableForLegalReasons(title="Test", description="Testdescription")
+            raise falcon.HTTPUnavailableForLegalReasons(title="Test",
+                                                        description="Testdescription")
         except falcon.HTTPUnavailableForLegalReasons as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_internal_server_error_entity_no_title_and_desc_and_challenges(self):
         try:
@@ -212,7 +230,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPInternalServerError(title="Test", description="Testdescription")
         except falcon.HTTPInternalServerError as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_bad_gateway_entity_no_title_and_desc_and_challenges(self):
         try:
@@ -227,7 +246,8 @@ class TestError(testtools.TestCase):
             raise falcon.HTTPBadGateway(title="Test", description="Testdescription")
         except falcon.HTTPBadGateway as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
 
     def test_http_service_unavailable_no_title_and_desc_and_challenges(self):
         try:
@@ -240,8 +260,10 @@ class TestError(testtools.TestCase):
 
     def test_http_service_unavailable_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPServiceUnavailable(title="Test", description="Testdescription", retry_after=123)
+            raise falcon.HTTPServiceUnavailable(title="Test", description="Testdescription",
+                                                retry_after=123)
         except falcon.HTTPServiceUnavailable as e:
             self.assertEqual("Test", e.title, 'Title should be "Test"')
-            self.assertEqual('Testdescription', e.description, 'Description should be "Testdescription"')
+            self.assertEqual('Testdescription', e.description,
+                             'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -14,9 +14,9 @@ class TestError(testtools.TestCase):
 
     def test_http_bad_request_with_title_and_desc(self):
         try:
-            raise falcon.HTTPBadRequest(title="Test", description="Testdescription")
+            raise falcon.HTTPBadRequest(title='Test', description='Testdescription')
         except falcon.HTTPBadRequest as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -32,10 +32,10 @@ class TestError(testtools.TestCase):
 
     def test_http_unauthorized_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnauthorized(title="Test", description="Testdescription",
+            raise falcon.HTTPUnauthorized(title='Test', description='Testdescription',
                                           challenges=['Testch'])
         except falcon.HTTPUnauthorized as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
             self.assertEqual('Testch', e.headers['WWW-Authenticate'], 'Challenges should be None')
@@ -50,9 +50,9 @@ class TestError(testtools.TestCase):
 
     def test_http_forbidden_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPForbidden(title="Test", description="Testdescription")
+            raise falcon.HTTPForbidden(title='Test', description='Testdescription')
         except falcon.HTTPForbidden as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -64,7 +64,7 @@ class TestError(testtools.TestCase):
 
     def test_http_not_acceptable_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPNotAcceptable(description="Testdescription")
+            raise falcon.HTTPNotAcceptable(description='Testdescription')
         except falcon.HTTPNotAcceptable as e:
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
@@ -79,9 +79,9 @@ class TestError(testtools.TestCase):
 
     def test_http_conflict_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPConflict(title="Test", description="Testdescription")
+            raise falcon.HTTPConflict(title='Test', description='Testdescription')
         except falcon.HTTPConflict as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -95,9 +95,9 @@ class TestError(testtools.TestCase):
 
     def test_http_length_required_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPLengthRequired(title="Test", description="Testdescription")
+            raise falcon.HTTPLengthRequired(title='Test', description='Testdescription')
         except falcon.HTTPLengthRequired as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -111,9 +111,9 @@ class TestError(testtools.TestCase):
 
     def test_http_precondition_faild_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPPreconditionFailed(title="Test", description="Testdescription")
+            raise falcon.HTTPPreconditionFailed(title='Test', description='Testdescription')
         except falcon.HTTPPreconditionFailed as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -128,10 +128,10 @@ class TestError(testtools.TestCase):
 
     def test_http_request_entity_too_large_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPRequestEntityTooLarge(title="Test", description="Testdescription",
+            raise falcon.HTTPRequestEntityTooLarge(title='Test', description='Testdescription',
                                                    retry_after=123)
         except falcon.HTTPRequestEntityTooLarge as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
@@ -146,9 +146,9 @@ class TestError(testtools.TestCase):
 
     def test_http_uri_too_long_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUriTooLong(title="Test", description="Testdescription")
+            raise falcon.HTTPUriTooLong(title='Test', description='Testdescription')
         except falcon.HTTPUriTooLong as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -160,7 +160,7 @@ class TestError(testtools.TestCase):
 
     def test_http_unsupported_media_type_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnsupportedMediaType(description="Testdescription")
+            raise falcon.HTTPUnsupportedMediaType(description='Testdescription')
         except falcon.HTTPUnsupportedMediaType as e:
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
@@ -175,9 +175,9 @@ class TestError(testtools.TestCase):
 
     def test_http_unprocessable_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnprocessableEntity(title="Test", description="Testdescription")
+            raise falcon.HTTPUnprocessableEntity(title='Test', description='Testdescription')
         except falcon.HTTPUnprocessableEntity as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -192,10 +192,10 @@ class TestError(testtools.TestCase):
 
     def test_http_too_many_requests_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPTooManyRequests(title="Test", description="Testdescription",
+            raise falcon.HTTPTooManyRequests(title='Test', description='Testdescription',
                                              retry_after=123)
         except falcon.HTTPTooManyRequests as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')
@@ -210,10 +210,10 @@ class TestError(testtools.TestCase):
 
     def test_http_unavailable_for_legal_reasons_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPUnavailableForLegalReasons(title="Test",
-                                                        description="Testdescription")
+            raise falcon.HTTPUnavailableForLegalReasons(title='Test',
+                                                        description='Testdescription')
         except falcon.HTTPUnavailableForLegalReasons as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -227,9 +227,9 @@ class TestError(testtools.TestCase):
 
     def test_http_internal_server_error_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPInternalServerError(title="Test", description="Testdescription")
+            raise falcon.HTTPInternalServerError(title='Test', description='Testdescription')
         except falcon.HTTPInternalServerError as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -243,9 +243,9 @@ class TestError(testtools.TestCase):
 
     def test_http_bad_gateway_entity_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPBadGateway(title="Test", description="Testdescription")
+            raise falcon.HTTPBadGateway(title='Test', description='Testdescription')
         except falcon.HTTPBadGateway as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
 
@@ -260,10 +260,10 @@ class TestError(testtools.TestCase):
 
     def test_http_service_unavailable_with_title_and_desc_and_challenges(self):
         try:
-            raise falcon.HTTPServiceUnavailable(title="Test", description="Testdescription",
+            raise falcon.HTTPServiceUnavailable(title='Test', description='Testdescription',
                                                 retry_after=123)
         except falcon.HTTPServiceUnavailable as e:
-            self.assertEqual("Test", e.title, 'Title should be "Test"')
+            self.assertEqual('Test', e.title, 'Title should be "Test"')
             self.assertEqual('Testdescription', e.description,
                              'Description should be "Testdescription"')
             self.assertEqual('123', e.headers['Retry-After'], 'Retry-After should be 123')


### PR DESCRIPTION
The changes should cause no breaks, however as I ran the tests some of the tests failed, but the problem was with the Wrapper and some module imports