### PR TITLE
Request and Response media-type handling

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,6 +9,7 @@ Classes and Functions
    cookies
    status
    errors
+   media
    redirects
    middleware
    hooks

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -47,6 +47,15 @@ media type that JSON also supports (i.e. dicts, lists, etc).
 .. autofunction:: falcon.media.validators.jsonschema.validate
 
 
+Content-Type Negotiation
+------------------------
+
+Falcon currently only supports partial negotiation out of the box. By default,
+when the ``media`` attribute is used it attempts to de/serialize based on the
+``Content-Type`` header value. The missing link that Falcon doesn't provide
+is the connection between the :any:`falcon.Request` ``Accept`` header provided
+by a user and the :any:`falcon.Response` ``Content-Type`` header.
+
 
 Replacing The Default Handlers
 ------------------------------

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -1,0 +1,110 @@
+.. _media:
+
+Media
+=====
+
+Falcon allows for easy and customizable media handling. By default
+Falcon only enables a single JSON handler. However, other/multiple handlers
+can be configured through the :any:`falcon.RequestOptions` and
+:any:`falcon.ResponseOptions` objects specified on your :any:`falcon.API`.
+
+.. note::
+
+    For performance concerns, Falcon will not attempt to handle request
+    media until the first time it's accessed. Once it has procesed the
+    request, it'll use the cached result for subsequent interactions.
+
+Usage
+-----
+
+If you're creating a JSON API then zero configuration is needed. Just access
+or set the ``media`` attribute as appropriate and let Falcon do the heavy
+lifting for you.
+
+.. code:: python
+
+    import falcon
+
+
+    class EchoResource(object):
+        def on_post(self, req, resp):
+            message = req.media.get('message')
+
+            resp.media = {'message': message}
+            resp.status = falcon.HTTP_200
+
+Validating Media
+----------------
+
+Falcon currently does not validate media for you as requirements and tooling
+vary quite largely between projects; however, here is an example of how you
+might go about implementing a JSON Schema validator using a decorator.
+
+.. code:: python
+
+    import jsonschema
+
+
+    def validate(schema):
+        def decorator(func):
+            def wrapper(self, req, resp, *args, **kwargs):
+                try:
+                    jsonschema.validate(req.media, schema)
+                except jsonschema.ValidationError as e:
+                    raise falcon.HTTPBadRequest(
+                        'Failed data validation',
+                        e.message
+                    )
+
+                return func(self, req, resp, *args, **kwargs)
+            return wrapper
+        return decorator
+
+
+Given that decorator you could use it on the resource as such:
+
+.. code:: python
+
+    # -- snip --
+
+    @validate(my_post_schema)
+    def on_post(self, req, resp):
+    # -- snip --
+
+
+Replacing the default handlers
+------------------------------
+
+When creating your API object you can either add or completely
+replace all of the handlers. For example, lets say you want to write an API
+that sends and receives MessagePack. We can easily do this by telling our
+Falcon API that we want a default media-type of `application/msgpack` and
+then create a new ``Handlers`` object specifying the desired media type and
+a handler that can process that data.
+
+.. code:: python
+
+    import falcon
+    from falcon import media_handlers
+
+
+    handlers = media_handlers.Handlers({
+        'application/msgpack': media_handlers.MessagePack,
+    })
+
+    api = falcon.API(media_type='application/msgpack')
+
+    api.req_options.media_handlers = handlers
+    api.resp_options.media_handlers = handlers
+
+
+Custom Handlers
+---------------
+
+Currently Falcon only supports a handful of media handlers out of the box;
+however, you can easily create your own. All you need is an object that
+contains the following class methods:
+
+ * ``load(cls)``
+ * ``deserialize(cls, raw)``
+ * ``serialize(cls, media)``

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -82,18 +82,18 @@ Replacing The Default Handlers
 When creating your API object you can either add or completely
 replace all of the handlers. For example, lets say you want to write an API
 that sends and receives MessagePack. We can easily do this by telling our
-Falcon API that we want a default media-type of `application/msgpack` and
-then create a new ``Handlers`` object specifying the desired media type and
+Falcon API that we want a default media-type of ``application/msgpack`` and
+then create a new :any:`Handlers` object specifying the desired media type and
 a handler that can process that data.
 
 .. code:: python
 
     import falcon
-    from falcon import media_handlers
+    from falcon import media
 
 
-    handlers = media_handlers.Handlers({
-        'application/msgpack': media_handlers.MessagePack,
+    handlers = media.Handlers({
+        'application/msgpack': media.MessagePackHandler,
     })
 
     api = falcon.API(media_type='application/msgpack')
@@ -106,9 +106,16 @@ Custom Handlers
 ---------------
 
 Currently Falcon only supports a handful of media handlers out of the box;
-however, you can easily create your own. All you need is an object that
-contains the following class methods:
+however, you can easily create your own using the following abstract base
+class:
 
- * ``load(cls)``
- * ``deserialize(cls, raw)``
- * ``serialize(cls, media)``
+.. autoclass:: falcon.media.BaseHandler
+    :members:
+    :member-order: bysource
+
+
+Handlers
+--------
+
+.. autoclass:: falcon.media.Handlers
+    :members:

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -93,7 +93,7 @@ a handler that can process that data.
 
 
     handlers = media.Handlers({
-        'application/msgpack': media.MessagePackHandler,
+        'application/msgpack': media.MessagePackHandler(),
     })
 
     api = falcon.API(media_type='application/msgpack')
@@ -101,13 +101,21 @@ a handler that can process that data.
     api.req_options.media_handlers = handlers
     api.resp_options.media_handlers = handlers
 
+Supported Handler Types
+-----------------------
 
-Custom Handlers
----------------
+.. autoclass:: falcon.media.JSONHandler
+    :members:
 
-Currently Falcon only supports a handful of media handlers out of the box;
-however, you can easily create your own using the following abstract base
-class:
+.. autoclass:: falcon.media.MessagePackHandler
+    :members:
+
+Custom Handler Type
+-------------------
+
+If Falcon doesn't have a internet media type handler that supports your
+use-case. You can easily implement your own using the abstract base class
+provided by Falcon:
 
 .. autoclass:: falcon.media.BaseHandler
     :members:

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -40,40 +40,12 @@ lifting for you.
 Validating Media
 ----------------
 
-Falcon currently does not validate media for you as requirements and tooling
-vary quite largely between projects; however, here is an example of how you
-might go about implementing a JSON Schema validator using a decorator.
+Falcon currently only supports a JSONSchema media type handler; however,
+JSONSchema is very versatile and can be used to validate any deserialized
+media type that JSON also supports (i.e. dicts, lists, etc).
 
-.. code:: python
+.. autofunction:: falcon.media.validators.jsonschema.validate
 
-    import jsonschema
-
-
-    def validate(schema):
-        def decorator(func):
-            def wrapper(self, req, resp, *args, **kwargs):
-                try:
-                    jsonschema.validate(req.media, schema)
-                except jsonschema.ValidationError as e:
-                    raise falcon.HTTPBadRequest(
-                        'Failed data validation',
-                        e.message
-                    )
-
-                return func(self, req, resp, *args, **kwargs)
-            return wrapper
-        return decorator
-
-
-Given that decorator you could use it on the resource as such:
-
-.. code:: python
-
-    # -- snip --
-
-    @validate(my_post_schema)
-    def on_post(self, req, resp):
-    # -- snip --
 
 
 Replacing The Default Handlers

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -40,8 +40,8 @@ lifting for you.
 Validating Media
 ----------------
 
-Falcon currently only supports a JSONSchema media type handler; however,
-JSONSchema is very versatile and can be used to validate any deserialized
+Falcon currently only provides a JSON Schema media validator; however,
+JSON Schema is very versatile and can be used to validate any deserialized
 media type that JSON also supports (i.e. dicts, lists, etc).
 
 .. autofunction:: falcon.media.validators.jsonschema.validate
@@ -56,8 +56,17 @@ when the ``media`` attribute is used it attempts to de/serialize based on the
 is the connection between the :any:`falcon.Request` ``Accept`` header provided
 by a user and the :any:`falcon.Response` ``Content-Type`` header.
 
+If you do need full negotiation, it is very easy to bridge the gap using
+middleware. Here is an example of how this can be done:
 
-Replacing The Default Handlers
+.. code-block:: python
+
+    class NegotiationMiddleware(object):
+        def process_request(self, req, resp):
+            resp.content_type = req.accept
+
+
+Replacing the Default Handlers
 ------------------------------
 
 When creating your API object you can either add or completely
@@ -82,6 +91,25 @@ a handler that can process that data.
     api.req_options.media_handlers = handlers
     api.resp_options.media_handlers = handlers
 
+Alternatively, if you would like to add an additional handler such as
+MessagePack, this can be easily done in the following manner:
+
+.. code-block:: python
+
+    import falcon
+    from falcon import media
+
+
+    extra_handlers = {
+        'application/msgpack': media.MessagePackHandler(),
+    }
+
+    api = falcon.API()
+
+    api.req_options.media_handlers.update(extra_handlers)
+    api.resp_options.media_handlers.update(extra_handlers)
+
+
 Supported Handler Types
 -----------------------
 
@@ -94,8 +122,8 @@ Supported Handler Types
 Custom Handler Type
 -------------------
 
-If Falcon doesn't have a internet media type handler that supports your
-use-case. You can easily implement your own using the abstract base class
+If Falcon doesn't have an internet media type handler that supports your
+use case, you can easily implement your own using the abstract base class
 provided by Falcon:
 
 .. autoclass:: falcon.media.BaseHandler

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -33,6 +33,10 @@ lifting for you.
             resp.media = {'message': message}
             resp.status = falcon.HTTP_200
 
+.. warning::
+
+    Once `media` is called on a request, it'll consume the request's stream.
+
 Validating Media
 ----------------
 

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -3,21 +3,21 @@
 Media
 =====
 
-Falcon allows for easy and customizable media handling. By default
-Falcon only enables a single JSON handler. However, other/multiple handlers
+Falcon allows for easy and customizable internet media type handling. By default
+Falcon only enables a single JSON handler. However, additional handlers
 can be configured through the :any:`falcon.RequestOptions` and
 :any:`falcon.ResponseOptions` objects specified on your :any:`falcon.API`.
 
 .. note::
 
-    For performance concerns, Falcon will not attempt to handle request
-    media until the first time it's accessed. Once it has procesed the
-    request, it'll use the cached result for subsequent interactions.
+    To avoid unnecessary overhead, Falcon will only process request media
+    the first time the media property is referenced. Once it has been
+    referenced, it'll use the cached result for subsequent interactions.
 
 Usage
 -----
 
-If you're creating a JSON API then zero configuration is needed. Just access
+Zero configuration is needed if you're creating a JSON API. Just access
 or set the ``media`` attribute as appropriate and let Falcon do the heavy
 lifting for you.
 
@@ -76,7 +76,7 @@ Given that decorator you could use it on the resource as such:
     # -- snip --
 
 
-Replacing the default handlers
+Replacing The Default Handlers
 ------------------------------
 
 When creating your API object you can either add or completely

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -155,6 +155,9 @@ class API(object):
         self.req_options = RequestOptions()
         self.resp_options = ResponseOptions()
 
+        self.req_options.default_media_type = media_type
+        self.resp_options.default_media_type = media_type
+
         # NOTE(kgriffs): Add default error handlers
         self.add_error_handler(falcon.HTTPError, self._http_error_handler)
         self.add_error_handler(falcon.HTTPStatus, self._http_status_handler)

--- a/falcon/media/__init__.py
+++ b/falcon/media/__init__.py
@@ -1,0 +1,5 @@
+from .base import BaseHandler  # NOQA
+from .json import JSONHandler  # NOQA
+from .msgpack import MessagePackHandler  # NOQA
+
+from .handlers import Handlers  # NOQA

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -14,7 +14,6 @@ class BaseHandler(object):
         Allows for implementors to specify runtime configuration
         and/or dependencies.
         """
-        pass
 
     @abc.abstractmethod
     def serialize(self, obj):
@@ -26,7 +25,6 @@ class BaseHandler(object):
         Returns:
             bytes: The resulting serialized bytes from the input object.
         """
-        pass
 
     @abc.abstractmethod
     def deserialize(self, raw):
@@ -38,4 +36,3 @@ class BaseHandler(object):
         Returns:
             object: A deserialized object.
         """
-        pass

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -1,0 +1,44 @@
+import abc
+
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class BaseHandler(object):
+    """Abstract Base Class for an internet media type handler"""
+
+    @classmethod
+    @abc.abstractmethod
+    def load(cls):
+        """Loads any required imports and configuration.
+
+        Allows for implementors to specify runtime configuration
+        and/or dependencies.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def serialize(cls, obj):
+        """Serialize the media object on a :any:`falcon.Response`
+
+        Args:
+            obj (object): A serializable object.
+
+        Returns:
+            bytes: The resulting serialized bytes from the input object.
+        """
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def deserialize(cls, raw):
+        """Deserialize the :any:`falcon.Request` body.
+
+        Args:
+            raw (bytes): Input bytes to deserialize
+
+        Returns:
+            object: A deserialized object.
+        """
+        pass

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -7,9 +7,8 @@ import six
 class BaseHandler(object):
     """Abstract Base Class for an internet media type handler"""
 
-    @classmethod
     @abc.abstractmethod
-    def load(cls):
+    def load(self):
         """Loads any required imports and configuration.
 
         Allows for implementors to specify runtime configuration
@@ -17,9 +16,8 @@ class BaseHandler(object):
         """
         pass
 
-    @classmethod
     @abc.abstractmethod
-    def serialize(cls, obj):
+    def serialize(self, obj):
         """Serialize the media object on a :any:`falcon.Response`
 
         Args:
@@ -30,9 +28,8 @@ class BaseHandler(object):
         """
         pass
 
-    @classmethod
     @abc.abstractmethod
-    def deserialize(cls, raw):
+    def deserialize(self, raw):
         """Deserialize the :any:`falcon.Request` body.
 
         Args:

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -8,14 +8,6 @@ class BaseHandler(object):
     """Abstract Base Class for an internet media type handler"""
 
     @abc.abstractmethod
-    def load(self):
-        """Loads any required imports and configuration.
-
-        Allows for implementors to specify runtime configuration
-        and/or dependencies.
-        """
-
-    @abc.abstractmethod
     def serialize(self, obj):
         """Serialize the media object on a :any:`falcon.Response`
 

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -7,10 +7,7 @@ from falcon.media import JSONHandler
 
 
 class Handlers(UserDict):
-    """A dictionary like object that manages internet media type handlers.
-
-    Attempts to load any imports for handlers as they are added.
-    """
+    """A dictionary like object that manages internet media type handlers."""
     def __init__(self, initial=None):
         handlers = initial or {
             'application/json': JSONHandler(),
@@ -20,19 +17,6 @@ class Handlers(UserDict):
         # NOTE(jmvrbanac): Directly calling UserDict as it's not inheritable.
         # Also, this results in self.update(...) being called.
         UserDict.__init__(self, handlers)
-
-    def update(self, input_dict):
-        for handler in input_dict.values():
-            handler.load()
-
-        UserDict.update(self, input_dict)
-
-    def __setitem__(self, key, item):
-        if not key:
-            raise ValueError('Media Type cannot be None or an empty string')
-
-        item.load()
-        self.data[key] = item
 
     def _resolve_media_type(self, media_type, all_media_types):
         resolved = None
@@ -51,13 +35,13 @@ class Handlers(UserDict):
 
     def find_by_media_type(self, media_type, default):
         # PERF(jmvrbanac): Check via a quick methods first for performance
+        if media_type == '*/*' or not media_type:
+            return self.data[default]
+
         try:
             return self.data[media_type]
         except KeyError:
             pass
-
-        if media_type == '*/*' or not media_type:
-            return self.data[default]
 
         # PERF(jmvrbanac): Fallback to the slower method
         resolved = self._resolve_media_type(media_type, self.data.keys())

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -1,7 +1,9 @@
 import mimeparse
+
 from six.moves import UserDict
 
 from falcon import errors
+from falcon.media import JSONHandler
 
 
 class Handlers(UserDict):
@@ -11,8 +13,8 @@ class Handlers(UserDict):
     """
     def __init__(self, initial=None):
         handlers = initial or {
-            'application/json': Json,
-            'application/json; charset=UTF-8': Json
+            'application/json': JSONHandler,
+            'application/json; charset=UTF-8': JSONHandler
         }
 
         # NOTE(jmvrbanac): Directly calling UserDict as it's not inheritable.
@@ -36,6 +38,8 @@ class Handlers(UserDict):
         resolved = None
 
         try:
+            # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
+            # parse the media type, but cannot find a suitable type.
             resolved = mimeparse.best_match(
                 all_media_types,
                 media_type
@@ -58,62 +62,9 @@ class Handlers(UserDict):
         # PERF(jmvrbanac): Fallback to the slower method
         resolved = self._resolve_media_type(media_type, self.data.keys())
 
-        # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
-        # parse the media type, but cannot find a suitable type.
         if not resolved:
             raise errors.HTTPUnsupportedMediaType(
                 '{0} is an unsupported media type.'.format(media_type)
             )
 
         return self.data[resolved]
-
-
-class Json(object):
-    @classmethod
-    def load(cls):
-        import json
-        cls.json = json
-
-    @classmethod
-    def deserialize(cls, raw):
-        try:
-            return cls.json.loads(raw.decode('utf-8'))
-        except ValueError as err:
-            raise errors.HTTPBadRequest(
-                'Invalid JSON',
-                'Could not parse JSON body - {0}'.format(err)
-            )
-
-    @classmethod
-    def serialize(cls, media):
-        return cls.json.dumps(media)
-
-
-class MessagePack(object):
-    @classmethod
-    def load(cls):
-        import msgpack
-
-        cls.msgpack = msgpack
-        cls.packer = msgpack.Packer(
-            encoding='utf-8',
-            autoreset=True,
-            use_bin_type=True,
-        )
-
-    @classmethod
-    def deserialize(cls, raw):
-        try:
-            # NOTE(jmvrbanac): Using unpackb since we would need to manage
-            # a bytes buffer anyhow, so we might as well just create a
-            # new instance for the time being.
-            return cls.msgpack.unpackb(raw)
-        except ValueError as err:
-            raise errors.HTTPBadRequest(
-                'Invalid MessagePack',
-                'Could not parse MessagePack body - {0}'.format(err)
-            )
-
-    @classmethod
-    def serialize(cls, media):
-        return cls.packer.pack(media)

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -7,14 +7,14 @@ from falcon.media import JSONHandler
 
 
 class Handlers(UserDict):
-    """Manages media type handlers.
+    """A dictionary like object that manages internet media type handlers.
 
     Attempts to load any imports for handlers as they are added.
     """
     def __init__(self, initial=None):
         handlers = initial or {
-            'application/json': JSONHandler,
-            'application/json; charset=UTF-8': JSONHandler
+            'application/json': JSONHandler(),
+            'application/json; charset=UTF-8': JSONHandler(),
         }
 
         # NOTE(jmvrbanac): Directly calling UserDict as it's not inheritable.

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -5,21 +5,20 @@ from falcon.media import BaseHandler
 
 
 class JSONHandler(BaseHandler):
-    @classmethod
-    def load(cls):
-        import json
-        cls.json = json
+    """Handler built using Python's :py:mod:`json` module."""
 
-    @classmethod
-    def deserialize(cls, raw):
+    def load(self):
+        import json
+        self.json = json
+
+    def deserialize(self, raw):
         try:
-            return cls.json.loads(raw.decode('utf-8'))
+            return self.json.loads(raw.decode('utf-8'))
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
                 'Could not parse JSON body - {0}'.format(err)
             )
 
-    @classmethod
-    def serialize(cls, media):
-        return cls.json.dumps(media, ensure_ascii=False).encode('utf-8')
+    def serialize(self, media):
+        return self.json.dumps(media, ensure_ascii=False).encode('utf-8')

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+
+from falcon import errors
+from falcon.media import BaseHandler
+
+
+class JSONHandler(BaseHandler):
+    @classmethod
+    def load(cls):
+        import json
+        cls.json = json
+
+    @classmethod
+    def deserialize(cls, raw):
+        try:
+            return cls.json.loads(raw.decode('utf-8'))
+        except ValueError as err:
+            raise errors.HTTPBadRequest(
+                'Invalid JSON',
+                'Could not parse JSON body - {0}'.format(err)
+            )
+
+    @classmethod
+    def serialize(cls, media):
+        return cls.json.dumps(media, ensure_ascii=False).encode('utf-8')

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import json
+
 from falcon import errors
 from falcon.media import BaseHandler
 
@@ -7,13 +9,9 @@ from falcon.media import BaseHandler
 class JSONHandler(BaseHandler):
     """Handler built using Python's :py:mod:`json` module."""
 
-    def load(self):
-        import json
-        self.json = json
-
     def deserialize(self, raw):
         try:
-            return self.json.loads(raw.decode('utf-8'))
+            return json.loads(raw.decode('utf-8'))
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
@@ -21,4 +19,4 @@ class JSONHandler(BaseHandler):
             )
 
     def serialize(self, media):
-        return self.json.dumps(media, ensure_ascii=False).encode('utf-8')
+        return json.dumps(media, ensure_ascii=False).encode('utf-8')

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -5,29 +5,31 @@ from falcon.media import BaseHandler
 
 
 class MessagePackHandler(BaseHandler):
-    @classmethod
-    def load(cls):
+    """Handler built using the :py:mod:`msgpack` module from python-msgpack
+
+    Requires the ``python-msgpack`` module to be installed.
+    """
+
+    def load(self):
         import msgpack
 
-        cls.msgpack = msgpack
-        cls.packer = msgpack.Packer(
+        self.msgpack = msgpack
+        self.packer = msgpack.Packer(
             encoding='utf-8',
             autoreset=True,
             use_bin_type=True,
         )
 
-    @classmethod
-    def deserialize(cls, raw):
+    def deserialize(self, raw):
         try:
             # NOTE(jmvrbanac): Using unpackb since we would need to manage
             # a buffer for Unpacker() which wouldn't gain us much.
-            return cls.msgpack.unpackb(raw)
+            return self.msgpack.unpackb(raw)
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid MessagePack',
                 'Could not parse MessagePack body - {0}'.format(err)
             )
 
-    @classmethod
-    def serialize(cls, media):
-        return cls.packer.pack(media)
+    def serialize(self, media):
+        return self.packer.pack(media)

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -7,10 +7,15 @@ from falcon.media import BaseHandler
 class MessagePackHandler(BaseHandler):
     """Handler built using the :py:mod:`msgpack` module from python-msgpack
 
-    Requires the ``python-msgpack`` module to be installed.
+    Note:
+        This handler uses the `bin` type option which expects bytes instead
+        of strings.
+
+    Note:
+        This handler requires the ``python-msgpack`` package to be installed.
     """
 
-    def load(self):
+    def __init__(self):
         import msgpack
 
         self.msgpack = msgpack
@@ -24,7 +29,7 @@ class MessagePackHandler(BaseHandler):
         try:
             # NOTE(jmvrbanac): Using unpackb since we would need to manage
             # a buffer for Unpacker() which wouldn't gain us much.
-            return self.msgpack.unpackb(raw)
+            return self.msgpack.unpackb(raw, encoding='utf-8')
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid MessagePack',

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from falcon import errors
+from falcon.media import BaseHandler
+
+
+class MessagePackHandler(BaseHandler):
+    @classmethod
+    def load(cls):
+        import msgpack
+
+        cls.msgpack = msgpack
+        cls.packer = msgpack.Packer(
+            encoding='utf-8',
+            autoreset=True,
+            use_bin_type=True,
+        )
+
+    @classmethod
+    def deserialize(cls, raw):
+        try:
+            # NOTE(jmvrbanac): Using unpackb since we would need to manage
+            # a buffer for Unpacker() which wouldn't gain us much.
+            return cls.msgpack.unpackb(raw)
+        except ValueError as err:
+            raise errors.HTTPBadRequest(
+                'Invalid MessagePack',
+                'Could not parse MessagePack body - {0}'.format(err)
+            )
+
+    @classmethod
+    def serialize(cls, media):
+        return cls.packer.pack(media)

--- a/falcon/media/validators/jsonschema.py
+++ b/falcon/media/validators/jsonschema.py
@@ -9,10 +9,10 @@ except ImportError:
 
 
 def validate(schema):
-    """Decorator that validates ``req.media`` using JSONSchema
+    """Decorator that validates ``req.media`` using JSON Schema
 
     Args:
-        schema (dict): A dictionary that follows the JSONSchema specification.
+        schema (dict): A dictionary that follows the JSON Schema specification.
             See `json-schema.org <http://json-schema.org/>`_ for more
             information on defining a compatible dictionary.
 
@@ -28,9 +28,9 @@ def validate(schema):
 
             # -- snip --
 
-
     Note:
-        The ``jsonschema`` library requires Python 2.7+.
+        This validator requires the ``jsonschema`` library available via
+        PyPI. The library also requires Python 2.7+.
     """
     def decorator(func):
         def wrapper(self, req, resp, *args, **kwargs):

--- a/falcon/media/validators/jsonschema.py
+++ b/falcon/media/validators/jsonschema.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+
+import falcon
+
+try:
+    import jsonschema
+except ImportError:
+    pass
+
+
+def validate(schema):
+    """Decorator that validates ``req.media`` using JSONSchema
+
+    Args:
+        schema (dict): A dictionary that follows the JSONSchema specification.
+            See `json-schema.org <http://json-schema.org/>`_ for more
+            information on defining a compatible dictionary.
+
+    Example:
+        .. code:: python
+
+            from falcon.media.validators import jsonschema
+
+            # -- snip --
+
+            @jsonschema.validate(my_post_schema)
+            def on_post(self, req, resp):
+
+            # -- snip --
+
+
+    Note:
+        The ``jsonschema`` library requires Python 2.7+.
+    """
+    def decorator(func):
+        def wrapper(self, req, resp, *args, **kwargs):
+            try:
+                jsonschema.validate(req.media, schema)
+            except jsonschema.ValidationError as e:
+                raise falcon.HTTPBadRequest(
+                    'Failed data validation',
+                    description=e.message
+                )
+
+            return func(self, req, resp, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -1,0 +1,95 @@
+import mimeparse
+from six.moves import UserDict
+
+from falcon import errors
+
+
+class Handlers(UserDict):
+    """Manages Media Type Handlers.
+
+    Attempts to load any imports for handlers as they are added.
+    """
+    def __init__(self, initial=None):
+        handlers = initial or {'application/json': Json}
+
+        # Directly calling UserDict as it's not inheritable.
+        UserDict.__init__(self, handlers)
+
+    def update(self, input_dict):
+        for handler in input_dict.values():
+            handler.load()
+
+        UserDict.update(self, input_dict)
+
+    def __setitem__(self, key, item):
+        item.load()
+        self.data[key] = item
+
+    def find_by_media_type(self, media_type, default):
+        supported_media_types = self.data.keys()
+        resolved = None
+
+        # Check via a quick method first for performance
+        if media_type in supported_media_types or media_type == '*/*':
+            resolved = media_type
+
+        # Fallback to the slower method
+        else:
+            try:
+                resolved = mimeparse.best_match(
+                    supported_media_types,
+                    media_type
+                )
+            except ValueError:
+                resolved = None
+
+        if resolved == '*/*':
+            resolved = default
+        elif not resolved:
+            raise errors.HTTPUnsupportedMediaType(
+                '{0} is a unsupported media type.'.format(media_type)
+            )
+
+        return self.data[resolved]
+
+
+class Json(object):
+    @classmethod
+    def load(cls):
+        import json
+        cls.json = json
+
+    @classmethod
+    def deserialize(cls, raw):
+        try:
+            return cls.json.loads(raw.decode('utf-8'))
+        except ValueError:
+            raise errors.HTTPBadRequest(
+                'Invalid JSON',
+                'Could not parse JSON body'
+            )
+
+    @classmethod
+    def serialize(cls, media):
+        return cls.json.dumps(media)
+
+
+class MessagePack(object):
+    @classmethod
+    def load(cls):
+        import msgpack
+        cls.msgpack = msgpack
+
+    @classmethod
+    def deserialize(cls, raw):
+        try:
+            return cls.msgpack.unpackb(raw)
+        except ValueError:
+            raise errors.HTTPBadRequest(
+                'Invalid MessagePack',
+                'Could not parse MessagePack body'
+            )
+
+    @classmethod
+    def serialize(cls, media):
+        return cls.msgpack.packb(media)

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -22,6 +22,9 @@ class Handlers(UserDict):
         UserDict.update(self, input_dict)
 
     def __setitem__(self, key, item):
+        if not key:
+            raise ValueError('Media Type cannot be None or empty string')
+
         item.load()
         self.data[key] = item
 
@@ -46,6 +49,8 @@ class Handlers(UserDict):
             except:
                 pass
 
+        # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
+        # parse the media type, but cannot find a suitable type.
         if not resolved:
             raise errors.HTTPUnsupportedMediaType(
                 '{0} is a unsupported media type.'.format(media_type)
@@ -64,10 +69,10 @@ class Json(object):
     def deserialize(cls, raw):
         try:
             return cls.json.loads(raw.decode('utf-8'))
-        except ValueError:
+        except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
-                'Could not parse JSON body'
+                'Could not parse JSON body - {0}'.format(err)
             )
 
     @classmethod
@@ -85,10 +90,10 @@ class MessagePack(object):
     def deserialize(cls, raw):
         try:
             return cls.msgpack.unpackb(raw)
-        except ValueError:
+        except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid MessagePack',
-                'Could not parse MessagePack body'
+                'Could not parse MessagePack body - {0}'.format(err)
             )
 
     @classmethod

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -5,14 +5,18 @@ from falcon import errors
 
 
 class Handlers(UserDict):
-    """Manages Media Type Handlers.
+    """Manages media type handlers.
 
     Attempts to load any imports for handlers as they are added.
     """
     def __init__(self, initial=None):
-        handlers = initial or {'application/json; charset=UTF-8': Json}
+        handlers = initial or {
+            'application/json': Json,
+            'application/json; charset=UTF-8': Json
+        }
 
-        # Directly calling UserDict as it's not inheritable.
+        # NOTE(jmvrbanac): Directly calling UserDict as it's not inheritable.
+        # Also, this results in self.update(...) being called.
         UserDict.__init__(self, handlers)
 
     def update(self, input_dict):
@@ -23,37 +27,42 @@ class Handlers(UserDict):
 
     def __setitem__(self, key, item):
         if not key:
-            raise ValueError('Media Type cannot be None or empty string')
+            raise ValueError('Media Type cannot be None or an empty string')
 
         item.load()
         self.data[key] = item
 
-    def find_by_media_type(self, media_type, default):
-        supported_media_types = self.data.keys()
+    def _resolve_media_type(self, media_type, all_media_types):
         resolved = None
 
-        # Check via a quick methods first for performance
-        if media_type in supported_media_types:
-            resolved = media_type
+        try:
+            resolved = mimeparse.best_match(
+                all_media_types,
+                media_type
+            )
+        except ValueError:
+            pass
 
-        elif media_type == '*/*' or not media_type:
-            resolved = default
+        return resolved
 
-        # Fallback to the slower method
-        else:
-            try:
-                resolved = mimeparse.best_match(
-                    supported_media_types,
-                    media_type
-                )
-            except:
-                pass
+    def find_by_media_type(self, media_type, default):
+        # PERF(jmvrbanac): Check via a quick methods first for performance
+        try:
+            return self.data[media_type]
+        except KeyError:
+            pass
+
+        if media_type == '*/*' or not media_type:
+            return self.data[default]
+
+        # PERF(jmvrbanac): Fallback to the slower method
+        resolved = self._resolve_media_type(media_type, self.data.keys())
 
         # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
         # parse the media type, but cannot find a suitable type.
         if not resolved:
             raise errors.HTTPUnsupportedMediaType(
-                '{0} is a unsupported media type.'.format(media_type)
+                '{0} is an unsupported media type.'.format(media_type)
             )
 
         return self.data[resolved]
@@ -84,11 +93,20 @@ class MessagePack(object):
     @classmethod
     def load(cls):
         import msgpack
+
         cls.msgpack = msgpack
+        cls.packer = msgpack.Packer(
+            encoding='utf-8',
+            autoreset=True,
+            use_bin_type=True,
+        )
 
     @classmethod
     def deserialize(cls, raw):
         try:
+            # NOTE(jmvrbanac): Using unpackb since we would need to manage
+            # a bytes buffer anyhow, so we might as well just create a
+            # new instance for the time being.
             return cls.msgpack.unpackb(raw)
         except ValueError as err:
             raise errors.HTTPBadRequest(
@@ -98,4 +116,4 @@ class MessagePack(object):
 
     @classmethod
     def serialize(cls, media):
-        return cls.msgpack.packb(media)
+        return cls.packer.pack(media)

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -35,13 +35,7 @@ class Handlers(UserDict):
 
         # Fallback to the slower method
         else:
-            try:
-                resolved = mimeparse.best_match(
-                    supported_media_types,
-                    media_type
-                )
-            except ValueError:
-                resolved = None
+            resolved = mimeparse.best_match(supported_media_types, media_type)
 
         if resolved == '*/*':
             resolved = default

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -29,17 +29,24 @@ class Handlers(UserDict):
         supported_media_types = self.data.keys()
         resolved = None
 
-        # Check via a quick method first for performance
-        if media_type in supported_media_types or media_type == '*/*':
+        # Check via a quick methods first for performance
+        if media_type in supported_media_types:
             resolved = media_type
+
+        elif media_type == '*/*' or not media_type:
+            resolved = default
 
         # Fallback to the slower method
         else:
-            resolved = mimeparse.best_match(supported_media_types, media_type)
+            try:
+                resolved = mimeparse.best_match(
+                    supported_media_types,
+                    media_type
+                )
+            except:
+                pass
 
-        if resolved == '*/*':
-            resolved = default
-        elif not resolved:
+        if not resolved:
             raise errors.HTTPUnsupportedMediaType(
                 '{0} is a unsupported media type.'.format(media_type)
             )

--- a/falcon/media_handlers.py
+++ b/falcon/media_handlers.py
@@ -10,7 +10,7 @@ class Handlers(UserDict):
     Attempts to load any imports for handlers as they are added.
     """
     def __init__(self, initial=None):
-        handlers = initial or {'application/json': Json}
+        handlers = initial or {'application/json; charset=UTF-8': Json}
 
         # Directly calling UserDict as it's not inheritable.
         UserDict.__init__(self, handlers)

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -40,7 +40,7 @@ from falcon import DEFAULT_MEDIA_TYPE
 from falcon import errors
 from falcon import request_helpers as helpers
 from falcon import util
-from falcon.media_handlers import Handlers
+from falcon.media import Handlers
 from falcon.util.uri import parse_host, parse_query_string, unquote_string
 
 # NOTE(tbug): In some cases, http_cookies is not a module

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -756,9 +756,6 @@ class Request(object):
         if self._media:
             return self._media
 
-        if not self.content_type:
-            self.content_type = self.options.default_media_type
-
         handler = self.options.media_handlers.find_by_media_type(
             self.content_type,
             self.options.default_media_type

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -762,13 +762,7 @@ class Request(object):
         )
 
         # Consume the stream
-        try:
-            raw = self.stream.read()
-        except Exception:
-            raise errors.HTTPBadRequest(
-                'Invalid Data',
-                'Could not parse request body'
-            )
+        raw = self.bounded_stream.read()
 
         # Deserialize and Return
         self._media = handler.deserialize(raw)

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -747,7 +747,7 @@ class Request(object):
             return self._media
 
         handler = self.options.media_handlers.find_by_media_type(
-            self.accept,
+            self.content_type,
             self.options.default_media_type
         )
 

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -252,6 +252,16 @@ class Request(object):
 
                 doc = json.load(req.bounded_stream)
 
+        media (object): Returns a deserialized form of the request stream.
+            When called, it will attempt to deserialize the request stream
+            using the Content-Type header as well as the media-type handlers
+            configured in the request options.
+
+            Note:
+                This operation will consume the request stream the first time
+                it's called and cache the results. Follow-up calls, will just
+                retrieve a cached version of object.
+
         date (datetime): Value of the Date header, converted to a
             ``datetime`` instance. The header value is assumed to
             conform to RFC 1123.
@@ -1420,6 +1430,12 @@ class RequestOptions(object):
             forward slash. However, this behavior can be problematic in
             certain cases, such as when working with authentication
             schemes that employ URL-based signatures.
+
+        default_media_type (str): The default media-type to use when
+            deserializing a response.
+
+        media_handlers (Handlers): A dict-like object that allows for you to
+            configure the media-types that you would like to handle.
     """
     __slots__ = (
         'keep_blank_qs_values',

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1434,7 +1434,7 @@ class RequestOptions(object):
             if created independently, this will default to the
             ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
 
-        media_handlers (Handlers): A dict-like object that allows for you to
+        media_handlers (Handlers): A dict-like object that allows you to
             configure the media-types that you would like to handle.
             By default, a handler is provided for the ``application/json``
             media type.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -257,7 +257,7 @@ class Request(object):
             using the Content-Type header as well as the media-type handlers
             configured in the request options.
 
-            Note:
+            Warning:
                 This operation will consume the request stream the first time
                 it's called and cache the results. Follow-up calls, will just
                 retrieve a cached version of object.
@@ -755,6 +755,9 @@ class Request(object):
     def media(self):
         if self._media:
             return self._media
+
+        if not self.content_type:
+            self.content_type = self.options.default_media_type
 
         handler = self.options.media_handlers.find_by_media_type(
             self.content_type,

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -36,6 +36,7 @@ import mimeparse
 import six
 from six.moves import http_cookies
 
+from falcon import DEFAULT_MEDIA_TYPE
 from falcon import errors
 from falcon import request_helpers as helpers
 from falcon import util
@@ -255,12 +256,14 @@ class Request(object):
         media (object): Returns a deserialized form of the request stream.
             When called, it will attempt to deserialize the request stream
             using the Content-Type header as well as the media-type handlers
-            configured in the request options.
+            configured via :class:`falcon.RequestOptions`.
+
+            See :ref:`media` for more information regarding media handling.
 
             Warning:
                 This operation will consume the request stream the first time
-                it's called and cache the results. Follow-up calls, will just
-                retrieve a cached version of object.
+                it's called and cache the results. Follow-up calls will just
+                retrieve a cached version of the object.
 
         date (datetime): Value of the Date header, converted to a
             ``datetime`` instance. The header value is assumed to
@@ -1426,10 +1429,15 @@ class RequestOptions(object):
             schemes that employ URL-based signatures.
 
         default_media_type (str): The default media-type to use when
-            deserializing a response.
+            deserializing a response. This value is normally set to the media
+            type provided when a :class:`falcon.API` is initialized; however,
+            if created independently, this will default to the
+            ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
 
         media_handlers (Handlers): A dict-like object that allows for you to
             configure the media-types that you would like to handle.
+            By default, a handler is provided for the ``application/json``
+            media type.
     """
     __slots__ = (
         'keep_blank_qs_values',
@@ -1445,5 +1453,5 @@ class RequestOptions(object):
         self.auto_parse_form_urlencoded = False
         self.auto_parse_qs_csv = True
         self.strip_url_path_trailing_slash = True
-        self.default_media_type = 'application/json'
+        self.default_media_type = DEFAULT_MEDIA_TYPE
         self.media_handlers = Handlers()

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -757,7 +757,7 @@ class Request(object):
         except Exception:
             raise errors.HTTPBadRequest(
                 'Invalid Data',
-                'Couldn\'t parse request body'
+                'Could not parse request body'
             )
 
         # Deserialize and Return

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -814,7 +814,7 @@ class ResponseOptions(object):
             if created independently, this will default to the
             ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
 
-        media_handlers (Handlers): A dict-like object that allows for you to
+        media_handlers (Handlers): A dict-like object that allows you to
             configure the media-types that you would like to handle.
             By default, a handler is provided for the ``application/json``
             media type.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -23,7 +23,7 @@ from six import string_types as STRING_TYPES
 from six.moves import http_cookies
 
 from falcon import DEFAULT_MEDIA_TYPE
-from falcon.media_handlers import Handlers
+from falcon.media import Handlers
 from falcon.response_helpers import (
     format_header_value_list,
     format_range,

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -22,6 +22,7 @@ from six import string_types as STRING_TYPES
 # See issue https://github.com/falconry/falcon/issues/556
 from six.moves import http_cookies
 
+from falcon import DEFAULT_MEDIA_TYPE
 from falcon.media_handlers import Handlers
 from falcon.response_helpers import (
     format_header_value_list,
@@ -88,12 +89,9 @@ class Response(object):
                 HTTP response.
 
         media (object): A serializable object supported by the media handlers
-            configured via response options.
+            configured via :class:`falcon.RequestOptions`.
 
-            Note:
-                This operation will consume the response stream the first time
-                it's called and cache the results. Follow-up calls, will just
-                retrieve the cached version of the object.
+            See :ref:`media` for more information regarding media handling.
 
         stream: Either a file-like object with a `read()` method that takes
             an optional size argument and returns a block of bytes, or an
@@ -811,10 +809,15 @@ class ResponseOptions(object):
             be overridden via `set_cookie()`'s `secure` kwarg.
 
         default_media_type (str): The default media-type to use when
-            deserializing a response.
+            deserializing a response. This value is normally set to the media
+            type provided when a :class:`falcon.API` is initialized; however,
+            if created independently, this will default to the
+            ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
 
-        media_handlers (Handlers): A dict-like object that allows for you
-            to configure the media-types that you would like to handle.
+        media_handlers (Handlers): A dict-like object that allows for you to
+            configure the media-types that you would like to handle.
+            By default, a handler is provided for the ``application/json``
+            media type.
     """
     __slots__ = (
         'secure_cookies_by_default',
@@ -824,5 +827,5 @@ class ResponseOptions(object):
 
     def __init__(self):
         self.secure_cookies_by_default = True
-        self.default_media_type = 'application/json'
+        self.default_media_type = DEFAULT_MEDIA_TYPE
         self.media_handlers = Handlers()

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -162,6 +162,10 @@ class Response(object):
     @media.setter
     def media(self, obj):
         self._media = obj
+
+        if not self.content_type:
+            self.content_type = self.options.default_media_type
+
         handler = self.options.media_handlers.find_by_media_type(
             self.content_type,
             self.options.default_media_type

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -87,6 +87,14 @@ class Response(object):
                 ensure Unicode characters are properly encoded in the
                 HTTP response.
 
+        media (object): A serializable object supported by the media handlers
+            configured via response options.
+
+            Note:
+                This operation will consume the response stream the first time
+                it's called and cache the results. Follow-up calls, will just
+                retrieve the cached version of the object.
+
         stream: Either a file-like object with a `read()` method that takes
             an optional size argument and returns a block of bytes, or an
             iterable object, representing response content, and yielding
@@ -801,6 +809,12 @@ class ResponseOptions(object):
             default to ``False``. This can make testing easier by
             not requiring HTTPS. Note, however, that this setting can
             be overridden via `set_cookie()`'s `secure` kwarg.
+
+        default_media_type (str): The default media-type to use when
+            deserializing a response.
+
+        media_handlers (Handlers): A dict-like object that allows for you
+            to configure the media-types that you would like to handle.
     """
     __slots__ = (
         'secure_cookies_by_default',

--- a/requirements/tests
+++ b/requirements/tests
@@ -9,3 +9,6 @@ testtools
 
 # Handler Specific
 msgpack-python
+
+# Validator Specific
+jsonschema

--- a/requirements/tests
+++ b/requirements/tests
@@ -6,3 +6,6 @@ pyyaml
 requests
 six
 testtools
+
+# Handler Specific
+msgpack-python

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -3,16 +3,6 @@ import pytest
 from falcon import media
 
 
-@pytest.mark.parametrize('key', ['', None])
-def test_set_invalid_handlers(key):
-    handlers = media.Handlers()
-
-    with pytest.raises(ValueError) as err:
-        handlers[''] = 'nope'
-
-    assert str(err.value) == 'Media Type cannot be None or an empty string'
-
-
 def test_base_handler_contract():
     class TestHandler(media.BaseHandler):
         pass
@@ -20,4 +10,4 @@ def test_base_handler_contract():
     with pytest.raises(TypeError) as err:
         TestHandler()
 
-    assert 'abstract methods deserialize, load, serialize' in str(err.value)
+    assert 'abstract methods deserialize, serialize' in str(err.value)

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -10,4 +10,4 @@ def test_set_invalid_handlers(key):
     with pytest.raises(ValueError) as err:
         handlers[''] = 'nope'
 
-    assert str(err.value) == 'Media Type cannot be None or empty string'
+    assert str(err.value) == 'Media Type cannot be None or an empty string'

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -1,0 +1,13 @@
+import pytest
+
+from falcon import media_handlers
+
+
+@pytest.mark.parametrize('key', ['', None])
+def test_set_invalid_handlers(key):
+    handlers = media_handlers.Handlers()
+
+    with pytest.raises(ValueError) as err:
+        handlers[''] = 'nope'
+
+    assert str(err.value) == 'Media Type cannot be None or empty string'

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -1,11 +1,11 @@
 import pytest
 
-from falcon import media_handlers
+from falcon import media
 
 
 @pytest.mark.parametrize('key', ['', None])
 def test_set_invalid_handlers(key):
-    handlers = media_handlers.Handlers()
+    handlers = media.Handlers()
 
     with pytest.raises(ValueError) as err:
         handlers[''] = 'nope'

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -11,3 +11,13 @@ def test_set_invalid_handlers(key):
         handlers[''] = 'nope'
 
     assert str(err.value) == 'Media Type cannot be None or an empty string'
+
+
+def test_base_handler_contract():
+    class TestHandler(media.BaseHandler):
+        pass
+
+    with pytest.raises(TypeError) as err:
+        TestHandler()
+
+    assert 'abstract methods deserialize, load, serialize' in str(err.value)

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -46,13 +46,21 @@ def test_msgpack(media_type):
         'application/msgpack': media.MessagePackHandler(),
         'application/x-msgpack': media.MessagePackHandler(),
     })
-    expected_body = b'\x81\xc4\tsomething\xc3'
     headers = {'Content-Type': media_type}
+
+    # Bytes
+    expected_body = b'\x81\xc4\tsomething\xc3'
     client.simulate_post('/', body=expected_body, headers=headers)
 
     req_media = client.resource.captured_req.media
-    assert req_media is not None
     assert req_media.get(b'something') is True
+
+    # Unicode
+    expected_body = b'\x81\xa9something\xc3'
+    client.simulate_post('/', body=expected_body, headers=headers)
+
+    req_media = client.resource.captured_req.media
+    assert req_media.get(u'something') is True
 
 
 @pytest.mark.parametrize('media_type', [

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -1,0 +1,65 @@
+import pytest
+
+import falcon
+from falcon import errors, media_handlers, testing
+
+
+def create_client(handlers=None):
+    res = testing.SimpleTestResource()
+
+    app = falcon.API()
+    app.add_route('/', res)
+
+    if handlers:
+        app.req_options.media_handlers.update(handlers)
+
+    client = testing.TestClient(app)
+    client.resource = res
+
+    return client
+
+
+@pytest.mark.parametrize('accept', [
+    ('*/*'),
+    ('application/json'),
+    ('application/json; charset=utf-8'),
+])
+def test_json(accept):
+    client = create_client()
+    expected_body = b'{"something": true}'
+    headers = {'Accept': accept}
+    client.simulate_post('/', body=expected_body, headers=headers)
+
+    media = client.resource.captured_req.media
+    assert media is not None
+    assert media.get('something') is True
+
+
+@pytest.mark.parametrize('accept', [
+    ('application/msgpack'),
+    ('application/msgpack; charset=utf-8'),
+    ('application/x-msgpack'),
+])
+def test_msgpack(accept):
+    client = create_client({
+        'application/msgpack': media_handlers.MessagePack,
+        'application/x-msgpack': media_handlers.MessagePack,
+    })
+    expected_body = b'\x81\xa9something\xc3'
+    headers = {'Accept': accept}
+    client.simulate_post('/', body=expected_body, headers=headers)
+
+    media = client.resource.captured_req.media
+    assert media is not None
+    assert media.get(b'something') is True
+
+
+def test_unknown_media_type():
+    client = create_client()
+    headers = {'Accept': 'nope/json'}
+    client.simulate_get('/', headers=headers)
+
+    with pytest.raises(errors.HTTPUnsupportedMediaType) as err:
+        client.resource.captured_req.media
+
+    assert err.value.description == 'nope/json is a unsupported media type.'

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -46,7 +46,7 @@ def test_msgpack(media_type):
         'application/msgpack': media_handlers.MessagePack,
         'application/x-msgpack': media_handlers.MessagePack,
     })
-    expected_body = b'\x81\xa9something\xc3'
+    expected_body = b'\x81\xc4\tsomething\xc3'
     headers = {'Content-Type': media_type}
     client.simulate_post('/', body=expected_body, headers=headers)
 
@@ -66,7 +66,7 @@ def test_unknown_media_type(media_type):
     with pytest.raises(errors.HTTPUnsupportedMediaType) as err:
         client.resource.captured_req.media
 
-    msg = '{0} is a unsupported media type.'.format(media_type)
+    msg = '{0} is an unsupported media type.'.format(media_type)
     assert err.value.description == msg
 
 
@@ -84,7 +84,7 @@ def test_invalid_json():
 
 def test_invalid_msgpack():
     client = create_client({'application/msgpack': media_handlers.MessagePack})
-    expected_body = '/////////'
+    expected_body = '/////////////////////'
     headers = {'Content-Type': 'application/msgpack'}
     client.simulate_post('/', body=expected_body, headers=headers)
 

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -1,7 +1,7 @@
 import pytest
 
 import falcon
-from falcon import errors, media_handlers, testing
+from falcon import errors, media, testing
 
 
 def create_client(handlers=None):
@@ -43,16 +43,16 @@ def test_json(media_type):
 ])
 def test_msgpack(media_type):
     client = create_client({
-        'application/msgpack': media_handlers.MessagePack,
-        'application/x-msgpack': media_handlers.MessagePack,
+        'application/msgpack': media.MessagePackHandler,
+        'application/x-msgpack': media.MessagePackHandler,
     })
     expected_body = b'\x81\xc4\tsomething\xc3'
     headers = {'Content-Type': media_type}
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    media = client.resource.captured_req.media
-    assert media is not None
-    assert media.get(b'something') is True
+    req_media = client.resource.captured_req.media
+    assert req_media is not None
+    assert req_media.get(b'something') is True
 
 
 @pytest.mark.parametrize('media_type', [
@@ -83,7 +83,7 @@ def test_invalid_json():
 
 
 def test_invalid_msgpack():
-    client = create_client({'application/msgpack': media_handlers.MessagePack})
+    client = create_client({'application/msgpack': media.MessagePackHandler})
     expected_body = '/////////////////////'
     headers = {'Content-Type': 'application/msgpack'}
     client.simulate_post('/', body=expected_body, headers=headers)

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -43,8 +43,8 @@ def test_json(media_type):
 ])
 def test_msgpack(media_type):
     client = create_client({
-        'application/msgpack': media.MessagePackHandler,
-        'application/x-msgpack': media.MessagePackHandler,
+        'application/msgpack': media.MessagePackHandler(),
+        'application/x-msgpack': media.MessagePackHandler(),
     })
     expected_body = b'\x81\xc4\tsomething\xc3'
     headers = {'Content-Type': media_type}
@@ -83,7 +83,7 @@ def test_invalid_json():
 
 
 def test_invalid_msgpack():
-    client = create_client({'application/msgpack': media.MessagePackHandler})
+    client = create_client({'application/msgpack': media.MessagePackHandler()})
     expected_body = '/////////////////////'
     headers = {'Content-Type': 'application/msgpack'}
     client.simulate_post('/', body=expected_body, headers=headers)

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -79,7 +79,7 @@ def test_invalid_json():
     with pytest.raises(errors.HTTPBadRequest) as err:
         client.resource.captured_req.media
 
-    assert err.value.description == 'Could not parse JSON body'
+    assert 'Could not parse JSON body' in err.value.description
 
 
 def test_invalid_msgpack():
@@ -91,7 +91,8 @@ def test_invalid_msgpack():
     with pytest.raises(errors.HTTPBadRequest) as err:
         client.resource.captured_req.media
 
-    assert err.value.description == 'Could not parse MessagePack body'
+    desc = 'Could not parse MessagePack body - unpack(b) received extra data.'
+    assert err.value.description == desc
 
 
 def test_invalid_stream_fails_gracefully():
@@ -100,12 +101,12 @@ def test_invalid_stream_fails_gracefully():
 
     req = client.resource.captured_req
     req.headers['Content-Type'] = 'application/json'
-    req.stream = None
+    req._bounded_stream = None
 
     with pytest.raises(errors.HTTPBadRequest) as err:
         req.media
 
-    assert err.value.description == 'Could not parse request body'
+    assert 'Could not parse JSON body' in err.value.description
 
 
 def test_use_cached_media():

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -1,4 +1,5 @@
 import pytest
+import six
 
 import falcon
 from falcon import errors, media_handlers, testing
@@ -78,12 +79,16 @@ def test_use_cached_media():
     assert resp.media == expected
 
 
-def test_default_media_type():
+@pytest.mark.parametrize('media_type', [
+    (''),
+    pytest.mark.skipif(six.PY2, reason='PY3 only')(None),
+])
+def test_default_media_type(media_type):
     client = create_client()
     client.simulate_get('/')
 
     resp = client.resource.captured_resp
-    resp.content_type = ''
+    resp.content_type = media_type
     resp.media = {'something': True}
 
     assert resp.data == '{"something": true}'

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -50,9 +50,9 @@ def test_msgpack(media_type):
 
     resp = client.resource.captured_resp
     resp.content_type = media_type
-    resp.media = {'something': True}
+    resp.media = {b'something': True}
 
-    assert resp.data == b'\x81\xa9something\xc3'
+    assert resp.data == b'\x81\xc4\tsomething\xc3'
 
 
 def test_unknown_media_type():
@@ -64,7 +64,7 @@ def test_unknown_media_type():
         resp.content_type = 'nope/json'
         resp.media = {'something': True}
 
-    assert err.value.description == 'nope/json is a unsupported media type.'
+    assert err.value.description == 'nope/json is an unsupported media type.'
 
 
 def test_use_cached_media():

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -43,8 +43,8 @@ def test_json(media_type):
 ])
 def test_msgpack(media_type):
     client = create_client({
-        'application/msgpack': media.MessagePackHandler,
-        'application/x-msgpack': media.MessagePackHandler,
+        'application/msgpack': media.MessagePackHandler(),
+        'application/x-msgpack': media.MessagePackHandler(),
     })
     client.simulate_get('/')
 

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -2,7 +2,7 @@ import pytest
 import six
 
 import falcon
-from falcon import errors, media_handlers, testing
+from falcon import errors, media, testing
 
 
 def create_client(handlers=None):
@@ -33,7 +33,7 @@ def test_json(media_type):
     resp.content_type = media_type
     resp.media = {'something': True}
 
-    assert resp.data == '{"something": true}'
+    assert resp.data == b'{"something": true}'
 
 
 @pytest.mark.parametrize('media_type', [
@@ -43,8 +43,8 @@ def test_json(media_type):
 ])
 def test_msgpack(media_type):
     client = create_client({
-        'application/msgpack': media_handlers.MessagePack,
-        'application/x-msgpack': media_handlers.MessagePack,
+        'application/msgpack': media.MessagePackHandler,
+        'application/x-msgpack': media.MessagePackHandler,
     })
     client.simulate_get('/')
 
@@ -91,7 +91,7 @@ def test_default_media_type(media_type):
     resp.content_type = media_type
     resp.media = {'something': True}
 
-    assert resp.data == '{"something": true}'
+    assert resp.data == b'{"something": true}'
     assert resp.content_type == 'application/json; charset=UTF-8'
 
 

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -64,3 +64,15 @@ def test_unknown_media_type():
         resp.media = {'something': True}
 
     assert err.value.description == 'nope/json is a unsupported media type.'
+
+
+def test_use_cached_media():
+    expected = {'something': True}
+
+    client = create_client()
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    resp._media = expected
+
+    assert resp.media == expected

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -76,3 +76,15 @@ def test_use_cached_media():
     resp._media = expected
 
     assert resp.media == expected
+
+
+def test_default_media_type():
+    client = create_client()
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    resp.content_type = ''
+    resp.media = {'something': True}
+
+    assert resp.data == '{"something": true}'
+    assert resp.content_type == 'application/json; charset=UTF-8'

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -50,9 +50,14 @@ def test_msgpack(media_type):
 
     resp = client.resource.captured_resp
     resp.content_type = media_type
-    resp.media = {b'something': True}
 
+    # Bytes
+    resp.media = {b'something': True}
     assert resp.data == b'\x81\xc4\tsomething\xc3'
+
+    # Unicode
+    resp.media = {u'something': True}
+    assert resp.data == b'\x81\xa9something\xc3'
 
 
 def test_unknown_media_type():

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -93,3 +93,14 @@ def test_default_media_type(media_type):
 
     assert resp.data == '{"something": true}'
     assert resp.content_type == 'application/json; charset=UTF-8'
+
+
+@pytest.mark.skipif(six.PY3, reason='Python 2 edge-case only')
+def test_mimeparse_edgecases():
+    client = create_client()
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    with pytest.raises(errors.HTTPUnsupportedMediaType):
+        resp.content_type = None
+        resp.media = {'something': True}

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -1,0 +1,66 @@
+import pytest
+
+import falcon
+from falcon import errors, media_handlers, testing
+
+
+def create_client(handlers=None):
+    res = testing.SimpleTestResource()
+
+    app = falcon.API()
+    app.add_route('/', res)
+
+    if handlers:
+        app.resp_options.media_handlers.update(handlers)
+
+    client = testing.TestClient(app)
+    client.resource = res
+
+    return client
+
+
+@pytest.mark.parametrize('media_type', [
+    ('*/*'),
+    ('application/json'),
+    ('application/json; charset=utf-8'),
+])
+def test_json(media_type):
+    client = create_client()
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    resp.content_type = media_type
+    resp.media = {'something': True}
+
+    assert resp.data == '{"something": true}'
+
+
+@pytest.mark.parametrize('media_type', [
+    ('application/msgpack'),
+    ('application/msgpack; charset=utf-8'),
+    ('application/x-msgpack'),
+])
+def test_msgpack(media_type):
+    client = create_client({
+        'application/msgpack': media_handlers.MessagePack,
+        'application/x-msgpack': media_handlers.MessagePack,
+    })
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    resp.content_type = media_type
+    resp.media = {'something': True}
+
+    assert resp.data == b'\x81\xa9something\xc3'
+
+
+def test_unknown_media_type():
+    client = create_client()
+    client.simulate_get('/')
+
+    resp = client.resource.captured_resp
+    with pytest.raises(errors.HTTPUnsupportedMediaType) as err:
+        resp.content_type = 'nope/json'
+        resp.media = {'something': True}
+
+    assert err.value.description == 'nope/json is a unsupported media type.'

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,51 @@
+import sys
+
+import pytest
+
+import falcon
+from falcon.media.validators import jsonschema
+
+skip_py26 = pytest.mark.skipif(
+    sys.version_info[:2] == (2, 6),
+    reason='Minimum Python version for this feature is 2.7.x'
+)
+
+basic_schema = {
+    'type': 'object',
+    'properies': {
+        'message': {
+            'type': 'string',
+        },
+    },
+    'required': ['message'],
+}
+
+
+class SampleResource(object):
+    @jsonschema.validate(basic_schema)
+    def on_get(self, req, resp):
+        assert req.media is not None
+
+
+class RequestStub(object):
+    media = {'message': 'something'}
+
+
+@skip_py26
+def test_jsonschema_validation_success():
+    req = RequestStub()
+
+    res = SampleResource()
+    assert res.on_get(req, None) is None
+
+
+@skip_py26
+def test_jsonschema_validation_failure():
+    req = RequestStub()
+    req.media = {}
+
+    res = SampleResource()
+    with pytest.raises(falcon.HTTPBadRequest) as err:
+        res.on_get(req, None)
+
+    assert err.value.description == '\'message\' is a required property'


### PR DESCRIPTION
This is a first pass at a non-breaking change that'll allow for a customizable media handling system. This approach combines many of the suggestions brought up by the community in #145.  

One the thing that is left out of this PR is handling full content negotiation (i.e. connecting the request's accept header to the response's content-type). Unfortunately, this is a harder problem to solve in a backwards compatible fashion that doesn't affect performance. However, especially as we move towards v2, I think that would be a great opportunity to revist full negotiation. In the meantime, there are several easy workarounds for people needing this functionality.