### PR TITLE
chore: Use pytest runner instead of nose collector for "setup.py test"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 dist
 build
 eggs
+.eggs
 parts
 var
 sdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,9 @@ tag_build = b1
 
 [wheel]
 universal = 1
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+addopts = tests

--- a/setup.py
+++ b/setup.py
@@ -104,11 +104,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIRES,
-    setup_requires=[],
+    setup_requires=['pytest-runner'],
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    test_suite='nose.collector',
-    tests_require=['nose', 'ddt', 'testtools', 'requests', 'pyyaml', 'pytest'],
+    tests_require=['ddt', 'testtools', 'requests', 'pyyaml', 'pytest'],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main',


### PR DESCRIPTION
See also: http://docs.pytest.org/en/latest/goodpractices.html?highlight=setup#integrating-with-setuptools-python-setup-py-test-pytest-runner