### PR TITLE
Move pytest-runner to tests_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,10 +104,10 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIRES,
-    setup_requires=['pytest-runner'],
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    tests_require=['ddt', 'testtools', 'requests', 'pyyaml', 'pytest'],
+    tests_require=['ddt', 'testtools', 'requests', 'pyyaml', 'pytest',
+                   'pytest-runner'],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main',


### PR DESCRIPTION
pytest-runner is not needed unless doing python setup.py test. Thus it's better to move it to the right place.

This patch is not tested yet. Because I'm trying to build falcon for a old CentOS 6 system. Please consider this change.