### PR TITLE
Convert TestClient Header Values to `str` in Py2

### DIFF
--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -21,6 +21,7 @@ WSGI callable, without having to stand up a WSGI server.
 import warnings
 import wsgiref.validate
 
+import six
 from six.moves import http_cookies
 
 from falcon.constants import MEDIA_JSON
@@ -684,5 +685,9 @@ class TestClient(object):
             merged_headers.update(additional_headers)
 
             kwargs['headers'] = merged_headers
+
+        if six.PY2 and 'headers' in kwargs:
+            for key, value in six.iteritems(kwargs['headers']):
+                kwargs['headers'][key] = str(value) if isinstance(value, unicode) else value
 
         return simulate_request(self.app, *args, **kwargs)

--- a/tests/test_py2_wsgi.py
+++ b/tests/test_py2_wsgi.py
@@ -1,0 +1,32 @@
+# Copyright 2013 by Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test unicode_literals in python2 invalidating headers which come as Unicode values"""
+from __future__ import unicode_literals
+
+import pytest
+
+import falcon
+from falcon.testing import TestClient
+
+
+@pytest.mark.parametrize(
+    'auth_header',
+    [u'token blah', 'token blah']
+)
+def test_test_client_works_in_py2(auth_header):
+    app = falcon.API()
+    client = TestClient(app)
+    client.simulate_get('/', headers={
+        'Authorization': auth_header
+    })

--- a/tests/test_py2_wsgi.py
+++ b/tests/test_py2_wsgi.py
@@ -1,4 +1,4 @@
-# Copyright 2013 by Rackspace Hosting, Inc.
+# Copyright 2018 by Nick Zaccardi
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes GH-1340