### PR TITLE
fix: URI template field parsing bugs

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -341,9 +341,11 @@ class API(object):
                 pass
 
         Individual path segments may contain one or more field
-        expressions::
+        expressions, and fields need not span the entire path
+        segment. For example::
 
             /repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}
+            /serviceRoot/People('{name}')
 
         Note:
             Because field names correspond to argument names in responder


### PR DESCRIPTION
Fix the following bugs:

* Only the '.' special character is properly handled, even though
  some URL schemas, such as OData, make use of other characters,
  like parens.
* Using duplicate field names leads to a nasty re error being
  raised in the case of them being contained to the same
  node, and a silent overwriting of param values in the case of
  field values being duplicated across multiple nodes.