### PR TITLE
fix(API): Normalize response status to type str under py27

### DIFF
--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -40,7 +40,9 @@ class TestStatusResource:
 
     @falcon.after(after_hook)
     def on_put(self, req, resp):
-        resp.status = falcon.HTTP_500
+        # NOTE(kgriffs): Test that passing a unicode status string
+        # works just fine.
+        resp.status = u'500 Internal Server Error'
         resp.set_header('X-Failed', 'True')
         resp.body = 'Fail'
 


### PR DESCRIPTION
While not specified in the spec that the status must be of type str
(not unicode on Py27), some WSGI servers can complain when it is not.