### PR TITLE
doc(errors): Fix RFC links

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -1196,8 +1196,8 @@ class HTTPNotImplemented(HTTPError):
     request method and is not capable of supporting it for any resource.
 
     A 501 response is cacheable by default; i.e., unless otherwise
-    indicated by the method definition or explicit cache controls (see
-    Section 4.2.2 of [RFC7234]).
+    indicated by the method definition or explicit cache controls
+    as described in RFC 7234, Section 4.2.2.
 
     (See also: RFC 7231, Section 6.6.2)
 
@@ -1400,8 +1400,8 @@ class HTTPVersionNotSupported(HTTPError):
     server does not support, or refuses to support, the major version of
     HTTP that was used in the request message.  The server is indicating
     that it is unable or unwilling to complete the request using the same
-    major version as the client, as described in Section 2.6 of
-    [RFC7230], other than with this error message.  The server SHOULD
+    major version as the client (as described in RFC 7230, Section 2.6),
+    other than with this error message.  The server SHOULD
     generate a representation for the 505 response that describes why
     that version is not supported and what other protocols are supported
     by that server.


### PR DESCRIPTION
The bracketed convention does not work with our sphinx setup, so switch to a format that *will* be recognized and linked.