### PR TITLE
feat(api): allow to override the default method mapping

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -23,8 +23,7 @@ h1 a:hover, h2 a:hover, h3 a:hover {
 }
 
 div.footer {
-    padding-left: 500px;
-    text-align: left;
+    text-align: center;
 }
 
 div.footer a:hover {

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -301,6 +301,26 @@ class API(object):
     def router_options(self):
         return self._router.options
 
+    def map_http_methods(self, resource, **kwargs):
+        """Map HTTP methods (e.g., GET, POST) to methods of a resource object.
+
+        You maybe override it to implement yourself method mapping.
+
+        Args:
+            resource (instance): Object which represents a REST resource.
+                The default maps the HTTP method ``GET`` to ``on_get()``,
+                ``POST`` to ``on_post()``, etc. If any HTTP methods are not
+                supported by your resource, simply don't define the
+                corresponding request handlers, and Falcon will do the right
+                thing.
+
+            kwargs (dict): Any additional keyword args
+                coming from ``add_route()``.
+        """
+
+        suffix = kwargs.get('suffix', None)
+        return routing.map_http_methods(resource, suffix=suffix)
+
     def add_route(self, uri_template, resource, suffix=None, **kwargs):
         """Associate a templatized URI path with a resource.
 
@@ -362,7 +382,7 @@ class API(object):
         if '//' in uri_template:
             raise ValueError("uri_template may not contain '//'")
 
-        method_map = routing.map_http_methods(resource, suffix=suffix)
+        method_map = self.map_http_methods(resource, suffix=suffix, **kwargs)
         routing.set_default_responders(method_map)
         self._router.add_route(uri_template, method_map, resource, **kwargs)
 

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -104,7 +104,7 @@ class CompiledRouter(object):
                 thing.
         """
 
-        return map_http_methods(resource, suffix=kwargs.get("suffix", None))
+        return map_http_methods(resource, suffix=kwargs.get('suffix', None))
 
     def add_route(self, uri_template, resource, suffix=None, **kwargs):
         """Adds a route between a URI path template and a resource.

--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -72,7 +72,7 @@ def test_can_pass_additional_params_to_add_route():
     check = []
 
     class CustomRouter(object):
-        def add_route(self, uri_template, method_map, resource, **kwargs):
+        def add_route(self, uri_template, resource, **kwargs):
             name = kwargs['name']
             self._index = {name: uri_template}
             check.append(name)

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -25,7 +25,8 @@ def router():
     router.add_route(
         '/repos/{org}/{repo}/commits', ResourceWithId(4))
     router.add_route(
-        u'/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}', ResourceWithId(5))
+        u'/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
+        ResourceWithId(5))
 
     router.add_route(
         '/teams/{id}', ResourceWithId(6))
@@ -42,7 +43,8 @@ def router():
     router.add_route(
         '/emojis', ResourceWithId(9))
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full', ResourceWithId(10))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
+        ResourceWithId(10))
     router.add_route(
         '/repos/{org}/{repo}/compare/all', ResourceWithId(11))
 
@@ -68,7 +70,8 @@ def router():
     router.add_route('/images/{id}.gif', ResourceWithId(27))
 
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part', ResourceWithId(15))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
+        ResourceWithId(15))
     router.add_route(
         '/repos/{org}/{repo}/compare/{usr0}:{branch0}', ResourceWithId(16))
     router.add_route(
@@ -97,7 +100,8 @@ def router():
         '/cvt/teams/default/members/{id:int}-{tenure:int}', ResourceWithId(32))
 
     router.add_route(
-        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}...{usr1}:{branch1:int}/part', ResourceWithId(33))
+        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}...{usr1}:{branch1:int}/part',
+        ResourceWithId(33))
     router.add_route(
         '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}', ResourceWithId(34))
     router.add_route(

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -17,99 +17,91 @@ def router():
     router = DefaultRouter()
 
     router.add_route(
-        '/repos', {}, ResourceWithId(1))
+        '/repos', ResourceWithId(1))
     router.add_route(
-        '/repos/{org}', {}, ResourceWithId(2))
+        '/repos/{org}', ResourceWithId(2))
     router.add_route(
-        '/repos/{org}/{repo}', {}, ResourceWithId(3))
+        '/repos/{org}/{repo}', ResourceWithId(3))
     router.add_route(
-        '/repos/{org}/{repo}/commits', {}, ResourceWithId(4))
+        '/repos/{org}/{repo}/commits', ResourceWithId(4))
     router.add_route(
-        u'/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}',
-        {}, ResourceWithId(5))
+        u'/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}', ResourceWithId(5))
 
     router.add_route(
-        '/teams/{id}', {}, ResourceWithId(6))
+        '/teams/{id}', ResourceWithId(6))
     router.add_route(
-        '/teams/{id}/members', {}, ResourceWithId(7))
+        '/teams/{id}/members', ResourceWithId(7))
 
     router.add_route(
-        '/teams/default', {}, ResourceWithId(19))
+        '/teams/default', ResourceWithId(19))
     router.add_route(
-        '/teams/default/members/thing', {}, ResourceWithId(19))
+        '/teams/default/members/thing', ResourceWithId(19))
 
     router.add_route(
-        '/user/memberships', {}, ResourceWithId(8))
+        '/user/memberships', ResourceWithId(8))
     router.add_route(
-        '/emojis', {}, ResourceWithId(9))
+        '/emojis', ResourceWithId(9))
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full',
-        {}, ResourceWithId(10))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/full', ResourceWithId(10))
     router.add_route(
-        '/repos/{org}/{repo}/compare/all', {}, ResourceWithId(11))
+        '/repos/{org}/{repo}/compare/all', ResourceWithId(11))
 
     # NOTE(kgriffs): The ordering of these calls is significant; we
     # need to test that the {id} field does not match the other routes,
     # regardless of the order they are added.
     router.add_route(
-        '/emojis/signs/0', {}, ResourceWithId(12))
+        '/emojis/signs/0', ResourceWithId(12))
     router.add_route(
-        '/emojis/signs/{id}', {}, ResourceWithId(13))
+        '/emojis/signs/{id}', ResourceWithId(13))
     router.add_route(
-        '/emojis/signs/42', {}, ResourceWithId(14))
+        '/emojis/signs/42', ResourceWithId(14))
     router.add_route(
-        '/emojis/signs/42/small.jpg', {}, ResourceWithId(23))
+        '/emojis/signs/42/small.jpg', ResourceWithId(23))
     router.add_route(
-        '/emojis/signs/78/small.png', {}, ResourceWithId(24))
+        '/emojis/signs/78/small.png', ResourceWithId(24))
 
     # Test some more special chars
     router.add_route(
-        '/emojis/signs/78/small(png)', {}, ResourceWithId(25))
+        '/emojis/signs/78/small(png)', ResourceWithId(25))
     router.add_route(
-        '/emojis/signs/78/small_png', {}, ResourceWithId(26))
-    router.add_route('/images/{id}.gif', {}, ResourceWithId(27))
+        '/emojis/signs/78/small_png', ResourceWithId(26))
+    router.add_route('/images/{id}.gif', ResourceWithId(27))
 
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part',
-        {}, ResourceWithId(15))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}...{usr1}:{branch1}/part', ResourceWithId(15))
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}',
-        {}, ResourceWithId(16))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}', ResourceWithId(16))
     router.add_route(
-        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full',
-        {}, ResourceWithId(17))
+        '/repos/{org}/{repo}/compare/{usr0}:{branch0}/full', ResourceWithId(17))
 
     router.add_route(
-        '/gists/{id}/{representation}', {}, ResourceWithId(21))
+        '/gists/{id}/{representation}', ResourceWithId(21))
     router.add_route(
-        '/gists/{id}/raw', {}, ResourceWithId(18))
+        '/gists/{id}/raw', ResourceWithId(18))
     router.add_route(
-        '/gists/first', {}, ResourceWithId(20))
+        '/gists/first', ResourceWithId(20))
 
-    router.add_route('/item/{q}', {}, ResourceWithId(28))
+    router.add_route('/item/{q}', ResourceWithId(28))
 
     # ----------------------------------------------------------------
     # Routes with field converters
     # ----------------------------------------------------------------
 
     router.add_route(
-        '/cvt/teams/{id:int(min=7)}', {}, ResourceWithId(29))
+        '/cvt/teams/{id:int(min=7)}', ResourceWithId(29))
     router.add_route(
-        '/cvt/teams/{id:int(min=7)}/members', {}, ResourceWithId(30))
+        '/cvt/teams/{id:int(min=7)}/members', ResourceWithId(30))
     router.add_route(
-        '/cvt/teams/default', {}, ResourceWithId(31))
+        '/cvt/teams/default', ResourceWithId(31))
     router.add_route(
-        '/cvt/teams/default/members/{id:int}-{tenure:int}', {}, ResourceWithId(32))
+        '/cvt/teams/default/members/{id:int}-{tenure:int}', ResourceWithId(32))
 
     router.add_route(
-        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}...{usr1}:{branch1:int}/part',
-        {}, ResourceWithId(33))
+        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}...{usr1}:{branch1:int}/part', ResourceWithId(33))
     router.add_route(
-        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}',
-        {}, ResourceWithId(34))
+        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}', ResourceWithId(34))
     router.add_route(
-        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}/full',
-        {}, ResourceWithId(35))
+        '/cvt/repos/{org}/{repo}/compare/{usr0}:{branch0:int}/full', ResourceWithId(35))
 
     return router
 
@@ -145,12 +137,12 @@ class SpamConverter(object):
 
 def test_user_regression_versioned_url():
     router = DefaultRouter()
-    router.add_route('/{version}/messages', {}, ResourceWithId(2))
+    router.add_route('/{version}/messages', ResourceWithId(2))
 
     resource, __, __, __ = router.find('/v2/messages')
     assert resource.resource_id == 2
 
-    router.add_route('/v2', {}, ResourceWithId(1))
+    router.add_route('/v2', ResourceWithId(1))
 
     resource, __, __, __ = router.find('/v2')
     assert resource.resource_id == 1
@@ -169,12 +161,10 @@ def test_user_regression_recipes():
     router = DefaultRouter()
     router.add_route(
         '/recipes/{activity}/{type_id}',
-        {},
         ResourceWithId(1)
     )
     router.add_route(
         '/recipes/baking',
-        {},
         ResourceWithId(2)
     )
 
@@ -235,7 +225,7 @@ def test_user_regression_recipes():
 def test_user_regression_special_chars(uri_template, path, expected_params):
     router = DefaultRouter()
 
-    router.add_route(uri_template, {}, ResourceWithId(1))
+    router.add_route(uri_template, ResourceWithId(1))
 
     route = router.find(path)
     assert route is not None
@@ -263,7 +253,7 @@ def test_not_str(uri_template):
 
 def test_root_path():
     router = DefaultRouter()
-    router.add_route('/', {}, ResourceWithId(42))
+    router.add_route('/', ResourceWithId(42))
 
     resource, __, __, __ = router.find('/')
     assert resource.resource_id == 42
@@ -292,7 +282,7 @@ def test_root_path():
 def test_duplicate_field_names(uri_template):
     router = DefaultRouter()
     with pytest.raises(ValueError):
-        router.add_route(uri_template, {}, ResourceWithId(1))
+        router.add_route(uri_template, ResourceWithId(1))
 
 
 @pytest.mark.parametrize('uri_template,path', [
@@ -304,7 +294,7 @@ def test_duplicate_field_names(uri_template):
 def test_match_entire_path(uri_template, path):
     router = DefaultRouter()
 
-    router.add_route(uri_template, {}, ResourceWithId(1))
+    router.add_route(uri_template, ResourceWithId(1))
 
     route = router.find(path)
     assert route is None
@@ -318,7 +308,7 @@ def test_match_entire_path(uri_template, path):
 ])
 def test_conflict(router, uri_template):
     with pytest.raises(ValueError):
-        router.add_route(uri_template, {}, ResourceWithId(-1))
+        router.add_route(uri_template, ResourceWithId(-1))
 
 
 @pytest.mark.parametrize('uri_template', [
@@ -327,7 +317,7 @@ def test_conflict(router, uri_template):
     '/repos/{org}/{repo}/compare/{complex}:{vs}...{complex2}/full',
 ])
 def test_non_conflict(router, uri_template):
-    router.add_route(uri_template, {}, ResourceWithId(-1))
+    router.add_route(uri_template, ResourceWithId(-1))
 
 
 @pytest.mark.parametrize('uri_template', [
@@ -365,7 +355,7 @@ def test_non_conflict(router, uri_template):
 ])
 def test_invalid_field_name(router, uri_template):
     with pytest.raises(ValueError):
-        router.add_route(uri_template, {}, ResourceWithId(-1))
+        router.add_route(uri_template, ResourceWithId(-1))
 
 
 def test_print_src(router):
@@ -379,7 +369,7 @@ def test_print_src(router):
 
 
 def test_override(router):
-    router.add_route('/emojis/signs/0', {}, ResourceWithId(-1))
+    router.add_route('/emojis/signs/0', ResourceWithId(-1))
 
     resource, __, __, __ = router.find('/emojis/signs/0')
     assert resource.resource_id == -1
@@ -467,7 +457,7 @@ def test_converters_with_invalid_options(router, uri_template):
     # when calling add_route(). Additional checks can be found
     # in test_uri_converters.py
     with pytest.raises(ValueError):
-        router.add_route(uri_template, {}, ResourceWithId(1))
+        router.add_route(uri_template, ResourceWithId(1))
 
 
 @pytest.mark.parametrize('uri_template', [
@@ -476,7 +466,7 @@ def test_converters_with_invalid_options(router, uri_template):
 ])
 def test_converters_malformed_specification(router, uri_template):
     with pytest.raises(ValueError):
-        router.add_route(uri_template, {}, ResourceWithId(1))
+        router.add_route(uri_template, ResourceWithId(1))
 
 
 def test_variable(router):
@@ -613,7 +603,7 @@ def test_complex_alt(router, url_postfix, resource_id, expected_template):
 def test_options_converters_set(router):
     router.options.converters['spam'] = SpamConverter
 
-    router.add_route('/{food:spam(3, eggs=True)}', {}, ResourceWithId(1))
+    router.add_route('/{food:spam(3, eggs=True)}', ResourceWithId(1))
     resource, __, params, __ = router.find('/spam')
 
     assert params == {'food': 'spam&eggs, spam&eggs, spam&eggs'}
@@ -630,7 +620,7 @@ def test_options_converters_update(router, converter_name):
     })
 
     template = '/{food:' + converter_name + '(3, eggs=True)}'
-    router.add_route(template, {}, ResourceWithId(1))
+    router.add_route(template, ResourceWithId(1))
     resource, __, params, __ = router.find('/spam')
 
     assert params == {'food': 'spam&eggs, spam&eggs, spam&eggs'}


### PR DESCRIPTION
Move `routing.map_http_methods()` to an instance method, so it will allow the user to override it to implement the self-defined method mapping.

------

Implement #1250