### PR TITLE
feat(Request): Add an option to keep a trailing slash in the request path (#966)

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -327,7 +327,8 @@ class Request(object):
                 # "bytes tunneled as latin-1" and must be encoded back
                 path = path.encode('latin1').decode('utf-8', 'replace')
 
-            if len(path) != 1 and path.endswith('/'):
+            if (self.options.strip_url_path_trailing_slash and
+                    len(path) != 1 and path.endswith('/')):
                 self.path = path[:-1]
             else:
                 self.path = path
@@ -1283,6 +1284,7 @@ class RequestOptions(object):
             For comma-separated values, this option also determines
             whether or not empty elements in the parsed list are
             retained.
+
         auto_parse_form_urlencoded: Set to ``True`` in order to
             automatically consume the request stream and merge the
             results into the request's query string params when the
@@ -1308,14 +1310,23 @@ class RequestOptions(object):
             occurrences of the same parameter, and when values may be
             encoded in alternative formats in which the comma character
             is significant.
+
+        strip_url_path_trailing_slash: Set to ``False`` in order to retain
+            a trailing slash, if exists, at the end of the url path
+            (default ``True``). When this option is enabled, such a
+            trailing slash, if exists, is stripped when normalizing the
+            url path.
+
     """
     __slots__ = (
         'keep_blank_qs_values',
         'auto_parse_form_urlencoded',
         'auto_parse_qs_csv',
+        'strip_url_path_trailing_slash',
     )
 
     def __init__(self):
         self.keep_blank_qs_values = False
         self.auto_parse_form_urlencoded = False
         self.auto_parse_qs_csv = True
+        self.strip_url_path_trailing_slash = True

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -13,11 +13,13 @@ class TestRequestOptions(testing.TestBase):
         self.assertFalse(options.keep_blank_qs_values)
         self.assertFalse(options.auto_parse_form_urlencoded)
         self.assertTrue(options.auto_parse_qs_csv)
+        self.assertTrue(options.strip_url_path_trailing_slash)
 
     @ddt.data(
         'keep_blank_qs_values',
         'auto_parse_form_urlencoded',
         'auto_parse_qs_csv',
+        'strip_url_path_trailing_slash',
     )
     def test_options_toggle(self, option_name):
         options = RequestOptions()

--- a/tests/test_req_vars.py
+++ b/tests/test_req_vars.py
@@ -5,7 +5,7 @@ import six
 import testtools
 
 import falcon
-from falcon.request import Request
+from falcon.request import Request, RequestOptions
 import falcon.testing as testing
 import falcon.uri
 
@@ -268,6 +268,16 @@ class TestReqVars(testing.TestBase):
         # NOTE(kgriffs): Call twice to check caching works
         self.assertEqual(req_noapp.relative_uri, self.relative_uri)
         self.assertEqual(req_noapp.relative_uri, self.relative_uri)
+
+        options = RequestOptions()
+        options.strip_url_path_trailing_slash = False
+        req_noapp = Request(testing.create_environ(
+            path='/hello/',
+            query_string=self.qs,
+            headers=self.headers),
+            options=options)
+
+        self.assertEqual(req_noapp.relative_uri, '/hello/' + '?' + self.qs)
 
     def test_client_accepts(self):
         headers = {'Accept': 'application/xml'}


### PR DESCRIPTION
Option strip_url_path_trailing_slash allows keeping a trailing slash, if
exists, at the end of the request url path when normalizing it.
The default conforms to the previous behavior, in which such a trailing
slash is stripped, in order to avoid introducing any breaking changes.