### PR TITLE
doc(API): Set 'Vary' header in set_error_serializer example, cross-link

### DIFF
--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -31,6 +31,10 @@ All classes are available directly from the `falcon` package namespace::
 
             # ...
 
+The default error serializer supports JSON and XML. You can override the
+default serializer by passing a callable to the :class:`~.API` method,
+:meth:`~.API.set_error_serializer`.
+
 Base Class
 ----------
 

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -459,6 +459,8 @@ class API(object):
                     resp.body = representation
                     resp.content_type = preferred
 
+                resp.append_header('Vary', 'Accept')
+
         Note:
             If a custom media type is used and the type includes a
             "+json" or "+xml" suffix, the default serializer will

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -28,9 +28,19 @@ from falcon.util import uri
 class HTTPError(Exception):
     """Represents a generic HTTP error.
 
-    Raise this or a child class to have Falcon automagically return pretty
-    error responses (with an appropriate HTTP status code) to the client
-    when something goes wrong.
+    Raise an instance or subclass of ``HTTPError`` to have Falcon return
+    a formatted error response and an appropriate HTTP status code
+    to the client when something goes wrong. JSON and XML media types
+    are supported by default.
+
+    To customize the error presentation, implement a custom error
+    serializer and set it on the :class:`~.API` instance via
+    :meth:`~.API.set_error_serializer`.
+
+    To customize what data is passed to the serializer, subclass
+    ``HTTPError`` and override the ``to_dict()`` method (``to_json()``
+    is implemented via ``to_dict()``). To also support XML, override
+    the ``to_xml()`` method.
 
     Attributes:
         status (str): HTTP status line, e.g. '748 Confounded by Ponies'.


### PR DESCRIPTION
The set_error_serializer() example should demonstrate setting the
'Vary' header, since the response does vary depending on the
'Accept' header in the request.

Also, cross-link set_error_serializer() from the errors page.