### PR TITLE
doc(README): Remove codecov badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|Docs| |Build Status| |codecov.io|
+|Docs| |Build Status|
 
 |Logo| The Falcon Web Framework
 ===========================


### PR DESCRIPTION
Since codecov has been unreliable, removing the badge until the situation improves.