### PR TITLE
JSON custom default and object hook

### DIFF
--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -126,6 +126,9 @@ objects.
 Note that specifying either or both of these functions will significantly
 increase the time it takes to process JSON documents.
 
+Also note that neither of these are able to be specified if ujson is installed,
+as it does not currently support these parameters.
+
 Supported Handler Types
 -----------------------
 

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -112,6 +112,20 @@ MessagePack, this can be easily done in the following manner:
     api.resp_options.media_handlers.update(extra_handlers)
 
 
+JSON Custom Serialization and Deserialization of Objects
+--------------------------------------------------------
+
+When instantiating a JSONHandler, a function may be passed as the ``default``
+parameter which provides custom serialization of objects which are not
+otherwise JSON serializable.
+
+Similarly, when instantiating a JSONHandler, a function may be passed as the
+``object_hook`` parameter, which provides custom deserialization of JSON into
+objects.
+
+Note that specifying either or both of these functions will significantly
+increase the time it takes to process JSON documents.
+
 Supported Handler Types
 -----------------------
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -42,17 +42,17 @@ class JSONHandler(BaseHandler):
     __slots__ = ('_default', '_object_hook')
 
     def __init__(self, default=None, object_hook=None):
-        ujson = pkgutil.find_loader('ujson') is not None
+        _ujson = pkgutil.find_loader('ujson') is not None
 
-        if default and ujson:
+        if default and _ujson:
             raise(TypeError(
                 'Specifying default is not compatible with ujson.'))
-        if object_hook and ujson:
+        if object_hook and _ujson:
             raise(TypeError(
                 'Specifying object_hook is not compatible with ujson.'))
 
-        self._default_arg = {} if ujson else {'default': default}
-        self._object_hook_arg = {} if ujson else {'object_hook': object_hook}
+        self._default_arg = {} if _ujson else {'default': default}
+        self._object_hook_arg = {} if _ujson else {'object_hook': object_hook}
 
     def deserialize(self, raw):
         try:

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -18,16 +18,25 @@ class JSONHandler(BaseHandler):
             Warning: Specifying this method will significantly increase the
             time it takes to process JSON documents.
 
+        object_hook (callable): A callable taking the form ``func(dict)``
+            which will provide an object to be used instead of the dict
+            produced when JSON is deserialized.
+
+            Warning: Specifying this method will significantly increase the
+            time it takes to process JSON documents.
+
     """
 
-    __slots__ = ('_default',)
+    __slots__ = ('_default', '_object_hook')
 
-    def __init__(self, default=None):
+    def __init__(self, default=None, object_hook=None):
         self._default = default
+        self._object_hook = object_hook
 
     def deserialize(self, raw):
         try:
-            return json.loads(raw.decode('utf-8'))
+            return json.loads(raw.decode('utf-8'),
+                              object_hook=self._object_hook)
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -8,7 +8,22 @@ from falcon.util import json
 
 
 class JSONHandler(BaseHandler):
-    """Handler built using Python's :py:mod:`json` module."""
+    """Handler built using Python's :py:mod:`json` module.
+
+    Keyword Arguments:
+        default (callable): A callable taking the form ``func(object)`` which
+            will be called to handle serializing objects which can't be
+            otherwise serialized.
+
+            Warning: Specifying this method will significantly increase the
+            time it takes to process JSON documents.
+
+    """
+
+    __slots__ = ('_default',)
+
+    def __init__(self, default=None):
+        self._default = default
 
     def deserialize(self, raw):
         try:
@@ -20,7 +35,7 @@ class JSONHandler(BaseHandler):
             )
 
     def serialize(self, media):
-        result = json.dumps(media, ensure_ascii=False)
+        result = json.dumps(media, ensure_ascii=False, default=self._default)
         if six.PY3 or not isinstance(result, bytes):
             return result.encode('utf-8')
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import pkgutil
 
 import six
 
@@ -15,28 +16,46 @@ class JSONHandler(BaseHandler):
             will be called to handle serializing objects which can't be
             otherwise serialized.
 
-            Warning: Specifying this method will significantly increase the
-            time it takes to process JSON documents.
+            Warning:
+                Specifying this method will significantly increase the
+                time it takes to process JSON documents.
+
+            Note:
+                This argument may not be specified if ujson is installed, for
+                compatibility reasons.
 
         object_hook (callable): A callable taking the form ``func(dict)``
             which will provide an object to be used instead of the dict
             produced when JSON is deserialized.
 
-            Warning: Specifying this method will significantly increase the
-            time it takes to process JSON documents.
+            Warning:
+                Specifying this method will significantly increase the
+                time it takes to process JSON documents.
+
+            Note:
+                This argument may not be specified if ujson is installed, for
+                compatibility reasons.
 
     """
 
     __slots__ = ('_default', '_object_hook')
 
     def __init__(self, default=None, object_hook=None):
-        self._default = default
-        self._object_hook = object_hook
+        ujson = pkgutil.find_loader('ujson') is not None
+
+        if default and ujson:
+            raise(TypeError(
+                'Specifying default is not compatible with ujson.'))
+        if object_hook and ujson:
+            raise(TypeError(
+                'Specifying object_hook is not compatible with ujson.'))
+
+        self._default_arg = {} if ujson else {'default': default}
+        self._object_hook_arg = {} if ujson else {'object_hook': object_hook}
 
     def deserialize(self, raw):
         try:
-            return json.loads(raw.decode('utf-8'),
-                              object_hook=self._object_hook)
+            return json.loads(raw.decode('utf-8'), **self._object_hook_arg)
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
@@ -44,7 +63,7 @@ class JSONHandler(BaseHandler):
             )
 
     def serialize(self, media):
-        result = json.dumps(media, ensure_ascii=False, default=self._default)
+        result = json.dumps(media, ensure_ascii=False, **self._default_arg)
         if six.PY3 or not isinstance(result, bytes):
             return result.encode('utf-8')
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import pkgutil
 
 import six

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -167,7 +167,7 @@ def test_json_object_hook_raises_with_ujson():
         return
 
     with pytest.raises(TypeError) as err:
-        client = create_client(handlers={
+        create_client(handlers={
             'application/json': JSONHandler(object_hook=my_object_hook)
         })
 

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -1,5 +1,4 @@
 import pkgutil
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -162,10 +161,10 @@ def test_json_object_hook():
     assert req_media.name == 'foo'
 
 
-@patch('falcon.media.json.pkgutil')
-def test_json_object_hook_raises_with_ujson(mock_pkgutil):
-    # Make it appear as though ujson is installed
-    mock_pkgutil.find_loader.return_value = object()
+def test_json_object_hook_raises_with_ujson():
+    # This test is only relevant if ujson is installed
+    if pkgutil.find_loader('ujson') is None:
+        return
 
     with pytest.raises(TypeError) as err:
         client = create_client(handlers={

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -1,6 +1,5 @@
 import json
 import pkgutil
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -187,10 +186,10 @@ def test_json_default_type_handler():
     resp.media = SimpleTestObject(name='foo')
 
 
-@patch('falcon.media.json.pkgutil')
-def test_json_default_raises_with_ujson(mock_pkgutil):
-    # Make it appear as though ujson is installed
-    mock_pkgutil.find_loader.return_value = object()
+def test_json_default_raises_with_ujson():
+    # This test is only relevant if ujson is installed
+    if pkgutil.find_loader('ujson') is None:
+        return
 
     with pytest.raises(TypeError) as err:
         client = create_client(handlers={

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -23,10 +23,10 @@ def create_client(handlers=None):
     return client
 
 
-def my_default(o):
-    if isinstance(o, SimpleTestObject):
+def my_default(obj):
+    if isinstance(obj, SimpleTestObject):
         return {
-            'name': o.name
+            'name': obj.name
         }
 
 

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -1,4 +1,5 @@
 import json
+import pkgutil
 
 import pytest
 
@@ -169,13 +170,20 @@ def test_mimeparse_edgecases():
 
 
 def test_json_default_type_handler():
-    client = create_client(handlers={
-        'application/json': JSONHandler(default=my_default)
-    })
-    client.simulate_get('/')
+    try:
+        client = create_client(handlers={
+            'application/json': JSONHandler(default=my_default)
+        })
+        client.simulate_get('/')
 
-    resp = client.resource.captured_resp
-    resp.content_type = 'application/json'
+        resp = client.resource.captured_resp
+        resp.content_type = 'application/json'
 
-    # Shouldn't raise an error
-    resp.media = SimpleTestObject(name='foo')
+        # Shouldn't raise an error
+        resp.media = SimpleTestObject(name='foo')
+    except TypeError as err:
+        if pkgutil.find_loader('ujson') is not None:
+            desc = 'Specifying default is not compatible with ujson.'
+            assert str(err) == desc
+        else:
+            raise

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -192,7 +192,7 @@ def test_json_default_raises_with_ujson():
         return
 
     with pytest.raises(TypeError) as err:
-        client = create_client(handlers={
+        create_client(handlers={
             'application/json': JSONHandler(default=my_default)
         })
 


### PR DESCRIPTION
fixes #1192 

Here's my first attempt at 1192. I made my best guess as to where to document these changes...

A couple questions:

- In the updated documentation, should we link to the Python json docs as in the initial issue, or is what is here sufficient?
- Is there somewhere else the SimpleTestObject class should live, given that it's duplicated in both test_request_media.py and test_response_media.py?