### PR TITLE
Providing of real content-type to media handlers.

### DIFF
--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -8,22 +8,25 @@ class BaseHandler(object):
     """Abstract Base Class for an internet media type handler"""
 
     @abc.abstractmethod  # pragma: no cover
-    def serialize(self, obj):
+    def serialize(self, media, content_type):
         """Serialize the media object on a :any:`falcon.Response`
 
         Args:
-            obj (object): A serializable object.
+            media (object): A serializable object.
+            content_type (str): Type of response content.
 
         Returns:
             bytes: The resulting serialized bytes from the input object.
         """
 
     @abc.abstractmethod  # pragma: no cover
-    def deserialize(self, raw):
+    def deserialize(self, stream, content_type, content_length):
         """Deserialize the :any:`falcon.Request` body.
 
         Args:
-            raw (bytes): Input bytes to deserialize
+            stream (object): Input data to deserialize.
+            content_type (str): Type of request content.
+            content_length (int): Length of request content.
 
         Returns:
             object: A deserialized object.

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -10,16 +10,16 @@ from falcon.util import json
 class JSONHandler(BaseHandler):
     """Handler built using Python's :py:mod:`json` module."""
 
-    def deserialize(self, raw):
+    def deserialize(self, stream, content_type, content_length):
         try:
-            return json.loads(raw.decode('utf-8'))
+            return json.loads(stream.read().decode('utf-8'))
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
                 'Could not parse JSON body - {0}'.format(err)
             )
 
-    def serialize(self, media):
+    def serialize(self, media, content_type):
         result = json.dumps(media, ensure_ascii=False)
         if six.PY3 or not isinstance(result, bytes):
             return result.encode('utf-8')

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -31,16 +31,16 @@ class MessagePackHandler(BaseHandler):
             use_bin_type=True,
         )
 
-    def deserialize(self, raw):
+    def deserialize(self, stream, content_type, content_length):
         try:
             # NOTE(jmvrbanac): Using unpackb since we would need to manage
             # a buffer for Unpacker() which wouldn't gain us much.
-            return self.msgpack.unpackb(raw, encoding='utf-8')
+            return self.msgpack.unpackb(stream.read(), encoding='utf-8')
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid MessagePack',
                 'Could not parse MessagePack body - {0}'.format(err)
             )
 
-    def serialize(self, media):
+    def serialize(self, media, content_type):
         return self.packer.pack(media)

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -941,7 +941,7 @@ class Request(object):
 
     @property
     def media(self):
-        if self._media:
+        if self._media is not None or self.bounded_stream.is_exhausted:
             return self._media
 
         handler = self.options.media_handlers.find_by_media_type(
@@ -949,11 +949,15 @@ class Request(object):
             self.options.default_media_type
         )
 
-        # Consume the stream
-        raw = self.bounded_stream.read()
+        try:
+            self._media = handler.deserialize(
+                self.bounded_stream,
+                self.content_type,
+                self.content_length
+            )
+        finally:
+            self.bounded_stream.exhaust()
 
-        # Deserialize and Return
-        self._media = handler.deserialize(raw)
         return self._media
 
     # ------------------------------------------------------------------------

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -157,6 +157,25 @@ class BoundedStream(io.IOBase):
 
         raise IOError('Stream is not writeable')
 
+    def exhaust(self, chunk_size=64 * 1024):
+        """Exhaust the stream.
+
+        This consumes all the data left until the limit is reached.
+
+        Args:
+            chunk_size (int): The size for a chunk (default: 64 KB).
+                It will read the chunk until the stream is exhausted.
+        """
+        while True:
+            chunk = self.read(chunk_size)
+            if not chunk:
+                break
+
+    @property
+    def is_exhausted(self):
+        """If the stream is exhausted this attribute is ``True``."""
+        return self._bytes_remaining <= 0
+
 
 # NOTE(kgriffs): Alias for backwards-compat
 Body = BoundedStream

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -192,7 +192,10 @@ class Response(object):
 
         # NOTE(kgriffs): Set _data to avoid re-serializing if the
         # data() property is called multiple times.
-        self._data = handler.serialize(self._media)
+        self._data = handler.serialize(
+            self._media,
+            self.content_type
+        )
         return self._data
 
     @data.setter


### PR DESCRIPTION
#1312 
Providing of real content-type to media handlers for deserializing and serializing media by corresponding to real content-type or specific parameters (such as "boundary" for multipart/form-data). Also provided content-length for special cases.

For avoiding reading big data to memory to media handlers now providing bounded stream instead raw data. Also consumption of stream proceed by small chunks.