### PR TITLE
chore: Fix code coverage race condition

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,5 +3,7 @@ branch = True
 source = falcon
 omit = falcon/tests*,falcon/cmd*,falcon/bench*
 
+parallel = True
+
 [report]
 show_missing = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,13 +63,6 @@ matrix:
 
 script: tools/travis/run_tests.sh
 notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#falconframework"
-    on_success: change
-    on_failure: always
-    use_notice: true
-    skip_join: true
   webhooks:
     urls:
       secure: "R4Hr754P2v69tWoy6vKz/4csb6ZHYRM/+8vTVV6ioDWyqsPqyGXAPiXDfZ617C7TLxJiTlbFIJPjlcH64estPg+RZ1NA4D8BrDKS2nKqHJ2Z5Jv6X5Ds6HkEUNnYXsuwsqNvZzhpPRcCKXXRpvmAbkNUSe8ftn4kz2zCOA9MBSY="

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,6 +1,5 @@
 coverage>=4.1
 pytest==3.2.5  # Last version to support py26 and py33
-pytest-cov
 pyyaml==3.11  # Last version to support py26
 requests
 six

--- a/tools/mintest.sh
+++ b/tools/mintest.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+rm -f .coverage.*
 tox -e py26,py27,py36,pep8 && tools/testing/combine_coverage.sh

--- a/tools/testing/combine_coverage.sh
+++ b/tools/testing/combine_coverage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-coverage combine .coverage_data
+coverage combine
 coverage html -d .coverage_html
 coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,12 @@
 # NOTE(kgriffs): The py26, py27, and py36 envs are required when
 # checking combined coverage. To check coverage:
 #
-#   $ tox -e py26,py27,py36 && tools/testing/combine_coverage.sh
+#   $ tools/mintest.sh
+#
+# Which is equivalent to:
+#
+#   $ rm -f .coverage.*
+#   $ tox -e py26,py27,py36,pep8 && tools/testing/combine_coverage.sh
 #
 # You can then drill down into coverage details by opening the HTML
 # report at ".coverage_html/index.html".
@@ -38,9 +43,7 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
 whitelist_externals = mkdir
                       mv
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
-           pytest --cov=falcon tests []
-           mkdir -p .coverage_data
-           mv {toxinidir}/.coverage {toxinidir}/.coverage_data/.coverage.{envname}
+           coverage run -m pytest tests []
 
 [testenv:py26]
 # NOTE(kgriffs): pytest-randomly is not compatible with py26
@@ -51,6 +54,7 @@ commands = {[with-coverage]commands}
 deps = {[testenv]deps}
        pytest-randomly
 whitelist_externals = {[with-coverage]whitelist_externals}
+; setenv = TOXINIDIR={toxinidir}
 commands = {[with-coverage]commands}
 
 [testenv:py36]


### PR DESCRIPTION
Generate unique coverage filenames for each env to ensure they don't step on eachother when multiple tox jobs run in parallel.