### PR TITLE
feat(util): Add internal cookie parsing support

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -34,19 +34,14 @@ from wsgiref.validate import InputWrapper
 
 import mimeparse
 import six
-from six.moves import http_cookies
 
 from falcon import DEFAULT_MEDIA_TYPE
 from falcon import errors
 from falcon import request_helpers as helpers
 from falcon import util
 from falcon.media import Handlers
+from falcon.util.cookies import parse_cookies
 from falcon.util.uri import parse_host, parse_query_string, unquote_string
-
-# NOTE(tbug): In some cases, http_cookies is not a module
-# but a dict-like structure. This fixes that issue.
-# See issue https://github.com/falconry/falcon/issues/556
-SimpleCookie = http_cookies.SimpleCookie
 
 DEFAULT_ERROR_LOG_FORMAT = (u'{0:%Y-%m-%d %H:%M:%S} [FALCON] [ERROR]'
                             u' {1} {2}{3} => ')
@@ -893,19 +888,8 @@ class Request(object):
     @property
     def cookies(self):
         if self._cookies is None:
-            # NOTE(tbug): We might want to look into parsing
-            # cookies ourselves. The SimpleCookie is doing a
-            # lot if stuff only required to SEND cookies.
             cookie_header = self.get_header('Cookie', default='')
-            parser = SimpleCookie()
-            for cookie_part in cookie_header.split('; '):
-                try:
-                    parser.load(cookie_part)
-                except http_cookies.CookieError:
-                    pass
-            cookies = {}
-            for morsel in parser.values():
-                cookies[morsel.key] = morsel.value
+            cookies = parse_cookies(cookie_header)
 
             self._cookies = cookies
 

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -34,6 +34,7 @@ from wsgiref.validate import InputWrapper
 
 import mimeparse
 import six
+from six.moves import http_cookies
 
 from falcon import DEFAULT_MEDIA_TYPE
 from falcon import errors
@@ -42,6 +43,11 @@ from falcon import util
 from falcon.media import Handlers
 from falcon.util.cookies import parse_cookies
 from falcon.util.uri import parse_host, parse_query_string, unquote_string
+
+# NOTE(tbug): In some cases, http_cookies is not a module
+# but a dict-like structure. This fixes that issue.
+# See issue https://github.com/falconry/falcon/issues/556
+SimpleCookie = http_cookies.SimpleCookie
 
 DEFAULT_ERROR_LOG_FORMAT = (u'{0:%Y-%m-%d %H:%M:%S} [FALCON] [ERROR]'
                             u' {1} {2}{3} => ')

--- a/falcon/util/cookies.py
+++ b/falcon/util/cookies.py
@@ -73,7 +73,7 @@ _reserved = {
     'httponly': 'HttpOnly',
     'version': 'Version',
 }
-_flags = {'secure', 'httponly'}
+_flags = ['secure', 'httponly']
 
 
 def parse_cookies(cookie_header):

--- a/falcon/util/cookies.py
+++ b/falcon/util/cookies.py
@@ -1,0 +1,194 @@
+# Copyright 2013 by Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cookie parsing utility.
+
+This module provides a utility function to parse cookies and is
+a refactored version of the cpython 3.7 cookies library. We have
+removed functionality that we don't use related to setting cookies
+in order to speed up performance for the falcon framework. This
+function is not available directly in the `falcon` module and so
+must be explicitly imported:
+
+    from falcon.util.cookies import parse_cookies
+
+"""
+
+import re
+import string
+
+_LegalKeyChars = r"\w\d!#%&'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\="
+_LegalValueChars = _LegalKeyChars + r'\[\]'
+_CookiePattern = re.compile(
+    r'(?x)'                              # This is a Verbose pattern
+    r'\s*'                               # Optional whitespace at start of cookie
+    r'(?P<key>'                          # Start of group 'key'
+    '[' + _LegalKeyChars + ']+?'  # Any word of at least one letter, nongreedy
+    r')'                                 # End of group 'key'
+    r'('                                 # Optional group: there may not be a value.
+    r'\s*=\s*'                           # Equal Sign
+    r'(?P<val>'                          # Start of group 'val'
+    r'"(?:[^\\"]|\\.)*"'                 # Any doublequoted string
+    r'|'                                 # or
+    r'\w{3},\s[\s\w\d-]{9,11}\s[\d:]{8}\sGMT'  # Special case for "expires" attr
+    r'|'                                 # or
+    '[' + _LegalValueChars + ']*'        # Any word or empty string
+    r')'                                 # End of group 'val'
+    r')?'                                # End of optional value group
+    r'\s*'                               # Any number of spaces.
+    r'(\s+|;|$)'                         # Ending either at space, semicolon, or EOS.
+)
+
+# RFC 2109 lists these attributes as reserved:
+#   path       comment         domain
+#   max-age    secure      version
+#
+# For historical reasons, these attributes are also reserved:
+#   expires
+#
+# This is an extension from Microsoft:
+#   httponly
+#
+# This dictionary provides a mapping from the lowercase
+# variant on the left to the appropriate traditional
+# formatting on the right.
+_reserved = {
+    'expires': 'expires',
+    'path': 'Path',
+    'comment': 'Comment',
+    'domain': 'Domain',
+    'max-age': 'Max-Age',
+    'secure': 'Secure',
+    'httponly': 'HttpOnly',
+    'version': 'Version',
+}
+_flags = {'secure', 'httponly'}
+
+
+def parse_cookies(cookie_header):
+    """Parses a cookie header string and returns a dict
+
+    This function parses each cookie individually and discards
+    any cookies that do not conform to the following specification.
+
+    KEY=VALUE;
+
+    Keys may contain any letters, digits, or the following
+    additional characters
+
+    !#$%&'*+-.^_`|~:
+
+    Values may contain the same set of characters as keys with the
+    additional characters
+
+    {}[]()<>@,/=
+
+    Args:
+        cookie_header (str): Cookie headers
+    """
+
+    i = 0                           # Our starting point
+    n = len(cookie_header)          # Length of string
+    parsed_cookies = {}             # Parsed cookies to return {key: val,}
+
+    while 0 <= i < n:
+        # Start looking for a cookie
+        match = _CookiePattern.match(cookie_header, i)
+        if not match:
+            break          # No more cookies
+
+        key, value = match.group('key'), match.group('val')
+        i = match.end(0)
+
+        # Parse the key, value in case it's metainfo
+        if key[0] == '$':
+            # NOTE(santeyio): from cpython 3.7 docs:
+            # We ignore attributes which pertain to the cookie
+            # mechanism as a whole, such as "$Version".
+            # See RFC 2965. (Does anyone care?)
+            continue
+        elif key.lower() in _reserved:
+            if value is None:
+                if key.lower() in _flags:
+                    parsed_cookies[key] = True
+            else:
+                parsed_cookies[key] = _unquote(value)
+        # make sure final key doesn't contain illegal chars, skip if it does
+        elif not _is_legal_key(key):
+            continue
+        # If there's no value it's an invalid cookie, skip it
+        elif value is not None:
+            parsed_cookies[key] = value
+
+    return parsed_cookies
+
+
+_OctalPatt = re.compile(r'\\[0-3][0-7][0-7]')
+_QuotePatt = re.compile(r'[\\].')
+_nulljoin = ''.join
+
+
+# NOTE(santeyio): This method is taken directly from the python 3.7
+# library. Reserved key values for cookie headers can contain ASCII
+# encoded characters in double quotes. This method removes double quotes
+# and converts ASCII codes to their character values.
+def _unquote(str):
+    # If there aren't any doublequotes,
+    # then there can't be any special characters.  See RFC 2109.
+    if str is None or len(str) < 2:
+        return str
+    if str[0] != '"' or str[-1] != '"':
+        return str
+
+    # We have to assume that we must decode this string.
+
+    # Remove the "s
+    str = str[1:-1]
+
+    # Check for special sequences.  Examples:
+    #    \012 --> \n
+    #    \"   --> "
+    #
+    i = 0
+    n = len(str)
+    res = []
+    while 0 <= i < n:
+        o_match = _OctalPatt.search(str, i)
+        q_match = _QuotePatt.search(str, i)
+        if not o_match and not q_match:            # Neither matched
+            res.append(str[i:])
+            break
+        # else:
+        j = k = -1
+        if o_match:
+            j = o_match.start(0)
+        if q_match:
+            k = q_match.start(0)
+        if q_match and (not o_match or k < j):     # QuotePatt matched
+            res.append(str[i:k])
+            res.append(str[k + 1])
+            i = k + 2
+        else:                                      # OctalPatt matched
+            res.append(str[i:j])
+            res.append(chr(int(str[j + 1:j + 4], 8)))
+            i = j + 4
+    return _nulljoin(res)
+
+
+def _is_legal_key(key):
+    # NOTE(santeyio): This is in place of re.fullmatch() (added in python 3.4)
+    # for backwards compatibility with python 2
+    _legal_chars = string.ascii_letters + string.digits + "!#$%&'*+-.^_`|~:"
+    r = '[%s]+' % re.escape(_legal_chars)
+    return re.match('(?:' + r + r')\Z', key, 0)

--- a/falcon/util/cookies.py
+++ b/falcon/util/cookies.py
@@ -76,7 +76,7 @@ _reserved = {
 _flags = ['secure', 'httponly']
 
 
-def parse_cookies(cookie_header):
+def parse_cookies(cookie_header_str):
     """Parses a cookie header string and returns a dict
 
     This function parses each cookie individually and discards
@@ -95,18 +95,16 @@ def parse_cookies(cookie_header):
     {}[]()<>@,/=
 
     Args:
-        cookie_header (str): Cookie headers
+        cookie_header_str (str): Cookie headers
     """
 
     i = 0                           # Our starting point
-    n = len(cookie_header)          # Length of string
+    n = len(cookie_header_str)          # Length of string
     parsed_cookies = {}             # Parsed cookies to return {key: val,}
 
     while 0 <= i < n:
         # Start looking for a cookie
-        match = _CookiePattern.match(cookie_header, i)
-        if not match:
-            break          # No more cookies
+        match = _CookiePattern.match(cookie_header_str, i)
 
         key, value = match.group('key'), match.group('val')
         i = match.end(0)
@@ -173,7 +171,11 @@ def _unquote(str):
         j = k = -1
         if o_match:
             j = o_match.start(0)
-        if q_match:
+        # NOTE(santeyio): coverage complains about the `if` below to the
+        # next `if` below that because there's never a branch from `if q_match`
+        # evaluating as false to the next `if q_match and (...)` Obviously
+        # this can never happen, thus the `pragma: no branch`.
+        if q_match:                                # pragma: no branch
             k = q_match.start(0)
         if q_match and (not o_match or k < j):     # QuotePatt matched
             res.append(str[i:k])

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -314,8 +314,8 @@ def test_cookie_flags_and_reserved_keys_set_properly():
     environ = testing.create_environ(headers=headers)
     req = falcon.Request(environ)
 
-    assert req.cookies['secure'] == True
-    assert req.cookies['HttpOnly'] == True
+    assert req.cookies['secure']
+    assert req.cookies['HttpOnly']
     assert req.cookies['domain'] == 'www.test.com'
     assert req.cookies['good_cookie'] == 'foo'
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -281,6 +281,45 @@ def test_invalid_cookies_are_ignored():
     assert 'bad{cookie' not in req.cookies
 
 
+def test_cookie_keys_related_to_mechanism_ignored():
+    headers = [
+        (
+            'Cookie',
+            """
+            $Version=2.0;
+            good_cookie=foo;
+            """
+        ),
+    ]
+
+    environ = testing.create_environ(headers=headers)
+    req = falcon.Request(environ)
+
+    assert req.cookies['good_cookie'] == 'foo'
+    assert '$Version' not in req.cookies
+
+
+def test_cookie_flags_and_reserved_keys_set_properly():
+    headers = [
+        (
+            'Cookie',
+            """
+            secure;HttpOnly;
+            domain=www.test.com;
+            good_cookie=foo;
+            """
+        ),
+    ]
+
+    environ = testing.create_environ(headers=headers)
+    req = falcon.Request(environ)
+
+    assert req.cookies['secure'] == True
+    assert req.cookies['HttpOnly'] == True
+    assert req.cookies['domain'] == 'www.test.com'
+    assert req.cookies['good_cookie'] == 'foo'
+
+
 def test_cookie_header_is_missing():
     environ = testing.create_environ(headers={})
     req = falcon.Request(environ)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,7 @@ import falcon
 from falcon import testing
 from falcon import util
 from falcon.util import uri
+from falcon.util.cookies import _unquote as parse_cookies_unquote, parse_cookies
 
 
 def _arbitrary_uris(count, length):
@@ -493,3 +494,39 @@ class TestSetupApi(testing.TestCase):
 
     def test_something(self):
         self.assertTrue(isinstance(self.api, falcon.API))
+
+
+#################################
+#   Tests for parsing cookies   #
+#################################
+
+
+@pytest.mark.parametrize('cookie_str,expected_dict', [
+    ('nocookies',
+        {}),
+    ('goodkey=goodval;',
+        {'goodkey': 'goodval'}),
+    ('goodkey=goodval;bad{key=trash;another_good-val=bar;',
+        {'goodkey': 'goodval', 'another_good-val': 'bar'}),
+    ('secure;HttpOnly;domain;$version=2.0;goodkey=goodval;',
+        {'secure': True, 'HttpOnly': True, 'goodkey': 'goodval'}),
+    ('expires="\\012somethingelse";',
+        {'expires': '\nsomethingelse'}),
+])
+def test_parse_cookies(cookie_str, expected_dict):
+    assert parse_cookies(cookie_str) == expected_dict
+
+
+# NOTE(santeyio): cover weird cases of quoted values
+# in reserved keyword cookies
+@pytest.mark.parametrize('quoted_str,expected_str', [
+    ('1', '1'),
+    ('"\\012"', '\n'),
+    ('"\\077"', '?'),
+    ('"something"', 'something'),
+    ('"something\\weird"', 'somethingweird'),
+    ('"weir\{d"', 'weir{d'),
+    ('"some\\077else\\char"', 'some?elsechar'),
+])
+def test_parse_cookies_unquote(quoted_str, expected_str):
+    assert parse_cookies_unquote(quoted_str) == expected_str


### PR DESCRIPTION
Right now I'm keeping to what the python standard library cookie module considers valid cookies. Removes all of the additional features from the standard library module that we don't need or care about for doing simple cookie parsing. 

I wasn't sure where the best place to put the cookie parser and helper methods -- I ended up putting them in with the utils, but let me know if there's somewhere else that I should put them that makes more sense. 

Fixes (#1107)