### PR TITLE
fix: strip whitespaces when parsing cookie in tests

### DIFF
--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -106,7 +106,7 @@ class Result(object):
                 cookies.load(value)
 
                 if _PY26 or (_PY27 and _JYTHON):
-                    match = re.match('([^=]+)=', value)
+                    match = re.match('\s*([^=;,]+)=', value)
                     assert match
 
                     cookie_name = match.group(1)


### PR DESCRIPTION
Currently, ' foo=bar' is parsed as ' foo' being the cookie_name in the tests.