### PR TITLE
test: Migrate URI template and router testing to pytest

### DIFF
--- a/falcon/testing/resource.py
+++ b/falcon/testing/resource.py
@@ -89,6 +89,7 @@ class SimpleTestResource(object):
             responses
 
     Attributes:
+        called (bool): Whether or not a req/resp was captured.
         captured_req (falcon.Request): The last Request object passed
             into any one of the responder methods.
         captured_resp (falcon.Response): The last Response object passed
@@ -115,6 +116,10 @@ class SimpleTestResource(object):
         self.captured_req = None
         self.captured_resp = None
         self.captured_kwargs = None
+
+    @property
+    def called(self):
+        return self.captured_req is not None
 
     @falcon.before(capture_responder_args)
     @falcon.before(set_resp_defaults)

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -1,7 +1,92 @@
-import ddt
+import pytest
 
+import falcon
+from falcon import testing
 from falcon.routing import DefaultRouter
-import falcon.testing as testing
+
+
+@pytest.fixture
+def client():
+    return testing.TestClient(falcon.API())
+
+
+@pytest.fixture
+def router():
+    router = DefaultRouter()
+
+    router.add_route(
+        '/repos', {}, ResourceWithId(1))
+    router.add_route(
+        '/repos/{org}', {}, ResourceWithId(2))
+    router.add_route(
+        '/repos/{org}/{repo}', {}, ResourceWithId(3))
+    router.add_route(
+        '/repos/{org}/{repo}/commits', {}, ResourceWithId(4))
+    router.add_route(
+        u'/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
+        {}, ResourceWithId(5))
+
+    router.add_route(
+        '/teams/{id}', {}, ResourceWithId(6))
+    router.add_route(
+        '/teams/{id}/members', {}, ResourceWithId(7))
+
+    router.add_route(
+        '/teams/default', {}, ResourceWithId(19))
+    router.add_route(
+        '/teams/default/members/thing', {}, ResourceWithId(19))
+
+    router.add_route(
+        '/user/memberships', {}, ResourceWithId(8))
+    router.add_route(
+        '/emojis', {}, ResourceWithId(9))
+    router.add_route(
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
+        {}, ResourceWithId(10))
+    router.add_route(
+        '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
+
+    # NOTE(kgriffs): The ordering of these calls is significant; we
+    # need to test that the {id} field does not match the other routes,
+    # regardless of the order they are added.
+    router.add_route(
+        '/emojis/signs/0', {}, ResourceWithId(12))
+    router.add_route(
+        '/emojis/signs/{id}', {}, ResourceWithId(13))
+    router.add_route(
+        '/emojis/signs/42', {}, ResourceWithId(14))
+    router.add_route(
+        '/emojis/signs/42/small.jpg', {}, ResourceWithId(23))
+    router.add_route(
+        '/emojis/signs/78/small.png', {}, ResourceWithId(24))
+
+    # Test some more special chars
+    router.add_route(
+        '/emojis/signs/78/small(png)', {}, ResourceWithId(25))
+    router.add_route(
+        '/emojis/signs/78/small_png', {}, ResourceWithId(26))
+    router.add_route('/images/{id}.gif', {}, ResourceWithId(27))
+
+    router.add_route(
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
+        {}, ResourceWithId(15))
+    router.add_route(
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
+        {}, ResourceWithId(16))
+    router.add_route(
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
+        {}, ResourceWithId(17))
+
+    router.add_route(
+        '/gists/{id}/{representation}', {}, ResourceWithId(21))
+    router.add_route(
+        '/gists/{id}/raw', {}, ResourceWithId(18))
+    router.add_route(
+        '/gists/first', {}, ResourceWithId(20))
+
+    router.add_route('/item/{q}', {}, ResourceWithId(28))
+
+    return router
 
 
 class ResourceWithId(object):
@@ -15,308 +100,303 @@ class ResourceWithId(object):
         resp.body = self.resource_id
 
 
-class TestRegressionCases(testing.TestBase):
-    """Test specific repros reported by users of the framework."""
-
-    def before(self):
-        self.router = DefaultRouter()
-
-    def test_versioned_url(self):
-        self.router.add_route('/{version}/messages', {}, ResourceWithId(2))
-
-        resource, __, __, __ = self.router.find('/v2/messages')
-        self.assertEqual(resource.resource_id, 2)
-
-        self.router.add_route('/v2', {}, ResourceWithId(1))
-
-        resource, __, __, __ = self.router.find('/v2')
-        self.assertEqual(resource.resource_id, 1)
-
-        resource, __, __, __ = self.router.find('/v2/messages')
-        self.assertEqual(resource.resource_id, 2)
-
-        resource, __, __, __ = self.router.find('/v1/messages')
-        self.assertEqual(resource.resource_id, 2)
-
-        route = self.router.find('/v1')
-        self.assertIs(route, None)
-
-    def test_recipes(self):
-        self.router.add_route(
-            '/recipes/{activity}/{type_id}', {}, ResourceWithId(1))
-        self.router.add_route(
-            '/recipes/baking', {}, ResourceWithId(2))
-
-        resource, __, __, __ = self.router.find('/recipes/baking/4242')
-        self.assertEqual(resource.resource_id, 1)
-
-        resource, __, __, __ = self.router.find('/recipes/baking')
-        self.assertEqual(resource.resource_id, 2)
-
-        route = self.router.find('/recipes/grilling')
-        self.assertIs(route, None)
+# =====================================================================
+# Regression tests for use cases reported by users
+# =====================================================================
 
 
-@ddt.ddt
-class TestComplexRouting(testing.TestBase):
-    def before(self):
-        self.router = DefaultRouter()
+def test_regression_versioned_url():
+    router = DefaultRouter()
+    router.add_route('/{version}/messages', {}, ResourceWithId(2))
 
-        self.router.add_route(
-            '/repos', {}, ResourceWithId(1))
-        self.router.add_route(
-            '/repos/{org}', {}, ResourceWithId(2))
-        self.router.add_route(
-            '/repos/{org}/{repo}', {}, ResourceWithId(3))
-        self.router.add_route(
-            '/repos/{org}/{repo}/commits', {}, ResourceWithId(4))
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
-            {}, ResourceWithId(5))
+    resource, __, __, __ = router.find('/v2/messages')
+    assert resource.resource_id == 2
 
-        self.router.add_route(
-            '/teams/{id}', {}, ResourceWithId(6))
-        self.router.add_route(
-            '/teams/{id}/members', {}, ResourceWithId(7))
+    router.add_route('/v2', {}, ResourceWithId(1))
 
-        self.router.add_route(
-            '/teams/default', {}, ResourceWithId(19))
-        self.router.add_route(
-            '/teams/default/members/thing', {}, ResourceWithId(19))
+    resource, __, __, __ = router.find('/v2')
+    assert resource.resource_id == 1
 
-        self.router.add_route(
-            '/user/memberships', {}, ResourceWithId(8))
-        self.router.add_route(
-            '/emojis', {}, ResourceWithId(9))
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
-            {}, ResourceWithId(10))
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
+    resource, __, __, __ = router.find('/v2/messages')
+    assert resource.resource_id == 2
 
-        # NOTE(kgriffs): The ordering of these calls is significant; we
-        # need to test that the {id} field does not match the other routes,
-        # regardless of the order they are added.
-        self.router.add_route(
-            '/emojis/signs/0', {}, ResourceWithId(12))
-        self.router.add_route(
-            '/emojis/signs/{id}', {}, ResourceWithId(13))
-        self.router.add_route(
-            '/emojis/signs/42', {}, ResourceWithId(14))
-        self.router.add_route(
-            '/emojis/signs/42/small', {}, ResourceWithId(14.1))
-        self.router.add_route(
-            '/emojis/signs/78/small', {}, ResourceWithId(22))
+    resource, __, __, __ = router.find('/v1/messages')
+    assert resource.resource_id == 2
 
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
-            {}, ResourceWithId(15))
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
-            {}, ResourceWithId(16))
-        self.router.add_route(
-            '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
-            {}, ResourceWithId(17))
+    route = router.find('/v1')
+    assert route is None
 
-        self.router.add_route(
-            '/gists/{id}/{representation}', {}, ResourceWithId(21))
-        self.router.add_route(
-            '/gists/{id}/raw', {}, ResourceWithId(18))
-        self.router.add_route(
-            '/gists/first', {}, ResourceWithId(20))
 
-        self.router.add_route('/item/{q}', {}, ResourceWithId(22))
+def test_regression_case_recipes():
+    router = DefaultRouter()
+    router.add_route(
+        '/recipes/{activity}/{type_id}', {}, ResourceWithId(1))
+    router.add_route(
+        '/recipes/baking', {}, ResourceWithId(2))
 
-    @ddt.data(
-        '/teams/{collision}',  # simple vs simple
-        '/emojis/signs/{id_too}',  # another simple vs simple
-        '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}:{collision}',
-    )
-    def test_collision(self, template):
-        self.assertRaises(
-            ValueError,
-            self.router.add_route, template, {}, ResourceWithId(-1)
-        )
+    resource, __, __, __ = router.find('/recipes/baking/4242')
+    assert resource.resource_id == 1
 
-    @ddt.data(
-        '/repos/{org}/{repo}/compare/{simple_vs_complex}',
-        '/repos/{complex}.{vs}.{simple}',
-        '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}/full',
-    )
-    def test_non_collision(self, template):
-        self.router.add_route(template, {}, ResourceWithId(-1))
+    resource, __, __, __ = router.find('/recipes/baking')
+    assert resource.resource_id == 2
 
-    @ddt.data(
-        '/{}',
-        '/{9v}',
-        '/{@kgriffs}',
-        '/repos/{simple-thing}/etc',
-        '/repos/{or g}/{repo}/compare/{thing}',
-        '/repos/{org}/{repo}/compare/{}',
-        '/repos/{complex}.{}.{thing}',
-        '/repos/{complex}.{9v}.{thing}/etc',
-    )
-    def test_invalid_field_name(self, template):
-        self.assertRaises(
-            ValueError,
-            self.router.add_route, template, {}, ResourceWithId(-1))
+    route = router.find('/recipes/grilling')
+    assert route is None
 
-    def test_dump(self):
-        print(self.router._src)
 
-    def test_override(self):
-        self.router.add_route('/emojis/signs/0', {}, ResourceWithId(-1))
+# =====================================================================
+# Other tests
+# =====================================================================
 
-        resource, __, __, __ = self.router.find('/emojis/signs/0')
-        self.assertEqual(resource.resource_id, -1)
 
-    def test_literal_segment(self):
-        resource, __, __, __ = self.router.find('/emojis/signs/0')
-        self.assertEqual(resource.resource_id, 12)
+@pytest.mark.parametrize('uri_template', [
+    {},
+    set(),
+    object()
+])
+def test_not_str(uri_template):
+    app = falcon.API()
+    with pytest.raises(TypeError):
+        app.add_route(uri_template, ResourceWithId(-1))
 
-        resource, __, __, __ = self.router.find('/emojis/signs/1')
-        self.assertEqual(resource.resource_id, 13)
 
-        resource, __, __, __ = self.router.find('/emojis/signs/42')
-        self.assertEqual(resource.resource_id, 14)
+def test_root_path():
+    router = DefaultRouter()
+    router.add_route('/', {}, ResourceWithId(42))
 
-        resource, __, __, __ = self.router.find('/emojis/signs/42/small')
-        self.assertEqual(resource.resource_id, 14.1)
+    resource, __, __, __ = router.find('/')
+    assert resource.resource_id == 42
 
-        route = self.router.find('/emojis/signs/1/small')
-        self.assertEqual(route, None)
 
-    @ddt.data(
-        '/teams',
-        '/emojis/signs',
-        '/gists',
-        '/gists/42',
-    )
-    def test_dead_segment(self, template):
-        route = self.router.find(template)
-        self.assertIs(route, None)
+@pytest.mark.parametrize('uri_template', [
+    '/teams/{collision}',  # simple vs simple
+    '/emojis/signs/{id_too}',  # another simple vs simple
+    '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}:{collision}',
+])
+def test_collision(router, uri_template):
+    with pytest.raises(ValueError):
+        router.add_route(uri_template, {}, ResourceWithId(-1))
 
-    def test_malformed_pattern(self):
-        route = self.router.find(
-            '/repos/racker/falcon/compare/foo')
-        self.assertIs(route, None)
 
-        route = self.router.find(
-            '/repos/racker/falcon/compare/foo/full')
-        self.assertIs(route, None)
+@pytest.mark.parametrize('uri_template', [
+    '/repos/{org}/{repo}/compare/{simple_vs_complex}',
+    '/repos/{complex}.{vs}.{simple}',
+    '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}/full',
+])
+def test_non_collision(router, uri_template):
+    router.add_route(uri_template, {}, ResourceWithId(-1))
 
-    def test_literal(self):
-        resource, __, __, __ = self.router.find('/user/memberships')
-        self.assertEqual(resource.resource_id, 8)
 
-    def test_variable(self):
-        resource, __, params, __ = self.router.find('/teams/42')
-        self.assertEqual(resource.resource_id, 6)
-        self.assertEqual(params, {'id': '42'})
+@pytest.mark.parametrize('uri_template', [
+    # Missing field name
+    '/{}',
+    '/repos/{org}/{repo}/compare/{}',
+    '/repos/{complex}.{}.{thing}',
 
-        __, __, params, __ = self.router.find('/emojis/signs/stop')
-        self.assertEqual(params, {'id': 'stop'})
+    # Field names must be valid Python identifiers
+    '/{9v}',
+    '/{524hello}/world',
+    '/hello/{1world}',
+    '/repos/{complex}.{9v}.{thing}/etc',
+    '/{*kgriffs}',
+    '/{@kgriffs}',
+    '/repos/{complex}.{v}.{@thing}/etc',
+    '/{-kgriffs}',
+    '/repos/{complex}.{-v}.{thing}/etc',
+    '/repos/{simple-thing}/etc',
 
-        __, __, params, __ = self.router.find('/gists/42/raw')
-        self.assertEqual(params, {'id': '42'})
+    # Neither fields nor literal segments may not contain whitespace
+    '/this and that',
+    '/this\tand\tthat'
+    '/this\nand\nthat'
+    '/{thing }/world',
+    '/{thing\t}/world',
+    '/{\nthing}/world',
+    '/{th\ving}/world',
+    '/{ thing}/world',
+    '/{ thing }/world',
+    '/{thing}/wo rld',
+    '/{thing} /world',
+    '/repos/{or g}/{repo}/compare/{thing}',
+    '/repos/{org}/{repo}/compare/{th\ting}',
+])
+def test_invalid_field_name(router, uri_template):
+    with pytest.raises(ValueError):
+        router.add_route(uri_template, {}, ResourceWithId(-1))
 
-    def test_single_character_field_name(self):
-        __, __, params, __ = self.router.find('/item/1234')
-        self.assertEqual(params, {'q': '1234'})
 
-    @ddt.data(
-        ('/teams/default', 19),
-        ('/teams/default/members', 7),
-        ('/teams/foo', 6),
-        ('/teams/foo/members', 7),
-        ('/gists/first', 20),
-        ('/gists/first/raw', 18),
-        ('/gists/first/pdf', 21),
-        ('/gists/1776/pdf', 21),
-        ('/emojis/signs/78', 13),
-        ('/emojis/signs/78/small', 22),
-    )
-    @ddt.unpack
-    def test_literal_vs_variable(self, path, expected_id):
-        resource, __, __, __ = self.router.find(path)
-        self.assertEqual(resource.resource_id, expected_id)
+def test_dump(router):
+    print(router._src)
 
-    @ddt.data(
-        # Misc.
-        '/this/does/not/exist',
-        '/user/bogus',
-        '/repos/racker/falcon/compare/johndoe:master...janedoe:dev/bogus',
 
-        # Literal vs variable (teams)
-        '/teams',
-        '/teams/42/members/undefined',
-        '/teams/42/undefined',
-        '/teams/42/undefined/segments',
-        '/teams/default/members/undefined',
-        '/teams/default/members/thing/undefined',
-        '/teams/default/members/thing/undefined/segments',
-        '/teams/default/undefined',
-        '/teams/default/undefined/segments',
+def test_override(router):
+    router.add_route('/emojis/signs/0', {}, ResourceWithId(-1))
 
-        # Literal vs variable (emojis)
-        '/emojis/signs',
-        '/emojis/signs/0/small',
-        '/emojis/signs/0/undefined',
-        '/emojis/signs/0/undefined/segments',
-        '/emojis/signs/20/small',
-        '/emojis/signs/20/undefined',
-        '/emojis/signs/42/undefined',
-        '/emojis/signs/78/undefined',
-    )
-    def test_not_found(self, path):
-        route = self.router.find(path)
-        self.assertIs(route, None)
+    resource, __, __, __ = router.find('/emojis/signs/0')
+    assert resource.resource_id == -1
 
-    def test_subsegment_not_found(self):
-        route = self.router.find('/emojis/signs/0/x')
-        self.assertIs(route, None)
 
-    def test_multivar(self):
-        resource, __, params, __ = self.router.find(
-            '/repos/racker/falcon/commits')
-        self.assertEqual(resource.resource_id, 4)
-        self.assertEqual(params, {'org': 'racker', 'repo': 'falcon'})
+def test_literal_segment(router):
+    resource, __, __, __ = router.find('/emojis/signs/0')
+    assert resource.resource_id == 12
 
-        resource, __, params, __ = self.router.find(
-            '/repos/racker/falcon/compare/all')
-        self.assertEqual(resource.resource_id, 11)
-        self.assertEqual(params, {'org': 'racker', 'repo': 'falcon'})
+    resource, __, __, __ = router.find('/emojis/signs/1')
+    assert resource.resource_id == 13
 
-    @ddt.data(('', 5), ('/full', 10), ('/part', 15))
-    @ddt.unpack
-    def test_complex(self, url_postfix, resource_id):
-        uri = '/repos/racker/falcon/compare/johndoe:master...janedoe:dev'
-        resource, __, params, __ = self.router.find(uri + url_postfix)
+    resource, __, __, __ = router.find('/emojis/signs/42')
+    assert resource.resource_id == 14
 
-        self.assertEqual(resource.resource_id, resource_id)
-        self.assertEqual(params, {
-            'org': 'racker',
-            'repo': 'falcon',
-            'usr0': 'johndoe',
-            'branch0': 'master',
-            'usr1': 'janedoe',
-            'branch1': 'dev',
-        })
+    resource, __, __, __ = router.find('/emojis/signs/42/small.jpg')
+    assert resource.resource_id == 23
 
-    @ddt.data(
-        ('', 16, '/repos/{org}/{repo}/compare/{usr0}:{branch0}'),
-        ('/full', 17, '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full')
-    )
-    @ddt.unpack
-    def test_complex_alt(self, url_postfix, resource_id, expected_template):
-        uri = '/repos/falconry/falcon/compare/johndoe:master' + url_postfix
-        resource, __, params, uri_template = self.router.find(uri)
+    route = router.find('/emojis/signs/1/small')
+    assert route is None
 
-        self.assertEqual(resource.resource_id, resource_id)
-        self.assertEqual(params, {
-            'org': 'falconry',
-            'repo': 'falcon',
-            'usr0': 'johndoe',
-            'branch0': 'master',
-        })
-        self.assertEqual(uri_template, expected_template)
+
+@pytest.mark.parametrize('uri_template', [
+    '/teams',
+    '/emojis/signs',
+    '/gists',
+    '/gists/42',
+])
+def test_dead_segment(router, uri_template):
+    route = router.find(uri_template)
+    assert route is None
+
+
+@pytest.mark.parametrize('uri_template', [
+    '/repos/racker/falcon/compare/foo',
+    '/repos/racker/falcon/compare/foo/full',
+])
+def test_malformed_pattern(router, uri_template):
+    route = router.find(uri_template)
+    assert route is None
+
+
+def test_literal(router):
+    resource, __, __, __ = router.find('/user/memberships')
+    assert resource.resource_id == 8
+
+
+def test_variable(router):
+    resource, __, params, __ = router.find('/teams/42')
+    assert resource.resource_id == 6
+    assert params == {'id': '42'}
+
+    __, __, params, __ = router.find('/emojis/signs/stop')
+    assert params == {'id': 'stop'}
+
+    __, __, params, __ = router.find('/gists/42/raw')
+    assert params == {'id': '42'}
+
+    __, __, params, __ = router.find('/images/42.gif')
+    assert params == {'id': '42'}
+
+
+def test_single_character_field_name(router):
+    __, __, params, __ = router.find('/item/1234')
+    assert params == {'q': '1234'}
+
+
+@pytest.mark.parametrize('path,expected_id', [
+    ('/teams/default', 19),
+    ('/teams/default/members', 7),
+    ('/teams/foo', 6),
+    ('/teams/foo/members', 7),
+    ('/gists/first', 20),
+    ('/gists/first/raw', 18),
+    ('/gists/first/pdf', 21),
+    ('/gists/1776/pdf', 21),
+    ('/emojis/signs/78', 13),
+    ('/emojis/signs/78/small.png', 24),
+    ('/emojis/signs/78/small(png)', 25),
+    ('/emojis/signs/78/small_png', 26),
+])
+def test_literal_vs_variable(router, path, expected_id):
+    resource, __, __, __ = router.find(path)
+    assert resource.resource_id == expected_id
+
+
+@pytest.mark.parametrize('path', [
+    # Misc.
+    '/this/does/not/exist',
+    '/user/bogus',
+    '/repos/racker/falcon/compare/johndoe:master...janedoe:dev/bogus',
+
+    # Literal vs variable (teams)
+    '/teams',
+    '/teams/42/members/undefined',
+    '/teams/42/undefined',
+    '/teams/42/undefined/segments',
+    '/teams/default/members/undefined',
+    '/teams/default/members/thing/undefined',
+    '/teams/default/members/thing/undefined/segments',
+    '/teams/default/undefined',
+    '/teams/default/undefined/segments',
+
+    # Literal vs variable (emojis)
+    '/emojis/signs',
+    '/emojis/signs/0/small',
+    '/emojis/signs/0/undefined',
+    '/emojis/signs/0/undefined/segments',
+    '/emojis/signs/20/small',
+    '/emojis/signs/20/undefined',
+    '/emojis/signs/42/undefined',
+    '/emojis/signs/78/undefined',
+])
+def test_not_found(router, path):
+    route = router.find(path)
+    assert route is None
+
+
+def test_subsegment_not_found(router):
+    route = router.find('/emojis/signs/0/x')
+    assert route is None
+
+
+def test_multivar(router):
+    resource, __, params, __ = router.find('/repos/racker/falcon/commits')
+    assert resource.resource_id == 4
+    assert params == {'org': 'racker', 'repo': 'falcon'}
+
+    resource, __, params, __ = router.find('/repos/racker/falcon/compare/all')
+    assert resource.resource_id == 11
+    assert params == {'org': 'racker', 'repo': 'falcon'}
+
+
+@pytest.mark.parametrize('url_postfix,resource_id', [
+    ('', 5),
+    ('/full', 10),
+    ('/part', 15),
+])
+def test_complex(router, url_postfix, resource_id):
+    uri = '/repos/racker/falcon/compare/johndoe:master...janedoe:dev'
+    resource, __, params, __ = router.find(uri + url_postfix)
+
+    assert resource.resource_id == resource_id
+    assert (params == {
+        'org': 'racker',
+        'repo': 'falcon',
+        'usr0': 'johndoe',
+        'branch0': 'master',
+        'usr1': 'janedoe',
+        'branch1': 'dev',
+    })
+
+
+@pytest.mark.parametrize('url_postfix,resource_id,expected_template', [
+    ('', 16, '/repos/{org}/{repo}/compare/{usr0}:{branch0}'),
+    ('/full', 17, '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full')
+])
+def test_complex_alt(router, url_postfix, resource_id, expected_template):
+    uri = '/repos/falconry/falcon/compare/johndoe:master' + url_postfix
+    resource, __, params, uri_template = router.find(uri)
+
+    assert resource.resource_id == resource_id
+    assert (params == {
+        'org': 'falconry',
+        'repo': 'falcon',
+        'usr0': 'johndoe',
+        'branch0': 'master',
+    })
+    assert uri_template == expected_template

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -1,8 +1,15 @@
-import ddt
+"""Application tests for URI templates using simulate_get().
+
+These tests differ from those in test_default_router in that they are
+a collection of sanity-checks that exercise the full framework code
+path via simulate_get(), vs. probing the router directly.
+"""
+
+import pytest
 import six
 
 import falcon
-import falcon.testing as testing
+from falcon import testing
 
 
 class IDResource(object):
@@ -63,204 +70,154 @@ class FileDetailsResource(object):
         self.called = True
 
 
-@ddt.ddt
-class TestUriTemplates(testing.TestBase):
+@pytest.fixture
+def resource():
+    return testing.SimpleTestResource()
 
-    def before(self):
-        self.resource = testing.TestResource()
 
-    def test_root_path(self):
-        self.api.add_route('/', self.resource)
-        self.simulate_request('/')
+@pytest.fixture
+def client():
+    return testing.TestClient(falcon.API())
 
-        self.assertTrue(self.resource.called)
-        req = self.resource.req
 
-        self.assertEqual(req.get_param('id'), None)
+def test_root_path(client, resource):
+    client.app.add_route('/', resource)
+    client.simulate_get('/')
+    assert resource.called
 
-    def test_not_str(self):
-        self.assertRaises(TypeError, self.api.add_route, {}, self.resource)
-        self.assertRaises(TypeError, self.api.add_route, [], self.resource)
-        self.assertRaises(TypeError, self.api.add_route, set(), self.resource)
-        self.assertRaises(TypeError, self.api.add_route, self, self.resource)
 
-    @ddt.data('/hello/{1world}', '/{524hello}/world')
-    def test_field_name_cannot_start_with_digit(self, route):
-        self.assertRaises(ValueError, self.api.add_route, route, self.resource)
+def test_no_vars(client, resource):
+    client.app.add_route('/hello/world', resource)
+    client.simulate_get('/hello/world')
+    assert resource.called
 
-    @ddt.data(
-        '/{thing }/world',
-        '/{ thing}/world',
-        '/{ thing }/world',
-        '/{thing}/wo rld',
-        '/{thing} /world'
-    )
-    def test_whitespace_not_allowed(self, route):
-        self.assertRaises(ValueError, self.api.add_route, route, self.resource)
 
-    def test_no_vars(self):
-        self.api.add_route('/hello/world', self.resource)
-        self.simulate_request('/hello/world')
+@pytest.mark.skipif(six.PY3, reason='Test only applies to Python 2')
+def test_unicode_literal_routes(client, resource):
+    client.app.add_route(u'/hello/world', resource)
+    client.simulate_get('/hello/world')
+    assert resource.called
 
-        self.assertTrue(self.resource.called)
-        req = self.resource.req
 
-        self.assertEqual(req.get_param('world'), None)
+def test_special_chars(client, resource):
+    client.app.add_route('/hello/world.json', resource)
+    client.app.add_route('/hello(world)', resource)
 
-    def test_unicode_literal_routes(self):
-        if six.PY3:
-            self.skipTest('Test only applies to Python 2')
+    client.simulate_get('/hello/world_json')
+    assert not resource.called
 
-        self.api.add_route(u'/hello/world', self.resource)
-        self.simulate_request('/hello/world')
+    client.simulate_get('/helloworld')
+    assert not resource.called
 
-        self.assertTrue(self.resource.called)
-        req = self.resource.req
+    client.simulate_get('/hello/world.json')
+    assert resource.called
 
-        self.assertEqual(req.get_param('world'), None)
+    client.simulate_get('/hello(world)')
+    assert resource.called
 
-    def test_special_chars(self):
-        self.api.add_route('/hello/world.json', self.resource)
-        self.api.add_route('/hello(world)', self.resource)
 
-        self.simulate_request('/hello/world_json')
-        self.assertFalse(self.resource.called)
+@pytest.mark.parametrize('field_name', [
+    'id',
+    'id123',
+    'widget_id',
+])
+def test_single(client, resource, field_name):
+    template = '/widgets/{{{0}}}'.format(field_name)
 
-        self.simulate_request('/helloworld')
-        self.assertFalse(self.resource.called)
+    client.app.add_route(template, resource)
 
-        self.simulate_request('/hello/world.json')
-        self.assertTrue(self.resource.called)
+    client.simulate_get('/widgets/123')
+    assert resource.called
+    assert resource.captured_kwargs[field_name] == '123'
 
-    def test_single(self):
-        self.api.add_route('/widgets/{id}', self.resource)
 
-        self.simulate_request('/widgets/123')
-        self.assertTrue(self.resource.called)
+def test_single_trailing_slash(client):
+    resource1 = IDResource()
+    client.app.add_route('/1/{id}/', resource1)
+    result = client.simulate_get('/1/123')
+    assert result.status == falcon.HTTP_200
+    assert resource1.called
+    assert resource1.id == '123'
+    assert resource1.req.path == '/1/123'
 
-        req = self.resource.req
-        kwargs = self.resource.kwargs
-        self.assertEqual(kwargs['id'], '123')
-        self.assertNotIn(kwargs, 'Id')
-        self.assertEqual(req.get_param('id'), None)
+    resource2 = IDResource()
+    client.app.add_route('/2/{id}/', resource2)
+    result = client.simulate_get('/2/123/')
+    assert result.status == falcon.HTTP_200
+    assert resource2.called
+    assert resource2.id == '123'
+    assert resource2.req.path == '/2/123'
 
-    def test_single_with_trailing_digits(self):
-        self.api.add_route('/widgets/{id12}', self.resource)
+    resource3 = IDResource()
+    client.app.add_route('/3/{id}', resource3)
+    result = client.simulate_get('/3/123/')
+    assert result.status == falcon.HTTP_200
+    assert resource3.called
+    assert resource3.id == '123'
+    assert resource3.req.path == '/3/123'
 
-        self.simulate_request('/widgets/123')
-        self.assertTrue(self.resource.called)
-        self.assertEqual(self.resource.kwargs['id12'], '123')
 
-    def test_single_with_underscore(self):
-        self.api.add_route('/widgets/{widget_id}', self.resource)
+def test_multiple(client):
+    resource = NameResource()
+    client.app.add_route('/messages/{id}/names/{name}', resource)
 
-        self.simulate_request('/widgets/123')
-        self.assertTrue(self.resource.called)
-        self.assertEqual(self.resource.kwargs['widget_id'], '123')
+    test_id = 'bfb54d43-219b-4336-a623-6172f920592e'
+    test_name = '758e3922-dd6d-4007-a589-50fba0789365'
+    path = '/messages/' + test_id + '/names/' + test_name
+    client.simulate_get(path)
 
-    def test_single_trailing_slash(self):
-        resource1 = IDResource()
-        self.api.add_route('/1/{id}/', resource1)
+    assert resource.called
+    assert resource.id == test_id
+    assert resource.name == test_name
 
-        self.simulate_request('/1/123')
-        self.assertEqual(self.srmock.status, falcon.HTTP_200)
-        self.assertTrue(resource1.called)
-        self.assertEqual(resource1.id, '123')
-        self.assertEqual(resource1.name, None)
-        self.assertEqual(resource1.req.path, '/1/123')
 
-        resource2 = IDResource()
-        self.api.add_route('/2/{id}/', resource2)
+@pytest.mark.parametrize('uri_template', [
+    '//',
+    '//begin',
+    '/end//',
+    '/in//side',
+])
+def test_empty_path_component(client, resource, uri_template):
+    with pytest.raises(ValueError):
+        client.app.add_route(uri_template, resource)
 
-        self.simulate_request('/2/123/')
-        self.assertTrue(resource2.called)
-        self.assertEqual(resource2.id, '123')
-        self.assertEqual(resource2.name, None)
-        self.assertEqual(resource2.req.path, '/2/123')
 
-        resource3 = IDResource()
-        self.api.add_route('/3/{id}', resource3)
+@pytest.mark.parametrize('uri_template', [
+    '',
+    'no',
+    'no/leading_slash',
+])
+def test_relative_path(client, resource, uri_template):
+    with pytest.raises(ValueError):
+        client.app.add_route(uri_template, resource)
 
-        self.simulate_request('/3/123/')
-        self.assertTrue(resource3.called)
-        self.assertEqual(resource3.id, '123')
-        self.assertEqual(resource3.name, None)
-        self.assertEqual(resource3.req.path, '/3/123')
 
-    def test_multiple(self):
-        resource = NameResource()
-        self.api.add_route('/messages/{id}/names/{name}', resource)
+@pytest.mark.parametrize('reverse', [True, False])
+def test_same_level_complex_var(client, reverse):
+    file_resource = FileResource()
+    details_resource = FileDetailsResource()
 
-        test_id = self.getUniqueString()
-        test_name = self.getUniqueString()
-        path = '/messages/' + test_id + '/names/' + test_name
-        self.simulate_request(path)
-        self.assertTrue(resource.called)
+    routes = [
+        ('/files/{file_id}', file_resource),
+        ('/files/{file_id}.{ext}', details_resource)
+    ]
+    if reverse:
+        routes.reverse()
 
-        self.assertEqual(resource.id, test_id)
-        self.assertEqual(resource.name, test_name)
+    for uri_template, resource in routes:
+        client.app.add_route(uri_template, resource)
 
-    def test_multiple_with_digits(self):
-        resource = NameAndDigitResource()
-        self.api.add_route('/messages/{id}/names/{name51}', resource)
+    file_id_1 = 'bc6b201d-b449-4290-a061-8eeb9f7b1450'
+    file_id_2 = '33b7f34c-6ee6-40e6-89a3-742a69b59de0'
+    ext = 'a4581b95-bc36-4c08-a3c2-23ba266abdf2'
+    path_1 = '/files/' + file_id_1
+    path_2 = '/files/' + file_id_2 + '.' + ext
 
-        test_id = self.getUniqueString()
-        test_name = self.getUniqueString()
-        path = '/messages/' + test_id + '/names/' + test_name
-        self.simulate_request(path)
-        self.assertTrue(resource.called)
+    client.simulate_get(path_1)
+    assert file_resource.called
+    assert file_resource.file_id == file_id_1
 
-        self.assertEqual(resource.id, test_id)
-        self.assertEqual(resource.name51, test_name)
-
-    @ddt.data('//', '//begin', '/end//', '/in//side')
-    def test_empty_path_component(self, route):
-        self.assertRaises(ValueError, self.api.add_route, route, self.resource)
-
-    @ddt.data('', 'no', 'no/leading_slash')
-    def test_relative_path(self, route):
-        self.assertRaises(ValueError, self.api.add_route, route, self.resource)
-
-    def test_same_level_complex_var(self):
-        resource = FileResource()
-        details_resource = FileDetailsResource()
-        self.api.add_route('/files/{file_id}', resource)
-        self.api.add_route('/files/{file_id}.{ext}', details_resource)
-
-        # dots cause ambiguous in filenames
-        file_id_1 = self.getUniqueString().replace('.', '-')
-        file_id_2 = self.getUniqueString().replace('.', '-')
-        ext = self.getUniqueString().replace('.', '-')
-        path_1 = '/files/' + file_id_1
-        path_2 = '/files/' + file_id_2 + '.' + ext
-
-        self.simulate_request(path_1)
-        self.assertTrue(resource.called)
-        self.assertEqual(resource.file_id, file_id_1)
-
-        self.simulate_request(path_2)
-        self.assertTrue(details_resource.called)
-        self.assertEqual(details_resource.file_id, file_id_2)
-        self.assertEqual(details_resource.ext, ext)
-
-    def test_same_level_complex_var_in_reverse_order(self):
-        resource = FileResource()
-        details_resource = FileDetailsResource()
-        self.api.add_route('/files/{file_id}.{ext}', details_resource)
-        self.api.add_route('/files/{file_id}', resource)
-
-        # dots cause ambiguous in filenames
-        file_id_1 = self.getUniqueString().replace('.', '-')
-        file_id_2 = self.getUniqueString().replace('.', '-')
-        ext = self.getUniqueString().replace('.', '-')
-        path_1 = '/files/' + file_id_1
-        path_2 = '/files/' + file_id_2 + '.' + ext
-
-        self.simulate_request(path_1)
-        self.assertTrue(resource.called)
-        self.assertEqual(resource.file_id, file_id_1)
-
-        self.simulate_request(path_2)
-        self.assertTrue(details_resource.called)
-        self.assertEqual(details_resource.file_id, file_id_2)
-        self.assertEqual(details_resource.ext, ext)
+    client.simulate_get(path_2)
+    assert details_resource.called
+    assert details_resource.file_id == file_id_2
+    assert details_resource.ext == ext

--- a/tox.ini
+++ b/tox.ini
@@ -146,7 +146,7 @@ basepython = python2.7
 
 commands = flake8 \
              --max-complexity=15 \
-             --exclude=./build,.venv,.tox,dist,docs,./falcon/bench/nuts \
+             --exclude=./build,.venv,.tox,dist,docs,.eggs,./falcon/bench/nuts \
              --ignore=F403 \
              --max-line-length=99 \
              --import-order-style=google \


### PR DESCRIPTION
Note that some tests were moved from test_uri_templates to test_default_router.