### PR TITLE
chore(build): Force set a pip config to use PyPI

### DIFF
--- a/pip.conf
+++ b/pip.conf
@@ -1,0 +1,2 @@
+[global]
+index-url=https://pypi.python.org/simple

--- a/pip.conf
+++ b/pip.conf
@@ -1,2 +1,2 @@
 [global]
-index-url=https://pypi.python.org/simple
+index-url=https://pypi.org/simple/

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ envlist = py27,
           docs
 
 [testenv]
+setenv =
+    PIP_CONFIG_FILE={toxinidir}/pip.conf
 deps = -r{toxinidir}/requirements/tests
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            pytest tests []


### PR DESCRIPTION
This should resolve issues where people who have corporate devpi default
configuration have difficulty pulling requirements on build.