### PR TITLE
Remove unnecessary content-length

### DIFF
--- a/falcon/responders.py
+++ b/falcon/responders.py
@@ -58,6 +58,5 @@ def create_default_options(allowed_methods):
     def on_options(req, resp, **kwargs):
         resp.status = HTTP_204
         resp.set_header('Allow', allowed)
-        resp.set_header('Content-Length', '0')
 
     return on_options


### PR DESCRIPTION
The 204 response MUST NOT include a message-body, thus should be no content-length.