### PR TITLE
Fix for resource-level before hooks not applying to suffixed responders

### DIFF
--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -13,13 +13,27 @@
 # limitations under the License.
 
 """Hook decorators."""
-import inspect
+
 from functools import wraps
+import inspect
 
 import six
 
 from falcon import COMBINED_METHODS
 from falcon.util.misc import get_argnames
+
+
+def predicate_method_function(member):
+    """Predicate to use for inspection of a resource in order to extract the responders.
+
+    Args:
+        member (member): A member tuple as returned per the inspect.getmembers function
+        where the first element of the tuple is the name and the second element the member itself.
+
+        Note:
+            Should be only used as a predicate of inspect.getmembers(to_inspect, predicate=this function.
+    """
+    return inspect.ismethod(member) or inspect.isfunction(member)
 
 
 def before(action, *args, **kwargs):
@@ -57,13 +71,13 @@ def before(action, *args, **kwargs):
         if isinstance(responder_or_resource, six.class_types):
             resource = responder_or_resource
 
-            members = inspect.getmembers(resource, predicate=inspect.isfunction)
+            members = inspect.getmembers(resource, predicate=predicate_method_function)
 
             responders = []
 
             for member in members:
                 for method in COMBINED_METHODS:
-                    if member[0].startswith("on_" + method.lower()):
+                    if member[0].startswith('on_' + method.lower()):
                         responders.append(member)
 
             for responder_name, responder in responders:

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -31,7 +31,8 @@ def predicate_method_function(member):
         where the first element of the tuple is the name and the second element the member itself.
 
         Note:
-            Should be only used as a predicate of inspect.getmembers(to_inspect, predicate=this function.
+            Should only be used as a predicate of
+            inspect.getmembers(to_inspect, predicate=this function).
     """
     return inspect.ismethod(member) or inspect.isfunction(member)
 


### PR DESCRIPTION
This PR is intended for this issue https://github.com/falconry/falcon/issues/1351 and was also discussed on gitter briefly (@vytas7 )
Basically the hooks were not applying to the responders added with a suffix,  a standalone fairly clear "test" can be found below.

This looks like a decent fix and makes sense to me, I hope it does to you as well as I don't clearly see all the eventual consequences of this change.
Couldn't come up with a test, cause I couldn't understand deeply enough to come up with one of my own, plus I didn't wanted to "waste" time considering the fact that my approach might be terrible.
The tests on the repository are passing, and my little standalone one as well.

I applied it to the @before hook, I can totally apply the same change to the @after hook for consistency of course.

I'm looking forward to your feedback and I am totally open for discussion, on gitter or here.

```python
import json
from wsgiref import simple_server
import falcon

def hook(req, resp, resource, params):
    print("Inside the hook for resource: ", type(resource))
    resp.body = json.dumps("HOOKED")

@falcon.before(hook)
class HookedResource:
    def on_get(self, req, resp):
        resp.status = falcon.HTTP_200
    def on_get_suffix(self, req, resp):
        resp.status = falcon.HTTP_202

class HookedMethod:
    @falcon.before(hook)
    def on_get_suffix(self, req, resp):
        resp.status = falcon.HTTP_202

api = falcon.API()
hkr = HookedResource()
hkm = HookedMethod()
api.add_route("/hooked_resource", hkr)
api.add_route("/hooked_resource_suffix", hkr, suffix="suffix")
api.add_route("/hooked_method_suffix", hkm, suffix="suffix")

if __name__ == '__main__':
    httpd = simple_server.make_server('127.0.0.1', 8000, api)
    httpd.serve_forever()
```