### PR TITLE
 feat(API): Support http.HTTPStatus (a proof-of-concept prototype) (#1135)

### DIFF
--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -17,7 +17,7 @@
 from collections import OrderedDict
 import xml.etree.ElementTree as et
 
-from falcon.util import json, uri
+from falcon.util import get_http_status_line, json, uri
 
 
 class HTTPError(Exception):
@@ -107,7 +107,7 @@ class HTTPError(Exception):
         #   we'll probably switch over to making everything code-based to more
         #   easily support HTTP/2. When that happens, should we continue to
         #   include the reason phrase in the title?
-        self.title = title or status
+        self.title = title or get_http_status_line(status)
 
         self.description = description
         self.headers = headers

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -34,6 +34,7 @@ from falcon.response_helpers import (
     header_property,
     is_ascii_encodable,
 )
+from falcon.status_codes import HTTP_OK, COMBINED_STATUS_CODES
 from falcon.util import dt_to_http, TimezoneGMT
 from falcon.util.uri import encode as uri_encode
 from falcon.util.uri import encode_value as uri_encode_value
@@ -151,7 +152,7 @@ class Response(object):
     context_type = dict
 
     def __init__(self, options=None):
-        self.status = '200 OK'
+        self.status = HTTP_OK
         self._headers = {}
 
         self.options = options if options else ResponseOptions()
@@ -802,6 +803,10 @@ class Response(object):
             type.
 
         """)
+
+    # @property
+    # def status_line(self):
+    #     return COMBINED_STATUS_CODES[self.status]
 
     def _set_media_type(self, media_type=None):
         """Wrapper around set_header to set a content-type.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -34,7 +34,7 @@ from falcon.response_helpers import (
     header_property,
     is_ascii_encodable,
 )
-from falcon.status_codes import HTTP_OK, COMBINED_STATUS_CODES
+from falcon.status_codes import HTTP_OK
 from falcon.util import dt_to_http, TimezoneGMT
 from falcon.util.uri import encode as uri_encode
 from falcon.util.uri import encode_value as uri_encode_value

--- a/falcon/status_codes.py
+++ b/falcon/status_codes.py
@@ -12,187 +12,216 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HTTP status line constants."""
+"""HTTP status constants."""
 
-HTTP_100 = '100 Continue'
+import itertools
+
+from falcon.util.status_enum import BaseHTTPStatus
+
+try:
+    from http import HTTPStatus
+except ImportError:
+    from falcon.util.status_enum import HTTPStatus
+
+
+class HTCPCPStatus(BaseHTTPStatus):
+    IM_A_TEAPOT = 418, "I'm a teapot"
+
+
+class HTTPStatusExtensions(BaseHTTPStatus):
+    UNAVAILABLE_FOR_LEGAL_REASONS = 451, '451 Unavailable For Legal Reasons'
+
+
+class HTTP7XXStatus(BaseHTTPStatus):
+    """HTTP 7XX Developer Errors.
+
+    See also: https://github.com/joho/7XX-rfc
+    """
+
+    # 70X - Inexcusable
+    MEH = 701, 'Meh'
+    EMACS = 702, 'Emacs'
+    EXPLOSION = 703, 'Explosion'
+    GOTO_FAIL = 704, 'Goto Fail'
+    MISSED_THE_NECESSARY_VALIDATION_BY_AN_OVERSIGHT = 705, (
+        'I wrote the code and missed the necessary validation by an oversight')
+    DELETE_YOUR_ACCOUNT = 706, 'Delete Your Account'
+    CANT_QUIT_VI = 707, "Can't quit vi"
+
+    # 71X - Novelty Implementations
+    PHP = 710, 'PHP'
+    CONVENIENCE_STORE = 711, 'Convenience Store'
+    NOSQL = 712, 'NoSQL'
+    I_AM_NOT_A_TEAPOT = 718, 'I am not a teapot'
+    HASKELL = 719, 'Haskell'
+
+    # 72X - Edge Cases
+    UNPOSSIBLE = 720, 'Unpossible'
+    KNOWN_UNKNOWNS = 721, 'Known Unknowns'
+    UNKNOWN_UNKNOWNS = 722, 'Unknown Unknowns'
+    TRICKY = 723, 'Tricky'
+    THIS_LINE_SHOULD_BE_UNREACHABLE = 724, 'This line should be unreachable'
+    IT_WORKS_ON_MY_MACHINE = 725, 'It works on my machine'
+    ITS_A_FEATURE_NOT_A_BUG = 726, "It's a feature, not a bug"
+    THIRTY_TWO_BITS_IS_PLENTY = 727, '32 bits is plenty'
+    IT_WORKS_IN_MY_TIMEZONE = 728, 'It works in my timezone'
+
+
+HTTP_100 = HTTPStatus(100)
 HTTP_CONTINUE = HTTP_100
-HTTP_101 = '101 Switching Protocols'
+HTTP_101 = HTTPStatus(101)
 HTTP_SWITCHING_PROTOCOLS = HTTP_101
-HTTP_102 = '102 Processing'
+HTTP_102 = HTTPStatus(102)
 HTTP_PROCESSING = HTTP_102
 
-HTTP_200 = '200 OK'
+HTTP_200 = HTTPStatus(200)
 HTTP_OK = HTTP_200
-HTTP_201 = '201 Created'
+HTTP_201 = HTTPStatus(201)
 HTTP_CREATED = HTTP_201
-HTTP_202 = '202 Accepted'
+HTTP_202 = HTTPStatus(202)
 HTTP_ACCEPTED = HTTP_202
-HTTP_203 = '203 Non-Authoritative Information'
+HTTP_203 = HTTPStatus(203)
 HTTP_NON_AUTHORITATIVE_INFORMATION = HTTP_203
-HTTP_204 = '204 No Content'
+HTTP_204 = HTTPStatus(204)
 HTTP_NO_CONTENT = HTTP_204
-HTTP_205 = '205 Reset Content'
+HTTP_205 = HTTPStatus(205)
 HTTP_RESET_CONTENT = HTTP_205
-HTTP_206 = '206 Partial Content'
+HTTP_206 = HTTPStatus(206)
 HTTP_PARTIAL_CONTENT = HTTP_206
-HTTP_207 = '207 Multi-Status'
+HTTP_207 = HTTPStatus(207)
 HTTP_MULTI_STATUS = HTTP_207
-HTTP_208 = '208 Already Reported'
+HTTP_208 = HTTPStatus(208)
 HTTP_ALREADY_REPORTED = HTTP_208
-HTTP_226 = '226 IM Used'
+HTTP_226 = HTTPStatus(226)
 HTTP_IM_USED = HTTP_226
 
-HTTP_300 = '300 Multiple Choices'
+HTTP_300 = HTTPStatus(300)
 HTTP_MULTIPLE_CHOICES = HTTP_300
-HTTP_301 = '301 Moved Permanently'
+HTTP_301 = HTTPStatus(301)
 HTTP_MOVED_PERMANENTLY = HTTP_301
-HTTP_302 = '302 Found'
+HTTP_302 = HTTPStatus(302)
 HTTP_FOUND = HTTP_302
-HTTP_303 = '303 See Other'
+HTTP_303 = HTTPStatus(303)
 HTTP_SEE_OTHER = HTTP_303
-HTTP_304 = '304 Not Modified'
+HTTP_304 = HTTPStatus(304)
 HTTP_NOT_MODIFIED = HTTP_304
-HTTP_305 = '305 Use Proxy'
+HTTP_305 = HTTPStatus(305)
 HTTP_USE_PROXY = HTTP_305
-HTTP_307 = '307 Temporary Redirect'
+HTTP_307 = HTTPStatus(307)
 HTTP_TEMPORARY_REDIRECT = HTTP_307
-HTTP_308 = '308 Permanent Redirect'
+HTTP_308 = HTTPStatus(308)
 HTTP_PERMANENT_REDIRECT = HTTP_308
 
-HTTP_400 = '400 Bad Request'
+HTTP_400 = HTTPStatus(400)
 HTTP_BAD_REQUEST = HTTP_400
-HTTP_401 = '401 Unauthorized'  # <-- Really means "unauthenticated"
+HTTP_401 = HTTPStatus(401)
 HTTP_UNAUTHORIZED = HTTP_401
-HTTP_402 = '402 Payment Required'
+HTTP_402 = HTTPStatus(402)
 HTTP_PAYMENT_REQUIRED = HTTP_402
-HTTP_403 = '403 Forbidden'  # <-- Really means "unauthorized"
+HTTP_403 = HTTPStatus(403)
 HTTP_FORBIDDEN = HTTP_403
-HTTP_404 = '404 Not Found'
+HTTP_404 = HTTPStatus(404)
 HTTP_NOT_FOUND = HTTP_404
-HTTP_405 = '405 Method Not Allowed'
+HTTP_405 = HTTPStatus(405)
 HTTP_METHOD_NOT_ALLOWED = HTTP_405
-HTTP_406 = '406 Not Acceptable'
+HTTP_406 = HTTPStatus(406)
 HTTP_NOT_ACCEPTABLE = HTTP_406
-HTTP_407 = '407 Proxy Authentication Required'
+HTTP_407 = HTTPStatus(407)
 HTTP_PROXY_AUTHENTICATION_REQUIRED = HTTP_407
-HTTP_408 = '408 Request Time-out'
+HTTP_408 = HTTPStatus(408)
 HTTP_REQUEST_TIMEOUT = HTTP_408
-HTTP_409 = '409 Conflict'
+HTTP_409 = HTTPStatus(409)
 HTTP_CONFLICT = HTTP_409
-HTTP_410 = '410 Gone'
+HTTP_410 = HTTPStatus(410)
 HTTP_GONE = HTTP_410
-HTTP_411 = '411 Length Required'
+HTTP_411 = HTTPStatus(411)
 HTTP_LENGTH_REQUIRED = HTTP_411
-HTTP_412 = '412 Precondition Failed'
+HTTP_412 = HTTPStatus(412)
 HTTP_PRECONDITION_FAILED = HTTP_412
-HTTP_413 = '413 Payload Too Large'
+HTTP_413 = HTTPStatus(413)
 HTTP_REQUEST_ENTITY_TOO_LARGE = HTTP_413
-HTTP_414 = '414 URI Too Long'
+HTTP_414 = HTTPStatus(414)
 HTTP_REQUEST_URI_TOO_LONG = HTTP_414
-HTTP_415 = '415 Unsupported Media Type'
+HTTP_415 = HTTPStatus(415)
 HTTP_UNSUPPORTED_MEDIA_TYPE = HTTP_415
-HTTP_416 = '416 Range Not Satisfiable'
+HTTP_416 = HTTPStatus(416)
 HTTP_REQUESTED_RANGE_NOT_SATISFIABLE = HTTP_416
-HTTP_417 = '417 Expectation Failed'
+HTTP_417 = HTTPStatus(417)
 HTTP_EXPECTATION_FAILED = HTTP_417
-HTTP_418 = "418 I'm a teapot"
+HTTP_418 = HTCPCPStatus(418)
 HTTP_IM_A_TEAPOT = HTTP_418
-HTTP_422 = '422 Unprocessable Entity'
+HTTP_422 = HTTPStatus(422)
 HTTP_UNPROCESSABLE_ENTITY = HTTP_422
-HTTP_423 = '423 Locked'
+HTTP_423 = HTTPStatus(423)
 HTTP_LOCKED = HTTP_423
-HTTP_424 = '424 Failed Dependency'
+HTTP_424 = HTTPStatus(424)
 HTTP_FAILED_DEPENDENCY = HTTP_424
-HTTP_426 = '426 Upgrade Required'
+HTTP_426 = HTTPStatus(426)
 HTTP_UPGRADE_REQUIRED = HTTP_426
-HTTP_428 = '428 Precondition Required'
+HTTP_428 = HTTPStatus(428)
 HTTP_PRECONDITION_REQUIRED = HTTP_428
-HTTP_429 = '429 Too Many Requests'
+HTTP_429 = HTTPStatus(429)
 HTTP_TOO_MANY_REQUESTS = HTTP_429
-HTTP_431 = '431 Request Header Fields Too Large'
+HTTP_431 = HTTPStatus(431)
 HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = HTTP_431
-HTTP_451 = '451 Unavailable For Legal Reasons'
+HTTP_451 = HTTPStatusExtensions(451)
 HTTP_UNAVAILABLE_FOR_LEGAL_REASONS = HTTP_451
 
-HTTP_500 = '500 Internal Server Error'
+HTTP_500 = HTTPStatus(500)
 HTTP_INTERNAL_SERVER_ERROR = HTTP_500
-HTTP_501 = '501 Not Implemented'
+HTTP_501 = HTTPStatus(501)
 HTTP_NOT_IMPLEMENTED = HTTP_501
-HTTP_502 = '502 Bad Gateway'
+HTTP_502 = HTTPStatus(502)
 HTTP_BAD_GATEWAY = HTTP_502
-HTTP_503 = '503 Service Unavailable'
+HTTP_503 = HTTPStatus(503)
 HTTP_SERVICE_UNAVAILABLE = HTTP_503
-HTTP_504 = '504 Gateway Timeout'
+HTTP_504 = HTTPStatus(504)
 HTTP_GATEWAY_TIMEOUT = HTTP_504
-HTTP_505 = '505 HTTP Version Not Supported'
+HTTP_505 = HTTPStatus(505)
 HTTP_HTTP_VERSION_NOT_SUPPORTED = HTTP_505
-HTTP_507 = '507 Insufficient Storage'
+HTTP_507 = HTTPStatus(507)
 HTTP_INSUFFICIENT_STORAGE = HTTP_507
-HTTP_508 = '508 Loop Detected'
+HTTP_508 = HTTPStatus(508)
 HTTP_LOOP_DETECTED = HTTP_508
-HTTP_511 = '511 Network Authentication Required'
+HTTP_511 = HTTPStatus(511)
 HTTP_NETWORK_AUTHENTICATION_REQUIRED = HTTP_511
 
 # 70X - Inexcusable
-HTTP_701 = '701 Meh'
-HTTP_702 = '702 Emacs'
-HTTP_703 = '703 Explosion'
+HTTP_701 = HTTP7XXStatus(701)
+HTTP_702 = HTTP7XXStatus(702)
+HTTP_703 = HTTP7XXStatus(703)
+HTTP_704 = HTTP7XXStatus(704)
+HTTP_705 = HTTP7XXStatus(705)
+HTTP_706 = HTTP7XXStatus(706)
+HTTP_707 = HTTP7XXStatus(707)
 
 # 71X - Novelty Implementations
-HTTP_710 = '710 PHP'
-HTTP_711 = '711 Convenience Store'
-HTTP_712 = '712 NoSQL'
-HTTP_719 = '719 I am not a teapot'
+HTTP_710 = HTTP7XXStatus(710)
+HTTP_711 = HTTP7XXStatus(711)
+HTTP_712 = HTTP7XXStatus(712)
+HTTP_718 = HTTP7XXStatus(718)
+HTTP_719 = HTTP7XXStatus(719)
 
 # 72X - Edge Cases
-HTTP_720 = '720 Unpossible'
-HTTP_721 = '721 Known Unknowns'
-HTTP_722 = '722 Unknown Unknowns'
-HTTP_723 = '723 Tricky'
-HTTP_724 = '724 This line should be unreachable'
-HTTP_725 = '725 It works on my machine'
-HTTP_726 = "726 It's a feature, not a bug"
-HTTP_727 = '727 32 bits is plenty'
+HTTP_720 = HTTP7XXStatus(720)
+HTTP_721 = HTTP7XXStatus(721)
+HTTP_722 = HTTP7XXStatus(722)
+HTTP_723 = HTTP7XXStatus(723)
+HTTP_724 = HTTP7XXStatus(724)
+HTTP_725 = HTTP7XXStatus(725)
+HTTP_726 = HTTP7XXStatus(726)
+HTTP_727 = HTTP7XXStatus(727)
+HTTP_728 = HTTP7XXStatus(728)
 
+# Work in progress:
 # 74X - Meme Driven
-HTTP_740 = '740 Computer says no'
-HTTP_741 = '741 Compiling'
-HTTP_742 = '742 A kitten dies'
-HTTP_743 = '743 I thought I knew regular expressions'
-HTTP_744 = '744 Y U NO write integration tests?'
-HTTP_745 = ("745 I don't always test my code, but when I do"
-            'I do it in production')
-HTTP_748 = '748 Confounded by Ponies'
-HTTP_749 = '749 Reserved for Chuck Norris'
-
 # 75X - Syntax Errors
-HTTP_750 = "750 Didn't bother to compile it"
-HTTP_753 = '753 Syntax Error'
-HTTP_754 = '754 Too many semi-colons'
-HTTP_755 = '755 Not enough semi-colons'
-HTTP_759 = '759 Unexpected T_PAAMAYIM_NEKUDOTAYIM'
-
 # 77X - Predictable Problems
-HTTP_771 = '771 Cached for too long'
-HTTP_772 = '772 Not cached long enough'
-HTTP_773 = '773 Not cached at all'
-HTTP_774 = '774 Why was this cached?'
-HTTP_776 = '776 Error on the Exception'
-HTTP_777 = '777 Coincidence'
-HTTP_778 = '778 Off By One Error'
-HTTP_779 = '779 Off By Too Many To Count Error'
-
 # 78X - Somebody Else's Problem
-HTTP_780 = '780 Project owner not responding'
-HTTP_781 = '781 Operations'
-HTTP_782 = '782 QA'
-HTTP_783 = '783 It was a customer request, honestly'
-HTTP_784 = '784 Management, obviously'
-HTTP_785 = '785 TPS Cover Sheet not attached'
-HTTP_786 = '786 Try it now'
-
 # 79X - Internet crashed
-HTTP_791 = '791 The Internet shut down due to copyright restrictions'
-HTTP_792 = '792 Climate change driven catastrophic weather event'
-HTTP_797 = '797 This is the last page of the Internet. Go back'
-HTTP_799 = '799 End of the world'
+
+
+COMBINED_STATUS_CODES = {
+    status: "{} {}".format(status.value, status.phrase)
+    for status in itertools.chain(HTTPStatus, HTTPStatusExtensions,
+                                  HTCPCPStatus, HTTP7XXStatus)}

--- a/falcon/status_codes.py
+++ b/falcon/status_codes.py
@@ -305,6 +305,6 @@ HTTP_799 = HTTP7XXStatus(799)
 
 
 COMBINED_STATUS_CODES = {
-    status: "{} {}".format(status.value, status.phrase)
+    status: str(status.value) + ' ' + status.phrase
     for status in itertools.chain(HTTPStatus, HTTPStatusExtensions,
                                   HTCPCPStatus, HTTP7XXStatus)}

--- a/falcon/status_codes.py
+++ b/falcon/status_codes.py
@@ -66,6 +66,54 @@ class HTTP7XXStatus(BaseHTTPStatus):
     THIRTY_TWO_BITS_IS_PLENTY = 727, '32 bits is plenty'
     IT_WORKS_IN_MY_TIMEZONE = 728, 'It works in my timezone'
 
+    # 75X - Syntax Errors
+    DIDNT_BOTHER_TO_COMPILE_IT = 750, "Didn't bother to compile it"
+    SYNTAX_ERROR = 753, 'Syntax Error'
+    TOO_MANY_SEMI_COLONS = 754, 'Too many semi-colons'
+    NOT_ENOUGH_SEMI_COLONS = 755, 'Not enough semi-colons'
+    INSUFFICIENTLY_POLITE = 756, 'Insufficiently polite'
+    EXCESSIVELY_POLITE = 757, 'Excessively polite'
+    UNEXPECTED_T_PAAMAYIM_NEKUDOTAYIM = 759, (
+        'Unexpected "T_PAAMAYIM_NEKUDOTAYIM"')
+
+    # 77X - Predictable Problems
+    CACHED_FOR_TOO_LONG = 771, 'Cached for too long'
+    NOT_CACHED_LONG_ENOUGH = 772, 'Not cached long enough'
+    NOT_CACHED_AT_ALL = 773, 'Not cached at all'
+    WHY_WAS_THIS_CACHED = 774, 'Why was this cached?'
+    OUT_OF_CASH = 775, 'Out of cash'
+    ERROR_ON_THE_EXCEPTION = 776, 'Error on the Exception'
+    COINCIDENCE = 777, 'Coincidence'
+    OFF_BY_ONE_ERROR = 778, 'Off By One Error'
+    OFF_BY_TOO_MANY_TO_COUNT_ERROR = 779, 'Off By Too Many To Count Error'
+
+    # 78X - Somebody Else's Problem
+    PROJECT_OWNER_NOT_RESPONDING = 780, 'Project owner not responding'
+    OPERATIONS = 781, 'Operations'
+    QA = 782, 'QA'
+    IT_WAS_A_CUSTOMER_REQUEST_HONESTLY = 783, (
+        'It was a customer request, honestly')
+    MANAGEMENT_OBVIOUSLY = 784, 'Management, obviously'
+    TPS_COVER_SHEET_NOT_ATTACHED = 785, 'TPS Cover Sheet not attached'
+    TRY_IT_NOW = 786, 'Try it now'
+    FURTHER_FUNDING_REQUIRED = 787, 'Further Funding Required'
+    DESIGNERS_FINAL_DESIGNS_WERENT = 788, "Designer's final designs weren't"
+    NOT_MY_DEPARTMENT = 789, 'Not my department'
+
+    # 79X - Internet crashed
+    THE_INTERNET_SHUT_DOWN_DUE_TO_COPYRIGHT_RESTRICTIONS = 791, (
+        'The Internet shut down due to copyright restrictions')
+    CLIMATE_CHANGE_DRIVEN_CATASTROPHIC_WEATHER_EVENT = 792, (
+        'Climate change driven catastrophic weather event')
+    ZOMBIE_APOCALYPSE = 793, 'Zombie Apocalypse'
+    SOMEONE_LET_PG_NEAR_A_REPL = 794, 'Someone let PG near a REPL'
+    HEARTBLEED = 795, '#heartbleed'
+    THIS_IS_THE_LAST_PAGE_OF_THE_INTERNET_GO_BACK = 797, (
+        'This is the last page of the Internet.  Go back')
+    I_CHECKED_THE_DB_BACKUPS_CUPBOARD_AND_THE_CUPBOARD_WAS_BARE = 798, (
+        'I checked the db backups cupboard and the cupboard was bare')
+    END_OF_THE_WORLD = 799, 'End of the world'
+
 
 HTTP_100 = HTTPStatus(100)
 HTTP_CONTINUE = HTTP_100
@@ -213,12 +261,47 @@ HTTP_726 = HTTP7XXStatus(726)
 HTTP_727 = HTTP7XXStatus(727)
 HTTP_728 = HTTP7XXStatus(728)
 
-# Work in progress:
-# 74X - Meme Driven
 # 75X - Syntax Errors
+HTTP_750 = HTTP7XXStatus(750)
+HTTP_753 = HTTP7XXStatus(753)
+HTTP_754 = HTTP7XXStatus(754)
+HTTP_755 = HTTP7XXStatus(755)
+HTTP_756 = HTTP7XXStatus(756)
+HTTP_757 = HTTP7XXStatus(757)
+HTTP_759 = HTTP7XXStatus(759)
+
 # 77X - Predictable Problems
+HTTP_771 = HTTP7XXStatus(771)
+HTTP_772 = HTTP7XXStatus(772)
+HTTP_773 = HTTP7XXStatus(773)
+HTTP_774 = HTTP7XXStatus(774)
+HTTP_775 = HTTP7XXStatus(775)
+HTTP_776 = HTTP7XXStatus(776)
+HTTP_777 = HTTP7XXStatus(777)
+HTTP_778 = HTTP7XXStatus(778)
+HTTP_779 = HTTP7XXStatus(779)
+
 # 78X - Somebody Else's Problem
+HTTP_780 = HTTP7XXStatus(780)
+HTTP_781 = HTTP7XXStatus(781)
+HTTP_782 = HTTP7XXStatus(782)
+HTTP_783 = HTTP7XXStatus(783)
+HTTP_784 = HTTP7XXStatus(784)
+HTTP_785 = HTTP7XXStatus(785)
+HTTP_786 = HTTP7XXStatus(786)
+HTTP_787 = HTTP7XXStatus(787)
+HTTP_788 = HTTP7XXStatus(788)
+HTTP_789 = HTTP7XXStatus(789)
+
 # 79X - Internet crashed
+HTTP_791 = HTTP7XXStatus(791)
+HTTP_792 = HTTP7XXStatus(792)
+HTTP_793 = HTTP7XXStatus(793)
+HTTP_794 = HTTP7XXStatus(794)
+HTTP_795 = HTTP7XXStatus(795)
+HTTP_797 = HTTP7XXStatus(797)
+HTTP_798 = HTTP7XXStatus(798)
+HTTP_799 = HTTP7XXStatus(799)
 
 
 COMBINED_STATUS_CODES = {

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -25,11 +25,11 @@ framework itself. These functions are hoisted into the front-door
 """
 
 import datetime
+import enum
 import functools
 import inspect
 import warnings
 
-import enum
 import six
 
 from falcon import status_codes

--- a/falcon/util/status_enum.py
+++ b/falcon/util/status_enum.py
@@ -1,0 +1,161 @@
+# Copied from the Python 3.6 Standard Library with minimal changes:
+# * Renamed HTTPStatus to BaseHTTPStatus to allow constructing other statuses.
+# * HTTPStatus replacement for older Python inheriting from HTTPBaseStatus.
+# * Indentation changes to comply with PEP8.
+#
+# Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+# 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018
+# Python Software Foundation. All rights reserved.
+#
+# Licensed under the Python Software Foundation License, Version 2:
+# https://docs.python.org/3/license.html
+
+"""HTTP status enumeration.
+
+This module provides :class:`BaseHTTPStatus` similar to Python's
+`http.HTTPStatus <https://docs.python.org/3/library/http.html#http.HTTPStatus>`
+enum. Furthermore, :class:`HTTPStatus` implementation is backported to Python
+versions prior to 3.5.
+"""
+
+from enum import IntEnum
+
+__all__ = ['HTTPStatus']
+
+
+class BaseHTTPStatus(IntEnum):
+    """HTTP status codes and reason phrases.
+
+    Status codes from the following RFCs are all observed:
+
+        * RFC 7231: Hypertext Transfer Protocol (HTTP/1.1), obsoletes 2616
+        * RFC 6585: Additional HTTP Status Codes
+        * RFC 3229: Delta encoding in HTTP
+        * RFC 4918: HTTP Extensions for WebDAV, obsoletes 2518
+        * RFC 5842: Binding Extensions to WebDAV
+        * RFC 7238: Permanent Redirect
+        * RFC 2295: Transparent Content Negotiation in HTTP
+        * RFC 2774: An HTTP Extension Framework
+    """
+    def __new__(cls, value, phrase, description=''):
+        obj = int.__new__(cls, value)
+        obj._value_ = value
+
+        obj.phrase = phrase
+        obj.description = description
+        return obj
+
+
+class HTTPStatus(BaseHTTPStatus):
+    # informational
+    CONTINUE = 100, 'Continue', 'Request received, please continue'
+    SWITCHING_PROTOCOLS = (101, 'Switching Protocols',
+                           'Switching to new protocol; obey Upgrade header')
+    PROCESSING = 102, 'Processing'
+
+    # success
+    OK = 200, 'OK', 'Request fulfilled, document follows'
+    CREATED = 201, 'Created', 'Document created, URL follows'
+    ACCEPTED = (202, 'Accepted',
+                'Request accepted, processing continues off-line')
+    NON_AUTHORITATIVE_INFORMATION = (203,
+                                     'Non-Authoritative Information',
+                                     'Request fulfilled from cache')
+    NO_CONTENT = 204, 'No Content', 'Request fulfilled, nothing follows'
+    RESET_CONTENT = 205, 'Reset Content', 'Clear input form for further input'
+    PARTIAL_CONTENT = 206, 'Partial Content', 'Partial content follows'
+    MULTI_STATUS = 207, 'Multi-Status'
+    ALREADY_REPORTED = 208, 'Already Reported'
+    IM_USED = 226, 'IM Used'
+
+    # redirection
+    MULTIPLE_CHOICES = (300, 'Multiple Choices',
+                        'Object has several resources -- see URI list')
+    MOVED_PERMANENTLY = (301, 'Moved Permanently',
+                         'Object moved permanently -- see URI list')
+    FOUND = 302, 'Found', 'Object moved temporarily -- see URI list'
+    SEE_OTHER = 303, 'See Other', 'Object moved -- see Method and URL list'
+    NOT_MODIFIED = (304, 'Not Modified',
+                    'Document has not changed since given time')
+    USE_PROXY = (
+        305, 'Use Proxy',
+        'You must use proxy specified in Location to access this resource')
+    TEMPORARY_REDIRECT = (307, 'Temporary Redirect',
+                          'Object moved temporarily -- see URI list')
+    PERMANENT_REDIRECT = (308, 'Permanent Redirect',
+                          'Object moved temporarily -- see URI list')
+
+    # client error
+    BAD_REQUEST = (400, 'Bad Request',
+                   'Bad request syntax or unsupported method')
+    UNAUTHORIZED = (401, 'Unauthorized',
+                    'No permission -- see authorization schemes')
+    PAYMENT_REQUIRED = (402, 'Payment Required',
+                        'No payment -- see charging schemes')
+    FORBIDDEN = (403, 'Forbidden',
+                 'Request forbidden -- authorization will not help')
+    NOT_FOUND = (404, 'Not Found',
+                 'Nothing matches the given URI')
+    METHOD_NOT_ALLOWED = (405, 'Method Not Allowed',
+                          'Specified method is invalid for this resource')
+    NOT_ACCEPTABLE = (406, 'Not Acceptable',
+                      'URI not available in preferred format')
+    PROXY_AUTHENTICATION_REQUIRED = (
+        407, 'Proxy Authentication Required',
+        'You must authenticate with this proxy before proceeding')
+    REQUEST_TIMEOUT = (408, 'Request Timeout',
+                       'Request timed out; try again later')
+    CONFLICT = 409, 'Conflict', 'Request conflict'
+    GONE = (410, 'Gone',
+            'URI no longer exists and has been permanently removed')
+    LENGTH_REQUIRED = (411, 'Length Required',
+                       'Client must specify Content-Length')
+    PRECONDITION_FAILED = (412, 'Precondition Failed',
+                           'Precondition in headers is false')
+    REQUEST_ENTITY_TOO_LARGE = (413, 'Request Entity Too Large',
+                                'Entity is too large')
+    REQUEST_URI_TOO_LONG = (414, 'Request-URI Too Long',
+                            'URI is too long')
+    UNSUPPORTED_MEDIA_TYPE = (415, 'Unsupported Media Type',
+                              'Entity body in unsupported format')
+    REQUESTED_RANGE_NOT_SATISFIABLE = (416,
+                                       'Requested Range Not Satisfiable',
+                                       'Cannot satisfy request range')
+    EXPECTATION_FAILED = (417, 'Expectation Failed',
+                          'Expect condition could not be satisfied')
+    UNPROCESSABLE_ENTITY = 422, 'Unprocessable Entity'
+    LOCKED = 423, 'Locked'
+    FAILED_DEPENDENCY = 424, 'Failed Dependency'
+    UPGRADE_REQUIRED = 426, 'Upgrade Required'
+    PRECONDITION_REQUIRED = (
+        428, 'Precondition Required',
+        'The origin server requires the request to be conditional')
+    TOO_MANY_REQUESTS = (429, 'Too Many Requests',
+                         'The user has sent too many requests in '
+                         'a given amount of time ("rate limiting")')
+    REQUEST_HEADER_FIELDS_TOO_LARGE = (
+        431, 'Request Header Fields Too Large',
+        'The server is unwilling to process the request because its header '
+        'fields are too large')
+
+    # server errors
+    INTERNAL_SERVER_ERROR = (500, 'Internal Server Error',
+                             'Server got itself in trouble')
+    NOT_IMPLEMENTED = (501, 'Not Implemented',
+                       'Server does not support this operation')
+    BAD_GATEWAY = (502, 'Bad Gateway',
+                   'Invalid responses from another server/proxy')
+    SERVICE_UNAVAILABLE = (
+        503, 'Service Unavailable',
+        'The server cannot process the request due to a high load')
+    GATEWAY_TIMEOUT = (504, 'Gateway Timeout',
+                       'The gateway server did not receive a timely response')
+    HTTP_VERSION_NOT_SUPPORTED = (505, 'HTTP Version Not Supported',
+                                  'Cannot fulfill request')
+    VARIANT_ALSO_NEGOTIATES = 506, 'Variant Also Negotiates'
+    INSUFFICIENT_STORAGE = 507, 'Insufficient Storage'
+    LOOP_DETECTED = 508, 'Loop Detected'
+    NOT_EXTENDED = 510, 'Not Extended'
+    NETWORK_AUTHENTICATION_REQUIRED = (
+        511, 'Network Authentication Required',
+        'The client needs to authenticate to gain network access')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
 # NOTE(kgriffs): python-mimeparse is better-maintained fork of mimeparse
-REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2']
+REQUIRES = [
+    'enum34;python_version<"3.4"',
+    'six>=1.4.0',
+    'python-mimeparse>=1.5.2',
+]
 
 try:
     sys.pypy_version_info

--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -62,7 +62,7 @@ def test_custom_router_find_should_be_used():
     for uri in ('/404', '/404/backwards-compat'):
         response = client.simulate_request(path=uri)
         assert not response.content
-        assert response.status == falcon.HTTP_404
+        assert response.status == '404 Not Found'
 
     assert router.reached_backwards_compat
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -4,7 +4,7 @@ import falcon
 import falcon.status_codes as status
 
 
-@pytest.mark.parametrize('err, title', [
+@pytest.mark.parametrize('err, status', [
     (falcon.HTTPBadRequest, status.HTTP_400),
     (falcon.HTTPForbidden, status.HTTP_403),
     (falcon.HTTPConflict, status.HTTP_409),
@@ -29,11 +29,12 @@ import falcon.status_codes as status
     (falcon.HTTPLoopDetected, status.HTTP_508),
     (falcon.HTTPNetworkAuthenticationRequired, status.HTTP_511),
 ])
-def test_with_default_title_and_desc(err, title):
+def test_with_default_title_and_desc(err, status):
     with pytest.raises(err) as e:
         raise err()
 
-    assert e.value.title == title
+    assert e.value.title.startswith(str(status.value))
+    assert e.value.title.endswith(status.phrase)
     assert e.value.description is None
 
     if e.value.headers:
@@ -112,7 +113,7 @@ def test_http_unauthorized_no_title_and_desc_and_challenges_and_headers():
     try:
         raise falcon.HTTPUnauthorized()
     except falcon.HTTPUnauthorized as e:
-        assert status.HTTP_401 == e.title
+        assert e.title == '401 Unauthorized'
         assert e.description is None
         assert 'WWW-Authenticate' not in e.headers
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -146,7 +146,7 @@ class TestHelloWorld(object):
         assert content_length == len(resource.sample_utf8)
 
         assert result.status == resource.sample_status
-        assert resp.status == resource.sample_status
+        assert resp.status == falcon.HTTP_OK
         assert get_body(resp) == resource.sample_utf8
         assert result.content == resource.sample_utf8
 

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -177,28 +177,28 @@ class TestHttpMethodRouting(object):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things/42/stuff/57')
-        assert response.status == falcon.HTTP_204
+        assert response.status == '204 No Content'
         assert resource_things.called
 
     def test_put(self, client, resource_things):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things/42/stuff/1337', method='PUT')
-        assert response.status == falcon.HTTP_201
+        assert response.status == '201 Created'
         assert resource_things.called
 
     def test_post_not_allowed(self, client, resource_things):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things/42/stuff/1337', method='POST')
-        assert response.status == falcon.HTTP_405
+        assert response.status == '405 Method Not Allowed'
         assert not resource_things.called
 
     def test_report(self, client, resource_things):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things/42/stuff/1337', method='REPORT')
-        assert response.status == falcon.HTTP_204
+        assert response.status_code == falcon.HTTP_204
         assert resource_things.called
 
     def test_misc(self, client, resource_misc):
@@ -213,7 +213,7 @@ class TestHttpMethodRouting(object):
         client.app.add_route('/stonewall', stonewall)
         for method in ['GET', 'HEAD', 'PUT', 'PATCH']:
             response = client.simulate_request(path='/stonewall', method=method)
-            assert response.status == falcon.HTTP_405
+            assert response.status_code == falcon.HTTP_405
 
     def test_methods_not_allowed_complex(self, client, resource_things):
         client.app.add_route('/things', resource_things)
@@ -226,7 +226,7 @@ class TestHttpMethodRouting(object):
             response = client.simulate_request(path='/things/84/stuff/65', method=method)
 
             assert not resource_things.called
-            assert response.status == falcon.HTTP_405
+            assert response.status_code == falcon.HTTP_405
 
             headers = response.headers
             assert headers['allow'] == 'GET, HEAD, PUT, REPORT, OPTIONS'
@@ -244,7 +244,7 @@ class TestHttpMethodRouting(object):
             )
 
             assert not resource_get_with_faulty_put.called
-            assert response.status == falcon.HTTP_405
+            assert response.status_code == falcon.HTTP_405
 
             headers = response.headers
             assert headers['allow'] == 'GET, PUT, OPTIONS'
@@ -253,14 +253,14 @@ class TestHttpMethodRouting(object):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things/84/stuff/65', method='OPTIONS')
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
 
         headers = response.headers
         assert headers['allow'] == 'GET, HEAD, PUT, REPORT'
 
     def test_on_options(self, client):
         response = client.simulate_request(path='/misc', method='OPTIONS')
-        assert response.status == falcon.HTTP_204
+        assert response.status_code == falcon.HTTP_204
 
         headers = response.headers
         assert headers['allow'] == 'GET'
@@ -270,4 +270,4 @@ class TestHttpMethodRouting(object):
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
         response = client.simulate_request(path='/things', method='SETECASTRONOMY')
         assert not resource_things.called
-        assert response.status == falcon.HTTP_400
+        assert response.status_code == falcon.HTTP_400

--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -12,7 +12,8 @@ def before_hook(req, resp, params):
 
 
 def after_hook(req, resp, resource):
-    resp.status = falcon.HTTP_200
+    # NOTE(vytas): Test that passing a plain integer code works just fine.
+    resp.status = 200
     resp.set_header('X-Failed', 'False')
     resp.body = 'Pass'
 
@@ -40,9 +41,7 @@ class TestStatusResource:
 
     @falcon.after(after_hook)
     def on_put(self, req, resp):
-        # NOTE(kgriffs): Test that passing a unicode status string
-        # works just fine.
-        resp.status = u'500 Internal Server Error'
+        resp.status = falcon.HTTP_500
         resp.set_header('X-Failed', 'True')
         resp.body = 'Fail'
 
@@ -81,7 +80,8 @@ class TestHTTPStatus(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='GET')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -92,7 +92,8 @@ class TestHTTPStatus(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='POST')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -103,7 +104,8 @@ class TestHTTPStatus(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='PUT')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -114,7 +116,8 @@ class TestHTTPStatus(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='DELETE')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -142,7 +145,8 @@ class TestHTTPStatusWithMiddleware(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='GET')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -159,7 +163,8 @@ class TestHTTPStatusWithMiddleware(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='GET')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
@@ -176,6 +181,7 @@ class TestHTTPStatusWithMiddleware(object):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/status', method='GET')
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == 200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -101,7 +101,7 @@ class MiddlewareClassResource(object):
         resp.body = json.dumps(_EXPECTED_BODY)
 
     def on_post(self, req, resp):
-        raise falcon.HTTPForbidden(falcon.HTTP_403, 'Setec Astronomy')
+        raise falcon.HTTPForbidden(description='Setec Astronomy')
 
 
 class EmptySignatureMiddleware(object):
@@ -130,7 +130,7 @@ class TestRequestTimeMiddleware(TestMiddleware):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/404')
-        assert response.status == falcon.HTTP_404
+        assert response.status_code == falcon.HTTP_404
         assert 'start_time' in context
         assert 'mid_time' not in context
         assert 'end_time' in context
@@ -177,7 +177,8 @@ class TestRequestTimeMiddleware(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
+        assert response.status_code == falcon.HTTP_200
 
         assert 'start_time' in context
         assert 'mid_time' in context
@@ -201,7 +202,7 @@ class TestTransactionIdMiddleware(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
         assert 'transaction_id' in context
         assert 'unique-req-id' == context['transaction_id']
 
@@ -217,7 +218,7 @@ class TestSeveralMiddlewares(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
         assert 'transaction_id' in context
         assert 'unique-req-id' == context['transaction_id']
         assert 'start_time' in context
@@ -249,7 +250,7 @@ class TestSeveralMiddlewares(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
         # as the method registration is in a list, the order also is
         # tested
         expectedExecutedMethods = [
@@ -273,7 +274,7 @@ class TestSeveralMiddlewares(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
         # as the method registration is in a list, the order also is
         # tested
         expectedExecutedMethods = [
@@ -298,7 +299,7 @@ class TestSeveralMiddlewares(TestMiddleware):
 
         class RaiseErrorMiddleware(object):
             def process_response(self, req, resp, resource):
-                raise falcon.HTTPError(falcon.HTTP_748)
+                raise falcon.HTTPError(falcon.HTTP_774)
 
         class ProcessResponseMiddleware(object):
             def process_response(self, req, resp, resource, req_succeeded):
@@ -316,7 +317,7 @@ class TestSeveralMiddlewares(TestMiddleware):
 
         response = client.simulate_request(path=TEST_ROUTE)
 
-        assert response.status == falcon.HTTP_748
+        assert response.status == '774 Why was this cached?'
 
         expected_methods = ['process_response'] * 3
         assert context['executed_methods'] == expected_methods
@@ -618,9 +619,9 @@ class TestRemoveBasePathMiddleware(TestMiddleware):
 
         response = client.simulate_request(path='/base_path/sub_path')
         assert _EXPECTED_BODY == response.json
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
         response = client.simulate_request(path='/base_pathIncorrect/sub_path')
-        assert response.status == falcon.HTTP_404
+        assert response.status_code == falcon.HTTP_404
 
 
 class TestResourceMiddleware(TestMiddleware):
@@ -663,8 +664,8 @@ class TestErrorHandling(TestMiddleware):
         client = testing.TestClient(app)
 
         response = client.simulate_request(path='/', method='POST')
-        assert response.status == falcon.HTTP_403
-        assert mw.resp.status == response.status
+        assert response.status_code == falcon.HTTP_403
+        assert mw.resp.status == response.status_code
 
         composed_body = json.loads(mw.resp.body)
         assert composed_body['title'] == response.status
@@ -690,5 +691,5 @@ class TestErrorHandling(TestMiddleware):
         app.add_error_handler(falcon.HTTPError, _http_error_handler)
 
         response = client.simulate_request(path='/', method='POST')
-        assert response.status == falcon.HTTP_201
-        assert mw.resp.status == response.status
+        assert response.status_code == falcon.HTTP_201
+        assert mw.resp.status == response.status_code

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -208,7 +208,7 @@ class TestQueryParams(object):
         client.app.add_route('/', resource)
         query_string = 'x=%%20%+%&y=peregrine&z=%a%z%zz%1%20e'
         response = simulate_request(client=client, path='/', query_string=query_string)
-        assert response.status == falcon.HTTP_200
+        assert response.status == '200 OK'
 
         req = resource.captured_req
         assert req.get_param('x') == '% % %'

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -78,7 +78,7 @@ class TestRedirects(object):
         result = client.simulate_request(path='/', method=method)
 
         assert not result.content
-        assert result.status == expected_status
+        assert result.status_code == expected_status
         assert result.headers['location'] == expected_location
 
     @pytest.mark.parametrize('method,expected_status,expected_location', [
@@ -93,6 +93,6 @@ class TestRedirects(object):
         result = client_exercising_headers.simulate_request(path='/', method=method)
 
         assert not result.content
-        assert result.status == expected_status
+        assert result.status_code == expected_status
         assert result.headers['location'] == expected_location
         assert result.headers['foo'] == 'bar'

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -51,32 +51,33 @@ class TestDefaultRouting(object):
         client.app.add_sink(sink)
 
         response = client.simulate_request(path='/')
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
 
     def test_single_simple_pattern(self, client, sink, resource):
         client.app.add_sink(sink, r'/foo')
 
         response = client.simulate_request(path='/foo/bar')
-        assert response.status == falcon.HTTP_503
+        assert response.status == '503 Service Unavailable'
+        assert response.status_code == falcon.HTTP_503
 
     def test_single_compiled_pattern(self, client, sink, resource):
         client.app.add_sink(sink, re.compile(r'/foo'))
 
         response = client.simulate_request(path='/foo/bar')
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
 
         response = client.simulate_request(path='/auth')
-        assert response.status == falcon.HTTP_404
+        assert response.status_code == falcon.HTTP_404
 
     def test_named_groups(self, client, sink, resource):
         client.app.add_sink(sink, r'/user/(?P<id>\d+)')
 
         response = client.simulate_request(path='/user/309')
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
         assert sink.kwargs['id'] == '309'
 
         response = client.simulate_request(path='/user/sally')
-        assert response.status == falcon.HTTP_404
+        assert response.status_code == falcon.HTTP_404
 
     def test_multiple_patterns(self, client, sink, resource):
         client.app.add_sink(sink, r'/foo')
@@ -85,10 +86,11 @@ class TestDefaultRouting(object):
         client.app.add_sink(sink, r'/katza')
 
         response = client.simulate_request(path='/foo/bar')
-        assert response.status == falcon.HTTP_781
+        assert response.status == '781 Operations'
+        assert response.status_code == falcon.HTTP_781
 
         response = client.simulate_request(path='/katza')
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
 
     def test_with_route(self, client, sink, resource):
         client.app.add_route('/books', resource)
@@ -96,11 +98,11 @@ class TestDefaultRouting(object):
 
         response = client.simulate_request(path='/proxy/books')
         assert not resource.called
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
 
         response = client.simulate_request(path='/books')
         assert resource.called
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
 
     def test_route_precedence(self, client, sink, resource):
         # NOTE(kgriffs): In case of collision, the route takes precedence.
@@ -109,7 +111,7 @@ class TestDefaultRouting(object):
 
         response = client.simulate_request(path='/books')
         assert resource.called
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200
 
     def test_route_precedence_with_id(self, client, sink, resource):
         # NOTE(kgriffs): In case of collision, the route takes precedence.
@@ -118,7 +120,7 @@ class TestDefaultRouting(object):
 
         response = client.simulate_request(path='/books')
         assert not resource.called
-        assert response.status == falcon.HTTP_503
+        assert response.status_code == falcon.HTTP_503
 
     def test_route_precedence_with_both_id(self, client, sink, resource):
         # NOTE(kgriffs): In case of collision, the route takes precedence.
@@ -127,4 +129,4 @@ class TestDefaultRouting(object):
 
         response = client.simulate_request(path='/books/123')
         assert resource.called
-        assert response.status == falcon.HTTP_200
+        assert response.status_code == falcon.HTTP_200

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -168,11 +168,12 @@ def test_lifo(client, monkeypatch):
     client.app.add_static_route('/downloads/archive', '/opt/somesite/x')
 
     response = client.simulate_request(path='/downloads/thing.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status == '200 OK'
+    assert response.status_code == falcon.HTTP_200
     assert response.text == '/opt/somesite/downloads/thing.zip'
 
     response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status_code == falcon.HTTP_200
     assert response.text == '/opt/somesite/x/thingtoo.zip'
 
 
@@ -183,11 +184,12 @@ def test_lifo_negative(client, monkeypatch):
     client.app.add_static_route('/downloads', '/opt/somesite/downloads')
 
     response = client.simulate_request(path='/downloads/thing.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status == '200 OK'
+    assert response.status_code == falcon.HTTP_200
     assert response.text == '/opt/somesite/downloads/thing.zip'
 
     response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status_code == falcon.HTTP_200
     assert response.text == '/opt/somesite/downloads/archive/thingtoo.zip'
 
 
@@ -198,15 +200,16 @@ def test_downloadable(client, monkeypatch):
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
 
     response = client.simulate_request(path='/downloads/thing.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status == '200 OK'
+    assert response.status_code == falcon.HTTP_200
     assert response.headers['Content-Disposition'] == 'attachment; filename="thing.zip"'
 
     response = client.simulate_request(path='/downloads/Some Report.zip')
-    assert response.status == falcon.HTTP_200
+    assert response.status_code == falcon.HTTP_200
     assert response.headers['Content-Disposition'] == 'attachment; filename="Some Report.zip"'
 
     response = client.simulate_request(path='/assets/css/main.css')
-    assert response.status == falcon.HTTP_200
+    assert response.status_code == falcon.HTTP_200
     assert 'Content-Disposition' not in response.headers
 
 
@@ -214,7 +217,7 @@ def test_downloadable_not_found(client):
     client.app.add_static_route('/downloads', '/opt/somesite/downloads', downloadable=True)
 
     response = client.simulate_request(path='/downloads/thing.zip')
-    assert response.status == falcon.HTTP_404
+    assert response.status_code == falcon.HTTP_404
 
 
 @pytest.mark.parametrize('uri, default, expected', [
@@ -276,9 +279,9 @@ def test_e2e_fallback_filename(client, monkeypatch, strip_slash, path, fallback,
     def test(prefix, directory, expected):
         response = client.simulate_request(path=prefix + path)
         if expected is None:
-            assert response.status == falcon.HTTP_404
+            assert response.status == '404 Not Found'
         else:
-            assert response.status == falcon.HTTP_200
+            assert response.status == '200 OK'
             assert response.text == directory + expected
 
     test('/static', '/opt/somesite/static/', static_exp)

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -348,7 +348,7 @@ def test_single_trailing_slash(client):
     resource1 = IDResource()
     client.app.add_route('/1/{id}/', resource1)
     result = client.simulate_get('/1/123')
-    assert result.status == falcon.HTTP_200
+    assert result.status == '200 OK'
     assert resource1.called
     assert resource1.id == '123'
     assert resource1.req.path == '/1/123'
@@ -356,7 +356,7 @@ def test_single_trailing_slash(client):
     resource2 = IDResource()
     client.app.add_route('/2/{id}/', resource2)
     result = client.simulate_get('/2/123/')
-    assert result.status == falcon.HTTP_404
+    assert result.status == '404 Not Found'
     assert not resource2.called
     assert resource2.id is None
 
@@ -364,7 +364,7 @@ def test_single_trailing_slash(client):
     client.app.add_route('/3/{id}/', resource3)
     client.app.req_options.strip_url_path_trailing_slash = True
     result = client.simulate_get('/3/123/')
-    assert result.status == falcon.HTTP_200
+    assert result.status == '200 OK'
     assert resource3.called
     assert resource3.id == '123'
     assert resource3.req.path == '/3/123'
@@ -373,7 +373,7 @@ def test_single_trailing_slash(client):
     client.app.add_route('/4/{id}', resource4)
     client.app.req_options.strip_url_path_trailing_slash = False
     result = client.simulate_get('/4/123/')
-    assert result.status == falcon.HTTP_404
+    assert result.status == '404 Not Found'
     assert not resource4.called
     assert resource4.id is None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,7 +302,6 @@ class TestFalconUtils(object):
         assert falcon.get_http_status('404.3') == falcon.HTTP_404
         assert falcon.get_http_status(404.9) == falcon.HTTP_404
         assert falcon.get_http_status('404') == falcon.HTTP_404
-        assert falcon.get_http_status(123) == '123 Unknown'
         with pytest.raises(ValueError):
             falcon.get_http_status('not_a_number')
         with pytest.raises(ValueError):
@@ -317,7 +316,17 @@ class TestFalconUtils(object):
             falcon.get_http_status('-404')
         with pytest.raises(ValueError):
             falcon.get_http_status('-404.3')
-        assert falcon.get_http_status(123, 'Go Away') == '123 Go Away'
+        with pytest.raises(ValueError):
+            falcon.get_http_status(123)
+
+    def test_get_http_status_line(self):
+        assert falcon.get_http_status_line(falcon.HTTP_404) == '404 Not Found'
+        assert falcon.get_http_status_line(404) == '404 Not Found'
+        assert falcon.get_http_status_line(702.0) == '702 Emacs'
+        with pytest.raises(ValueError):
+            falcon.get_http_status_line(123)
+        with pytest.raises(ValueError):
+            falcon.get_http_status_line('702 Emacs')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -442,15 +442,15 @@ class TestFalconTestingUtils(object):
 
     def test_status(self):
         app = falcon.API()
-        resource = testing.SimpleTestResource(status=falcon.HTTP_702)
+        resource = testing.SimpleTestResource(status=falcon.HTTP_707)
         app.add_route('/', resource)
         client = testing.TestClient(app)
 
         result = client.simulate_get()
-        assert result.status == falcon.HTTP_702
+        assert result.status == "707 Can't quit vi"
 
     def test_wsgi_iterable_not_closeable(self):
-        result = testing.Result([], falcon.HTTP_200, [])
+        result = testing.Result([], '200 OK', [])
         assert not result.content
         assert result.json is None
 

--- a/tests/test_wsgiref_inputwrapper_with_size.py
+++ b/tests/test_wsgiref_inputwrapper_with_size.py
@@ -33,5 +33,5 @@ class TestWsgiRefInputWrapper(object):
 
         result = client.simulate_post(path=type_route, body='hello')
 
-        assert result.status == falcon.HTTP_200
+        assert result.status == '200 OK'
         assert result.json == {'data': 'hello'}


### PR DESCRIPTION
This is not a fully polished version, but rather a prototype. Old documentation, tutorials and Python docstrings are still largely intact. It would be awesome to first discuss the proposed changeset with @kgriffs and @jmvrbanac, and distill an acceptable technical solution first; I would be happy to contribute to the documentation afterwards.

The main design ideas laid out below are roughly in-line with the plan found in #1135 :
* ``Response.status`` shall be set to ``http.HTTPStatus``, or its backport to older Python versions found in ``falcon.util.status_enum``
* Integer status codes implicitly work too (both a convenience and logical inheritance wise: ``http.HTTPStatus`` subclasses an ``int`` via ``IntEnum``)
* In the same ``falcon.util.status_enum``, a base HTTP status enum class is defined similarly to ``http.HTTPStatus``; that is used to support other non-standard status codes previously included in Falcon [1]
* Falcon usual status code constants are aliased to the new enum values [2], so a fair share of users could hopefully continue using most of their code as-is

Somewhat controversial ramifications:
* It may be cumbersome to define arbitrary codes; with the proposed changeset, one would need to resort to manually adding the string status to ``falcon.status_codes.COMBINED_STATUS_CODE`` lookup table. This could be made easier by either implementing support for legacy raw status, or probably by moving some part of this machinery to ``Response`` class, and documenting how and what to override to cram arbitrary status in; most probably both alternatives would come at a performance cost.

Other issues:
* Some of https://github.com/timothycrosley/hug tests are failing because of the same reason many Falcon tests were failing (assuming that ``falcon.HTTP_XXX`` are raw string statuses and using those values to check response status). @timothycrosley might now more, but from what I have seen in *hug* source code, it uses ``falcon.HTTP_XXX`` constants in a clean fashion, so it is just a problem with a couple of unit tests, not Hug API functionality.

1. As advertised!
> What other framework has integrated support for 786 TRY IT NOW?

2. On Python 3:
```python
>>> import falcon
>>> import http
>>> falcon.HTTP_404
<HTTPStatus.NOT_FOUND: 404>
>>> falcon.HTTP_404.phrase
'Not Found'
>>> int(falcon.HTTP_404)
404
>>> falcon.HTTP_FORBIDDEN
<HTTPStatus.FORBIDDEN: 403>
>>> falcon.HTTP_FORBIDDEN is http.HTTPStatus(403)
True
```