### PR TITLE
fix(TestClient): Return None from the json property when there is no content in the response.

### DIFF
--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -71,8 +71,9 @@ class Result(object):
             under Python 2.6 and 2.7, and of type ``str`` otherwise.
             If the content type does not specify an encoding, UTF-8 is
             assumed.
-        json (dict): Deserialized JSON body. Raises an error if the
-            response is not JSON.
+        json (dict): Deserialized JSON body. Will be ``None`` if the body has
+            no content to deserialize. Otherwise, raises an error if the
+            response is not valid JSON.
     """
 
     def __init__(self, iterable, status, headers):
@@ -164,6 +165,9 @@ class Result(object):
 
     @property
     def json(self):
+        if not self.text:
+            return None
+
         return json.loads(self.text)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -445,6 +445,7 @@ class TestFalconTestingUtils(object):
     def test_wsgi_iterable_not_closeable(self):
         result = testing.Result([], falcon.HTTP_200, [])
         assert not result.content
+        assert result.json is None
 
     def test_path_must_start_with_slash(self):
         app = falcon.API()


### PR DESCRIPTION
Instead of raising an error, return None. This simplifies testing and avoids the element of surprise.