### PR TITLE
feat(CompiledRouter): Add an intermediate AST step to the compiler

### DIFF
--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -5,7 +5,6 @@ from falcon import testing
 class TestCustomRouter(testing.TestBase):
 
     def test_custom_router_add_route_should_be_used(self):
-
         check = []
 
         class CustomRouter(object):

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 import falcon
@@ -224,6 +226,20 @@ def test_root_path():
     resource, __, __, __ = router.find('/')
     assert resource.resource_id == 42
 
+    expected_src = textwrap.dedent("""
+        def find(path, return_values, patterns, params):
+            path_len = len(path)
+            if path_len > 0:
+                if path[0] == '':
+                    if path_len == 1:
+                        return return_values[0]
+                    return None
+                return None
+            return None
+    """).strip()
+
+    assert router.finder_src == expected_src
+
 
 @pytest.mark.parametrize('uri_template', [
     '/{field}{field}',
@@ -309,8 +325,14 @@ def test_invalid_field_name(router, uri_template):
         router.add_route(uri_template, {}, ResourceWithId(-1))
 
 
-def test_dump(router):
-    print(router._src)
+def test_print_src(router):
+    """Diagnostic test that simply prints the router's find() source code.
+
+    Example:
+
+        $ tox -e py27_debug -- -k test_print_src -s
+    """
+    print('\n\n' + router.finder_src + '\n')
 
 
 def test_override(router):


### PR DESCRIPTION
Rather than compiling the routing tree directly to Python code, first generate an AST and then use it to produce the code. This provides several benefits, including:

* It makes the compilation process easier to reason about.
* It makes it easier to keep track of indentation and whitespace.
* It sets us up for being able to make transformations that we will need to do to support URI template filters, etc. in the future.