### PR TITLE
Make re strings that contain backslashes raw

### DIFF
--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -102,7 +102,7 @@ class CompiledRouter(object):
 
         # NOTE(kgriffs): Fields may have whitespace in them, so sub
         # those before checking the rest of the URI template.
-        if re.search('\s', _FIELD_PATTERN.sub('{FIELD}', uri_template)):
+        if re.search(r'\s', _FIELD_PATTERN.sub('{FIELD}', uri_template)):
             raise ValueError('URI templates may not include whitespace.')
 
         path = uri_template.strip('/').split('/')

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -95,7 +95,7 @@ class Result(object):
                 cookies.load(value)
 
                 if _PY26 or (_PY27 and _JYTHON):
-                    match = re.match('\s*([^=;,]+)=', value)
+                    match = re.match(r'\s*([^=;,]+)=', value)
                     assert match
 
                     cookie_name = match.group(1)

--- a/tests/test_wsgi_interface.py
+++ b/tests/test_wsgi_interface.py
@@ -33,7 +33,7 @@ class TestWSGIInterface(object):
         # Make sure start_response was passed a valid status string
         assert mock.call_count == 1
         assert isinstance(mock.status, str)
-        assert re.match('^\d+[a-zA-Z\s]+$', mock.status)
+        assert re.match(r'^\d+[a-zA-Z\s]+$', mock.status)
 
         # Verify headers is a list of tuples, each containing a pair of strings
         assert isinstance(mock.headers, list)


### PR DESCRIPTION
On Python 3.6 I’m getting occasionally `DeprecationWarning`s:

`source:98: DeprecationWarning: invalid escape sequence \s`

So I went thru the codebase and made those string raw such that Python doesn’t try to interpret the backslashes as escaped characters.