### PR TITLE
chore: Make testing backwards-compatible with pytest<=2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ matrix:
           env: TOXENV=pep8-examples
         - python: 2.6
           env: TOXENV=py26
+        - python: 2.6
+          env: TOXENV=py26_old_pytest
         - python: 2.7
           env: TOXENV=py27
+        - python: 2.7
+          env: TOXENV=py27_old_pytest
         - python: 2.7
           env: TOXENV=py27_ujson
         - python: 2.7
@@ -35,9 +39,13 @@ matrix:
         - python: 3.3
           env: TOXENV=py33
         - python: 3.3
+          env: TOXENV=py33_old_pytest
+        - python: 3.3
           env: TOXENV=py33_cython
         - python: 3.4
           env: TOXENV=py34
+        - python: 3.4
+          env: TOXENV=py34_old_pytest
         - python: 3.4
           env: TOXENV=py34_cython
         - python: 3.5

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,6 +1,6 @@
 coverage>=4.1
 ddt
-pytest>=3.0.1
+pytest>=2.7.0
 pytest-cov
 pytest-xdist
 pyyaml

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ tag_build = dev1
 universal = 1
 
 [aliases]
-test=pytest
+test=py.test
 
 [tool:pytest]
 addopts = tests

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,18 @@ MYDIR = path.abspath(os.path.dirname(__file__))
 VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
-# NOTE(kgriffs): python-mimeparse is better-maintained fork of mimeparse
+# NOTE(kgriffs): python-mimeparse is a better-maintained fork of mimeparse
 REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2']
+
+# NOTE(kgriffs):
+TESTS_REQUIRE = [
+    'ddt',
+    'pytest',
+    'pytest-runner'
+    'pyyaml',
+    'requests',
+    'testtools',
+]
 
 JYTHON = 'java' in sys.platform
 
@@ -105,10 +115,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIRES,
+    tests_require=TESTS_REQUIRE,
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    tests_require=['ddt', 'testtools', 'requests', 'pyyaml', 'pytest',
-                   'pytest-runner'],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main',

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ envlist = py26,
 [testenv]
 deps = -r{toxinidir}/requirements/tests
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           pytest tests []
+           py.test -n 6 tests []
 
 # --------------------------------------------------------------------
 # Coverage
@@ -27,7 +27,7 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
 whitelist_externals = mkdir
                       mv
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           pytest -n 4 --cov=falcon tests []
+           py.test -n 6 --cov=falcon tests []
            mkdir -p .coverage_data
            mv {toxinidir}/.coverage {toxinidir}/.coverage_data/.coverage.{envname}
 
@@ -49,21 +49,53 @@ whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
 # --------------------------------------------------------------------
-# Debugging
+# Debugging (adds pdbpp and disables xdist)
 # --------------------------------------------------------------------
 
 [with-debug-tools]
 deps = -r{toxinidir}/requirements/tests
        pdbpp
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
+           py.test tests []
+
 
 [testenv:py27_debug]
 basepython = python2.7
 deps = {[with-debug-tools]deps}
        funcsigs
+commands = {[with-debug-tools]commands}
 
-[testenv:py35_debug]
-basepython = python3.5
+[testenv:py36_debug]
+basepython = python3.6
 deps = {[with-debug-tools]deps}
+commands = {[with-debug-tools]commands}
+
+# --------------------------------------------------------------------
+# pytest==2.7.0 (ensure backwards compatibility)
+# --------------------------------------------------------------------
+
+[with-old-pytest]
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
+           pip install -I pytest==2.7.0
+           py.test -n 6 tests []
+
+[testenv:py26_old_pytest]
+basepython = python2.6
+commands = {[with-old-pytest]commands}
+
+[testenv:py27_old_pytest]
+basepython = python2.7
+commands = {[with-old-pytest]commands}
+
+[testenv:py33_old_pytest]
+basepython = python3.3
+commands = {[with-old-pytest]commands}
+
+# NOTE(kgriffs): 3.4 is the last Python that is compatible with pytest 2.7.0
+[testenv:py34_old_pytest]
+basepython = python3.4
+commands = {[with-old-pytest]commands}
+
 
 # --------------------------------------------------------------------
 # ujson


### PR DESCRIPTION
Ensure that Falcon tests execute with older versions of pytest, since
distro packages tend to lag behind the latest version.