### PR TITLE
docs(api/errors): fix syntax error in example code

### DIFF
--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -33,8 +33,8 @@ All classes are available directly in the ``falcon`` package namespace::
             # ...
 
             raise falcon.HTTPBadRequest(
-                'TTL Out of Range',
-                'The message's TTL must be between 60 and 300 seconds, inclusive.'
+                "TTL Out of Range",
+                "The message's TTL must be between 60 and 300 seconds, inclusive."
             )
 
             # ...

--- a/tests/test_wsgi_interface.py
+++ b/tests/test_wsgi_interface.py
@@ -51,5 +51,5 @@ def _is_iterable(thing):
             break
 
         return True
-    except:
+    except TypeError:
         return False


### PR DESCRIPTION
Use double quotes for strings, since there is a single apostrophe
inside.