### PR TITLE
feat(response): Add double quotes to etag header #1212

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -28,6 +28,7 @@ from falcon import DEFAULT_MEDIA_TYPE
 from falcon.media import Handlers
 from falcon.response_helpers import (
     format_content_disposition,
+    format_etag_header,
     format_header_value_list,
     format_range,
     header_property,
@@ -716,7 +717,12 @@ class Response(object):
 
     etag = header_property(
         'ETag',
-        'Set the ETag header.')
+        """Set the ETag header.
+
+        The ETag header will be wrapped with double quotes ``"value"`` in case
+        the user didn't pass it.
+        """,
+        format_etag_header)
 
     last_modified = header_property(
         'Last-Modified',

--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -91,6 +91,15 @@ def format_content_disposition(value):
     return 'attachment; filename="' + value + '"'
 
 
+def format_etag_header(value):
+    """Formats an ETag header, wrap it with " " in case of need."""
+
+    if value[-1] != '\"':
+        value = '\"' + value + '\"'
+
+    return value
+
+
 if six.PY2:
     def format_header_value_list(iterable):
         """Join an iterable of strings with commas."""

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -63,6 +63,7 @@ class HeaderHelpersResource(object):
         else:
             resp.content_range = (0, 25, 100, req.range_unit)
 
+        resp.accept_ranges = None  # Header not set yet, so should be a noop
         resp.accept_ranges = 'bytes'
 
         # Test the removal of custom headers
@@ -182,9 +183,16 @@ class AppendHeaderResource(object):
 
 
 class RemoveHeaderResource(object):
+    def __init__(self, with_double_quotes):
+        self.with_double_quotes = with_double_quotes
+
     def on_get(self, req, resp):
-        resp.etag = 'fa0d1a60ef6616bb28038515c8ea4cb2'
-        assert resp.etag == 'fa0d1a60ef6616bb28038515c8ea4cb2'
+        etag = 'fa0d1a60ef6616bb28038515c8ea4cb2'
+        if self.with_double_quotes:
+            etag = '\"' + etag + '\"'
+
+        resp.etag = etag
+        assert resp.etag == '"fa0d1a60ef6616bb28038515c8ea4cb2"'
         resp.etag = None
 
         resp.downloadable_as = 'foo.zip'
@@ -238,8 +246,9 @@ class TestHeaders(object):
         value = req.get_header('X-Not-Found', default='some-value')
         assert value == 'some-value'
 
-    def test_unset_header(self, client):
-        client.app.add_route('/', RemoveHeaderResource())
+    @pytest.mark.parametrize('with_double_quotes', [True, False])
+    def test_unset_header(self, client, with_double_quotes):
+        client.app.add_route('/', RemoveHeaderResource(with_double_quotes))
         result = client.simulate_get()
 
         assert 'Etag' not in result.headers
@@ -364,7 +373,7 @@ class TestHeaders(object):
         assert resp.cache_control == cache_control
         assert result.headers['Cache-Control'] == cache_control
 
-        etag = 'fa0d1a60ef6616bb28038515c8ea4cb2'
+        etag = '"fa0d1a60ef6616bb28038515c8ea4cb2"'
         assert resp.etag == etag
         assert result.headers['Etag'] == etag
 


### PR DESCRIPTION
Also, changed the relevant tests.

Added resp.accept_ranges = None to avoid coverage error, since now etag's header_property get's a transform. 