### PR TITLE
refactor(routing): Require custom routers to accept extra options only via **kwargs

### DIFF
--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -239,7 +239,7 @@ A custom router is any class that implements the following interface:
 .. code:: python
 
     class MyRouter(object):
-        def add_route(self, uri_template, method_map, resource):
+        def add_route(self, uri_template, method_map, resource, **kwargs):
             """Adds a route between URI path template and resource.
 
             Args:
@@ -248,6 +248,14 @@ A custom router is any class that implements the following interface:
                     falcon.routing.create_http_method_map.
                 resource (object): Instance of the resource class that
                     will handle requests for the given URI.
+
+            Keyword Arguments:
+
+                **kwargs (dict): Accepts any additional keyword arguments that
+                    were originally passed to the falcon.API.add_route() method.
+                    These arguments MUST be accepted via the double-star
+                    variadic pattern (**kwargs), and ignore any unrecognized
+                    or unsupported arguments.
             """
 
         def find(self, uri, req=None):

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -301,7 +301,7 @@ class API(object):
     def router_options(self):
         return self._router.options
 
-    def add_route(self, uri_template, resource, *args, **kwargs):
+    def add_route(self, uri_template, resource, suffix=None, **kwargs):
         """Associate a templatized URI path with a resource.
 
         Falcon routes incoming requests to resources based on a set of
@@ -342,12 +342,13 @@ class API(object):
                 resource.
 
         Note:
-            Any additional args and kwargs not defined above are passed
+            Any additional keyword arguments not defined above are passed
             through to the underlying router's ``add_route()`` method. The
-            default router does not expect any additional arguments, but
+            default router ignores any additional keyword arguments, but
             custom routers may take advantage of this feature to receive
-            additional options when setting up routes.
-
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
         """
 
         # NOTE(richardolsson): Doing the validation here means it doesn't have
@@ -361,17 +362,9 @@ class API(object):
         if '//' in uri_template:
             raise ValueError("uri_template may not contain '//'")
 
-        # NOTE(santeyio): This is a not very nice way to catch the suffix
-        # keyword. In python 3 it can be specified explicitly in the function
-        # definition, e.g.
-        # `add_route(self, uri_template, resource, *args, suffix=None, **kwargs)`
-        # but python 2 won't accept args like this.
-        suffix = kwargs.pop('suffix', None)
-
         method_map = routing.map_http_methods(resource, suffix=suffix)
         routing.set_default_responders(method_map)
-        self._router.add_route(uri_template, method_map, resource, *args,
-                               **kwargs)
+        self._router.add_route(uri_template, method_map, resource, **kwargs)
 
     def add_static_route(self, prefix, directory, downloadable=False, fallback_filename=None):
         """Add a route to a directory of static files.

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -89,7 +89,7 @@ class CompiledRouter(object):
     def finder_src(self):
         return self._finder_src
 
-    def add_route(self, uri_template, method_map, resource):
+    def add_route(self, uri_template, method_map, resource, **kwargs):
         """Adds a route between a URI path template and a resource.
 
         Args:

--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -1,3 +1,5 @@
+import pytest
+
 import falcon
 from falcon import testing
 
@@ -70,7 +72,8 @@ def test_can_pass_additional_params_to_add_route():
     check = []
 
     class CustomRouter(object):
-        def add_route(self, uri_template, method_map, resource, name):
+        def add_route(self, uri_template, method_map, resource, **kwargs):
+            name = kwargs['name']
             self._index = {name: uri_template}
             check.append(name)
 
@@ -83,11 +86,11 @@ def test_can_pass_additional_params_to_add_route():
     assert len(check) == 1
     assert 'my-url-name' in check
 
-    # Also as arg.
-    app.add_route('/test', 'resource', 'my-url-name-arg')
-
-    assert len(check) == 2
-    assert 'my-url-name-arg' in check
+    # NOTE(kgriffs): Extra values must be passed as kwargs, since that makes
+    #   it a lot easier for overriden methods to simply ignore options they
+    #   don't care about.
+    with pytest.raises(TypeError):
+        app.add_route('/test', 'resource', 'xarg1', 'xarg2')
 
 
 def test_custom_router_takes_req_positional_argument():


### PR DESCRIPTION
BREAKING CHANGE: 

Routers were previously allowed to accept additional args and
keyword arguments, and were not required to use the variadic form. Now,
they are only allowed to accept additional options as variadic keyword
arguments, and to ignore any arguments they don't support. This helps
overridden router logic be less fragile in terms of their interface
contracts, which also makes it easier to keep Falcon backwards-compatible
in the face of any future changes in this area.

BREAKING CHANGE: 

API.add_route() previously accepted *args, but no longer does.
Additionaly, suffix is now specified as an explicit keyword argument. This
means that if a single additional non-keyword argument was previously
passed, it will now erroneously be assigned to the suffix arg. This should
be a simple breaking change for apps to fix if they run into it.