### PR TITLE
fix: Use inspect.signature on py3k instead of inspect.getargspec

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -14,7 +14,6 @@
 
 """Falcon API class."""
 
-import inspect
 import re
 
 import six
@@ -26,6 +25,7 @@ from falcon.request import Request, RequestOptions
 import falcon.responders
 from falcon.response import Response
 import falcon.status_codes as status
+from falcon.util.misc import get_argnames
 
 
 class API(object):
@@ -475,8 +475,9 @@ class API(object):
 
         """
 
-        if len(inspect.getargspec(serializer).args) == 2:
+        if len(get_argnames(serializer)) == 2:
             serializer = helpers.wrap_old_error_serializer(serializer)
+
         self._serialize_error = serializer
 
     # ------------------------------------------------------------------------

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -15,7 +15,6 @@
 """Utilities for the API class."""
 
 from functools import wraps
-import inspect
 
 from falcon import util
 
@@ -55,9 +54,9 @@ def prepare_middleware(middleware=None):
         if process_response:
             # NOTE(kgriffs): Shim older implementations to ensure
             # backwards-compatibility.
-            spec = inspect.getargspec(process_response)
+            args = util.get_argnames(process_response)
 
-            if len(spec.args) == 4:  # (self, req, resp, resource)
+            if len(args) == 3:  # (req, resp, resource)
                 def let(process_response=process_response):
                     @wraps(process_response)
                     def shim(req, resp, resource, req_succeeded):

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -14,13 +14,12 @@
 
 """Hook decorators."""
 
-import functools
 from functools import wraps
-import inspect
 
 import six
 
 from falcon import HTTP_METHODS
+from falcon.util.misc import get_argnames
 
 
 def before(action):
@@ -136,28 +135,6 @@ def after(action):
 # -----------------------------------------------------------------------------
 
 
-def _has_resource_arg(action):
-    """Check if the given action function accepts a resource arg."""
-
-    if isinstance(action, functools.partial):
-        # NOTE(kgriffs): We special-case this, since versions of
-        # Python prior to 3.4 raise an error when trying to get the
-        # spec for a partial.
-        spec = inspect.getargspec(action.func)
-
-    elif inspect.isroutine(action):
-        # NOTE(kgriffs): We have to distinguish between instances of a
-        # callable class vs. a routine, since Python versions prior to
-        # 3.4 raise an error when trying to get the spec from
-        # a callable class instance.
-        spec = inspect.getargspec(action)
-
-    else:
-        spec = inspect.getargspec(action.__call__)
-
-    return 'resource' in spec.args
-
-
 def _wrap_with_after(action, responder):
     """Execute the given action function after a responder method.
 
@@ -169,7 +146,7 @@ def _wrap_with_after(action, responder):
 
     # NOTE(swistakm): create shim before checking what will be actually
     # decorated. This helps to avoid excessive nesting
-    if _has_resource_arg(action):
+    if 'resource' in get_argnames(action):
         shim = action
     else:
         # TODO(kgriffs): This decorator does not work on callable
@@ -198,7 +175,7 @@ def _wrap_with_before(action, responder):
 
     # NOTE(swistakm): create shim before checking what will be actually
     # decorated. This allows to avoid excessive nesting
-    if _has_resource_arg(action):
+    if 'resource' in get_argnames(action):
         shim = action
     else:
         # TODO(kgriffs): This decorator does not work on callable


### PR DESCRIPTION
[Note: merge before cutting 1.1rc1]

inspect.getargspec() is deprecated under py3k, and among other things
does not work for annotated functions. Use inspect.signature instead.

Fixes #911