### PR TITLE
Fix fallback filename content type inference

### DIFF
--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -106,7 +106,11 @@ class StaticRoute(object):
             except IOError:
                 raise falcon.HTTPNotFound()
 
-        suffix = os.path.splitext(file_path)[1]
+        path_with_extension = file_path
+        if self._fallback_filename is not None:
+            path_with_extension = self._fallback_filename
+
+        suffix = os.path.splitext(path_with_extension)[1]
         resp.content_type = resp.options.static_media_types.get(
             suffix,
             'application/octet-stream'

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -281,6 +281,9 @@ def test_e2e_fallback_filename(client, monkeypatch, strip_slash, path, fallback,
             assert response.status == falcon.HTTP_200
             assert response.text == directory + expected
 
+            if path.endswith('.html'):
+                assert response.headers['Content-Type'] == 'text/html'
+
     test('/static', '/opt/somesite/static/', static_exp)
     test('/assets', '/opt/somesite/assets/', assert_axp)
 


### PR DESCRIPTION
When using a fallback filename (#1226), the path used when setting the response's `Content-Type` is an empty string, so all responses are returned as `application/octet-stream`. This changes the content type update to refer to the the fallback filename, if given, or the path.