### PR TITLE
doc: Don't use a fixed sidebar to better accomodate small screens

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -14,6 +14,10 @@
     display: none;
 }
 
+#logo {
+    position: relative;
+}
+
 #logo a,
 #logo a:hover {
     border-bottom: none;
@@ -32,12 +36,12 @@
     font-family: "Amethysta", "goudy old style", serif;
     font-weight: bold;
 
-    font-size: 18pt;
+    font-size: 16pt;
     color: #444;
     position: absolute;
 
-    left: 9px;
-    top: 2px;
+    left: 10px;
+    top: -14px;
     /*margin: -4px -4px 0 0;*/
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -152,7 +152,7 @@ html_theme_options = {
     'github_repo': 'falcon',
     'github_button': False,
     'github_banner': True,
-    'fixed_sidebar': True,
+    'fixed_sidebar': False,
     'show_powered_by': False,
     'extra_nav_links': {
       'Falcon Home': 'http://falconframework.org/',


### PR DESCRIPTION
When the sidebar is too tall for the browser window, the user can
not scroll down to view the bottom of the sidebar when it is fixed.

Fixes #970