### PR TITLE
chore: Update test environments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,7 @@
 branch = True
 source = falcon
 omit = falcon/tests*,falcon/cmd*,falcon/bench*
+
+
+[report]
+show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,11 @@ cache:
 
 matrix:
     include:
-        - python: 2.7  # these are just to make travis's UI a bit prettier
+        - python: 2.7
           env: JYTHON=true
-        - python: pypy-5.3
+        - python: pypy-5.4
           env: TOXENV=pypy
+        # TODO(kgriffs): Uncomment when pypy3 is more mature
         # - python: pypy3
         #   env: TOXENV=pypy3
         - python: 2.7
@@ -19,6 +20,8 @@ matrix:
           env: TOXENV=py26
         - python: 2.7
           env: TOXENV=py27
+        - python: 2.7
+          env: TOXENV=py27_ujson
         - python: 2.7
           env: TOXENV=py27_smoke
         - python: 2.7
@@ -35,6 +38,8 @@ matrix:
           env: TOXENV=py34_cython
         - python: 3.5
           env: TOXENV=py35
+        - python: 3.5
+          env: TOXENV=py35_ujson
         - python: 3.5
           env: TOXENV=py35_cython
         - python: 2.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ $ ~/jython/bin/pytest tests
 Pull requests must maintain 100% test coverage of all code branches. This helps ensure the quality of the Falcon framework. To check coverage before submitting a pull request:
 
 ```bash
-$ tox -e py26,py27,py34 && tools/combine_coverage.sh
+$ tox -e py26,py27,py35 && tools/combine_coverage.sh
 ```
 
 It is necessary to combine test coverage from all three of these environments in order to account for branches in the code that are only taken for a given Python version.

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-# NOTE(kgriffs): The py26, py27, and py34 envs are required when
+# NOTE(kgriffs): The py26, py27, and py35 envs are required when
 # checking combined coverage. To check coverage:
 #
-#   $ tox -e py26,py27,py34 && tools/combine_coverage.sh
+#   $ tox -e py26,py27,py35 && tools/combine_coverage.sh
 #
 # You can then drill down into coverage details by opening the HTML
 # report at ".coverage_html/index.html".
@@ -42,7 +42,7 @@ deps = {[testenv]deps}
 whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
-[testenv:py34]
+[testenv:py35]
 deps = {[testenv]deps}
        pytest-randomly
 whitelist_externals = {[with-coverage]whitelist_externals}
@@ -57,12 +57,29 @@ deps = -r{toxinidir}/tools/test-requires
        pdbpp
 
 [testenv:py27_debug]
+basepython = python2.7
 deps = {[with-debug-tools]deps}
        funcsigs
 
-[testenv:py34_debug]
-basepython = python3.4
+[testenv:py35_debug]
+basepython = python3.5
 deps = {[with-debug-tools]deps}
+
+# --------------------------------------------------------------------
+# Cython
+# --------------------------------------------------------------------
+
+[with-ujson]
+deps = -r{toxinidir}/tools/test-requires
+       ujson
+
+[testenv:py27_ujson]
+basepython = python2.7
+deps = {[with-ujson]deps}
+
+[testenv:py35_ujson]
+basepython = python3.5
+deps = {[with-ujson]deps}
 
 # --------------------------------------------------------------------
 # Cython
@@ -73,15 +90,19 @@ deps = -r{toxinidir}/tools/test-requires
        cython
 
 [testenv:py27_cython]
+basepython = python2.7
 deps = {[with-cython]deps}
 
 [testenv:py33_cython]
+basepython = python3.3
 deps = {[with-cython]deps}
 
 [testenv:py34_cython]
+basepython = python3.4
 deps = {[with-cython]deps}
 
 [testenv:py35_cython]
+basepython = python3.5
 deps = {[with-cython]deps}
 
 # --------------------------------------------------------------------
@@ -93,11 +114,13 @@ commands = falcon-bench -t 1 -b falcon-ext
 
 [testenv:py27_smoke]
 # This test smoke-tests a basic Falcon app
+basepython = python2.7
 deps = -r{toxinidir}/tools/bench-requires
 commands = {[smoke-test]commands}
 
 [testenv:py27_smoke_cython]
 # This test ensures that a falcon app will run fine under Cython
+basepython = python2.7
 deps = -r{toxinidir}/tools/bench-requires
        cython
 commands = {[smoke-test]commands}
@@ -107,6 +130,7 @@ commands = {[smoke-test]commands}
 # --------------------------------------------------------------------
 
 [testenv:py3kwarn]
+basepython = python2.7
 deps = py3kwarn
 commands = py3kwarn falcon
 
@@ -135,14 +159,17 @@ commands = flake8 \
 # --------------------------------------------------------------------
 
 [testenv:py27_dump_uwsgi]
+basepython = python2.7
 deps = uwsgi
 commands = uwsgi --http localhost:8000 --wsgi-file {toxinidir}/tests/dump_wsgi.py
 
 [testenv:py27_dump_gunicorn]
+basepython = python2.7
 deps = gunicorn
 commands = gunicorn: gunicorn -b localhost:8000 tests.dump_wsgi
 
 [testenv:py27_dump_wsgiref]
+basepython = python2.7
 commands = python tests/dump_wsgi.py
 
 [testenv:py35_dump_wsgiref]
@@ -155,57 +182,70 @@ commands = python tests/dump_wsgi.py
 # --------------------------------------------------------------------
 
 [testenv:py26_bench]
+basepython = python2.6
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
 [testenv:py27_bench]
+basepython = python2.7
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
 [testenv:py27_bench_cython]
+basepython = python2.7
 deps = -r{toxinidir}/tools/bench-requires
        cython
 commands = falcon-bench []
 
 [testenv:py33_bench]
+basepython = python3.3
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
 [testenv:py33_bench_cython]
+basepython = python3.3
 deps = -r{toxinidir}/tools/bench-requires
        cython
 commands = falcon-bench []
 
 [testenv:py34_bench]
+basepython = python3.4
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
 [testenv:py34_bench_cython]
+basepython = python3.4
 deps = -r{toxinidir}/tools/bench-requires
        cython
 commands = falcon-bench []
 
 [testenv:py35_bench]
+basepython = python3.5
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
 [testenv:py35_bench_cython]
+basepython = python3.5
 deps = -r{toxinidir}/tools/bench-requires
        cython
 commands = falcon-bench []
 
 [testenv:pypy_bench]
+basepython = pypy
 deps = -r{toxinidir}/tools/bench-requires
 commands = falcon-bench []
 
-[testenv:pypy3_bench]
-deps = -r{toxinidir}/tools/bench-requires
-commands = falcon-bench []
+# TODO(kgriffs): Uncomment when pypy3 is more mature
+; [testenv:pypy3_bench]
+; basepython = pypy3
+; deps = -r{toxinidir}/tools/bench-requires
+; commands = falcon-bench []
 
 # --------------------------------------------------------------------
 # Documentation
 # --------------------------------------------------------------------
 [testenv:docs]
+basepython = python2.7
 deps = -r{toxinidir}/tools/doc-requires
 whitelist_externals = rm
 commands =


### PR DESCRIPTION
Do the following:

    * Use python 3.5 in lieu of 3.4 as the "default" py3k version.
    * Explicitly set basepython for all environments so the right
      version is used outside of travis.
    * Show missing lines when test coverage fails
    * Add ujson test environments to check