### PR TITLE
Enable jsonschema.validate() to validate responses.

### DIFF
--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -21,31 +21,47 @@ basic_schema = {
 }
 
 
-class SampleResource(object):
-    @jsonschema.validate(basic_schema)
-    def on_get(self, req, resp):
+class Resource(object):
+    @jsonschema.validate(schema_request=basic_schema)
+    def request_validated(self, req, resp):
         assert req.media is not None
+        return resp
+
+    @jsonschema.validate(schema_response=basic_schema)
+    def response_validated(self, req, resp):
+        assert req.media is not None
+        return resp
 
 
-class RequestStub(object):
+class GoodData(object):
     media = {'message': 'something'}
 
 
-@skip_py26
-def test_jsonschema_validation_success():
-    req = RequestStub()
-
-    res = SampleResource()
-    assert res.on_get(req, None) is None
+class BadData(object):
+    media = {}
 
 
 @skip_py26
-def test_jsonschema_validation_failure():
-    req = RequestStub()
-    req.media = {}
+def test_jsonschema_request_validation_success():
+    data = GoodData()
+    assert Resource().request_validated(GoodData(), data) is data
 
-    res = SampleResource()
+
+@skip_py26
+def test_jsonschema_request_validation_failure():
     with pytest.raises(falcon.HTTPBadRequest) as err:
-        res.on_get(req, None)
+        Resource().request_validated(BadData(), None)
+        assert err.value.description == '\'message\' is a required property'
 
-    assert err.value.description == '\'message\' is a required property'
+
+@skip_py26
+def test_jsonschema_response_validation_success():
+    data = GoodData()
+    assert Resource().response_validated(GoodData(), data) is data
+
+
+@skip_py26
+def test_jsonschema_response_validation_failure():
+    with pytest.raises(falcon.HTTPInternalServerError) as err:
+        Resource().response_validated(GoodData(), BadData())
+        assert err.title == 'Response data failed validation'


### PR DESCRIPTION
With this change, you can pass another schema dict to jsonschema.validate() as 'schema_response' to validate the response data against it.

A falcon.HTTPInternalServerError is raised on schema violations.

This is useful to make sure a bug in your code doesn't somehow accidentally cause your resource to return an out-of-spec response to users.

Let me know if you want me to change the name of the first parameter back. I think it's more specific as 'schema_request', but I understand it's possible some users may have explicitly keyworded it in their apps even though it was the only parameter.

I'm also open to splitting it into it's own 'validate_response' decorator.