### PR TITLE
feat(API): add support for routing on full request

### DIFF
--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -23,16 +23,24 @@ A custom router is any class that implements the following interface:
                     will handle requests for the given URI.
             """
 
-        def find(self, uri):
+        def find(self, uri, req=None):
             """Search for a route that matches the given partial URI.
 
             Args:
                 uri(str): The requested path to route
 
+            Keyword Args:
+                req(Request): The Request object that will be passed to the
+                    routed responder
+
             Returns:
                 tuple: A 4-member tuple composed of (resource, method_map,
                     params, uri_template), or ``None`` if no route matches
                     the requested path
+
+            Note:
+                The `req` keyword argument was added in version 1.2, but routers
+                which do not implement the interface are still supported.
             """
 
 A custom routing engine may be specified when instantiating

--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -12,6 +12,9 @@ class TestCustomRouter(testing.TestBase):
             def add_route(self, uri_template, *args, **kwargs):
                 check.append(uri_template)
 
+            def find(self, uri):
+                pass
+
         api = falcon.API(router=CustomRouter())
         api.add_route('/test', 'resource')
 
@@ -70,6 +73,9 @@ class TestCustomRouter(testing.TestBase):
                 self._index = {name: uri_template}
                 check.append(name)
 
+            def find(self, uri):
+                pass
+
         api = falcon.API(router=CustomRouter())
         api.add_route('/test', 'resource', name='my-url-name')
 
@@ -81,3 +87,31 @@ class TestCustomRouter(testing.TestBase):
 
         self.assertEqual(len(check), 2)
         self.assertIn('my-url-name-arg', check)
+
+    def test_custom_router_takes_req_positional_argument(self):
+        def responder(req, resp):
+            resp.body = 'OK'
+
+        class CustomRouter(object):
+            def find(self, uri, req):
+                if uri == '/test' and isinstance(req, falcon.Request):
+                    return responder, {'GET': responder}, {}, None
+
+        router = CustomRouter()
+        self.api = falcon.API(router=router)
+        body = self.simulate_request('/test')
+        self.assertEqual(body[0], b'OK')
+
+    def test_custom_router_takes_req_keyword_argument(self):
+        def responder(req, resp):
+            resp.body = 'OK'
+
+        class CustomRouter(object):
+            def find(self, uri, req=None):
+                if uri == '/test' and isinstance(req, falcon.Request):
+                    return responder, {'GET': responder}, {}, None
+
+        router = CustomRouter()
+        self.api = falcon.API(router=router)
+        body = self.simulate_request('/test')
+        self.assertEqual(body[0], b'OK')


### PR DESCRIPTION
This change allows the `find` method of a custom router to accept a `req` keyword argument to which a request instance is passed.