### PR TITLE
feat(json): refactor third party JSON support and extend falcon.media.JSONHandler

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,11 +202,11 @@ Installing it is as simple as:
 
     $ pip install falcon
 
-If `ujson <https://pypi.python.org/pypi/ujson>`__ is available, Falcon
-will use it to speed up media (de)serialization, error serialization,
-and query string parsing. Note that ``ujson`` can actually be slower
-on PyPy than the standard ``json`` module due to ctypes overhead, and
-so we recommend only using ``ujson`` with CPython deployments:
+Falcon uses `mujson <https://pypi.python.org/pypi/mujson>`__ to select the most
+performant JSON functions available at import time. For instance, if `ujson
+<https://pypi.python.org/pypi/ujson>`__ is available, Falcon will use it to
+speed up media (de)serialization, error serialization, and query string
+parsing.
 
 .. code:: bash
 

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -115,12 +115,12 @@ MessagePack, this can be easily done in the following manner:
 JSON Custom Serialization and Deserialization of Objects
 --------------------------------------------------------
 
-When instantiating a JSONHandler, a function may be passed as the ``default``
+When instantiating a JSONHandler, a function may be passed as the ``dumps_default``
 parameter which provides custom serialization of objects which are not
 otherwise JSON serializable.
 
 Similarly, when instantiating a JSONHandler, a function may be passed as the
-``object_hook`` parameter, which provides custom deserialization of JSON into
+``loads_object_hook`` parameter, which provides custom deserialization of JSON into
 objects.
 
 Note that specifying either or both of these functions will significantly

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -112,6 +112,20 @@ MessagePack, this can be easily done in the following manner:
     api.resp_options.media_handlers.update(extra_handlers)
 
 
+JSON Custom Serialization and Deserialization of Objects
+--------------------------------------------------------
+
+When instantiating a JSONHandler, a function may be passed as the ``default``
+parameter which provides custom serialization of objects which are not
+otherwise JSON serializable.
+
+Similarly, when instantiating a JSONHandler, a function may be passed as the
+``object_hook`` parameter, which provides custom deserialization of JSON into
+objects.
+
+Note that specifying either or both of these functions will significantly
+increase the time it takes to process JSON documents.
+
 Supported Handler Types
 -----------------------
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -10,13 +10,49 @@ from falcon.util import json
 class JSONHandler(BaseHandler):
     """JSON media handler.
 
-    This handler uses Python's :py:mod:`json` by default, but will
-    use :py:mod:`ujson` if available.
+    JSONHandler uses :py:mod:`mujson` to find the most performant JSON
+    functions available at import time. This behavior can be overriden by
+    explicitly passing desired implementations for ``dumps`` and/or ``loads``.
+
+    Keyword Arguments:
+        dumps (func): Use this argument to explicitly specify the
+            ``json.dumps``-like function to use during serialization. If not
+            passed, ``JSONHandler`` will attempt to use the most performant
+            ``json-dumps``-like function available at import time.
+        dumps_default (func): function, if any, to pass as ``default`` keyword
+            argument to ``dumps``. Use of this argument may impair performance
+            when serializing JSON payloads.
+        dumps_ensure_ascii (bool): value to pass as ``ensure_ascii`` keyword
+            argument to ``dumps``. (default ``False``)
+        loads (func): Use this argument to explicitly specify the
+            ``json.loads``-like function to use during deserialization.
+        loads_object_hook (func): function, if any, to pass as ``object_hook``
+            keyword argument to ``loads``. Use of this argument may impair
+            performance when deserializing JSON payloads.
     """
+    def __init__(self, dumps=None, dumps_default=None,
+                 dumps_ensure_ascii=False, loads=None,
+                 loads_object_hook=None):
+        self.dumps_kwargs = {'ensure_ascii': dumps_ensure_ascii}
+        self.loads_kwargs = {}
+
+        if dumps_default is not None:
+            self.dumps = dumps or json.compliant_dumps
+            self.dumps_kwargs['default'] = dumps_default
+        else:
+            self.dumps = dumps or json.dumps
+
+        if loads_object_hook is not None:
+            self.loads = loads or json.compliant_loads
+            self.loads_kwargs['object_hook'] = loads_object_hook
+        else:
+            self.loads = loads or json.loads
 
     def deserialize(self, stream, content_type, content_length):
         try:
-            return json.loads(stream.read().decode('utf-8'))
+            return self.loads(
+                stream.read().decode('utf-8'),
+                **self.loads_kwargs)
         except ValueError as err:
             raise errors.HTTPBadRequest(
                 'Invalid JSON',
@@ -24,7 +60,7 @@ class JSONHandler(BaseHandler):
             )
 
     def serialize(self, media, content_type):
-        result = json.dumps(media, ensure_ascii=False)
+        result = self.dumps(media, **self.dumps_kwargs)
         if six.PY3 or not isinstance(result, bytes):
             return result.encode('utf-8')
 

--- a/falcon/testing/resource.py
+++ b/falcon/testing/resource.py
@@ -24,10 +24,7 @@ directly from the `testing` package::
 
 """
 
-try:
-    from ujson import dumps as json_dumps
-except ImportError:
-    from json import dumps as json_dumps
+from mujson import dumps as json_dumps
 
 import falcon
 

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -20,10 +20,7 @@ Conversely, the `uri` module must be imported explicitly::
 
 """
 
-try:
-    import ujson as json  # NOQA
-except ImportError:
-    import json  # NOQA
+import mujson as json
 
 # Hoist misc. utils
 from falcon.util import structures

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -20,7 +20,7 @@ Conversely, the `uri` module must be imported explicitly::
 
 """
 
-import mujson as json
+import mujson as json  # NOQA
 
 # Hoist misc. utils
 from falcon.util import structures

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
 # NOTE(kgriffs): python-mimeparse is better-maintained fork of mimeparse
-REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2', 'mujson>=1.0']
+REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2', 'mujson>=1.3']
 
 try:
     sys.pypy_version_info

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
 VERSION = VERSION.__version__
 
 # NOTE(kgriffs): python-mimeparse is better-maintained fork of mimeparse
-REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2']
+REQUIRES = ['six>=1.4.0', 'python-mimeparse>=1.5.2', 'mujson>=1.0']
 
 try:
     sys.pypy_version_info

--- a/tests/test_after_hooks.py
+++ b/tests/test_after_hooks.py
@@ -2,13 +2,9 @@ import functools
 
 import pytest
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 import falcon
 from falcon import testing
+from falcon.util import json
 
 
 # --------------------------------------------------------------------

--- a/tests/test_after_hooks.py
+++ b/tests/test_after_hooks.py
@@ -215,7 +215,10 @@ class ClassResourceWithAwareHooks(object):
 def test_output_validator(client):
     result = client.simulate_get()
     assert result.status_code == 723
-    assert result.text == json.dumps({'title': 'Tricky'})
+    # HACK(mattgiles): not all JSON libraries treat white space consistently.
+    result = result.text.replace(' ', '')
+    expected = json.dumps({'title': 'Tricky'}).replace(' ', '')
+    assert result == expected
 
 
 def test_serializer(client):

--- a/tests/test_before_hooks.py
+++ b/tests/test_before_hooks.py
@@ -3,13 +3,9 @@ import io
 
 import pytest
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 import falcon
 import falcon.testing as testing
+from falcon.util import json
 
 
 def validate(req, resp, params):

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,7 +1,3 @@
-try:
-    import ujson as json
-except ImportError:
-    import json
 import logging
 import uuid
 from wsgiref import simple_server
@@ -9,6 +5,7 @@ from wsgiref import simple_server
 import requests
 
 import falcon
+from falcon.util import json
 
 
 class StorageEngine(object):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -2,13 +2,10 @@ from datetime import datetime
 
 import pytest
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 import falcon
 import falcon.testing as testing
+from falcon.util import json
+
 
 _EXPECTED_BODY = {u'status': u'ok'}
 

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -1,16 +1,12 @@
 from datetime import date, datetime
 from uuid import UUID
 
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 import pytest
 
 import falcon
 from falcon.errors import HTTPInvalidParam
 import falcon.testing as testing
+from falcon.util import json
 
 
 class Resource(testing.SimpleTestResource):

--- a/tests/test_wsgiref_inputwrapper_with_size.py
+++ b/tests/test_wsgiref_inputwrapper_with_size.py
@@ -1,10 +1,6 @@
-try:
-    import ujson as json
-except ImportError:
-    import json
-
 import falcon
 from falcon import testing
+from falcon.util import json
 
 
 class TypeResource(testing.SimpleTestResource):


### PR DESCRIPTION
Possible solution for #1192 and #1206.

I think there are two obvious open questions.

1. JSON functions are consumed from `falcon.util` in a few different places in the application. We have only parameterized the `media.JSONHandler` to address #1192. Does it make any sense to try to expose parameters such that they would also be used consistently in `Request` and `HTTPError` objects?

2. Right now, `mujson` declares explicit default rankings as to which JSON libs are preferred for different functions across different Python versions. The behavior defined in this PR is more or less a drop-in replacement for old `ujson` behavior, and it enables identical *implicit* behavior for users that install other libs like [yajl](https://github.com/rtyler/py-yajl) or [rapidjson](https://github.com/python-rapidjson/python-rapidjson). Which addresses #1206. However, `mujson` does not contemplate JSON libs which may arrive in the future (e.g. [hyperjson](https://github.com/mre/hyperjson)). The parameters for `media.JSONHandler` do include `dumps` and `loads` functions, so a user can explicitly override default rankings. But, depending on the answer to `1.` above it may make sense to give users the option to just specify `json_lib="hyperjson"` in a single place.

All of which is to say that this is a heavy PR insofar as it introduces a new top level requirement, but it is light insofar as it avoids a more opinionated refactoring of the configuration interface exposed to Falcon users -- which may or may not be desirable.