### PR TITLE
style: ignore Flake8 warning W504 and address W605 violations

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -714,12 +714,12 @@ class Response(object):
 
         The tuple has the form (*start*, *end*, *length*, [*unit*]), where *start* and
         *end* designate the range (inclusive), and *length* is the
-        total length, or '\*' if unknown. You may pass ``int``'s for
+        total length, or '\\*' if unknown. You may pass ``int``'s for
         these numbers (no need to convert to ``str`` beforehand). The optional value
         *unit* describes the range unit and defaults to 'bytes'
 
         Note:
-            You only need to use the alternate form, 'bytes \*/1234', for
+            You only need to use the alternate form, 'bytes \\*/1234', for
             responses that use the status '416 Range Not Satisfiable'. In this
             case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
             thing.

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -33,7 +33,7 @@ _FIELD_PATTERN = re.compile(
     #
     # We may want to create a contextual parser at some point to
     # work around this problem.
-    '{((?P<fname>[^}:]*)((?P<cname_sep>:(?P<cname>[^}\(]*))(\((?P<argstr>[^}]*)\))?)?)}'
+    r'{((?P<fname>[^}:]*)((?P<cname_sep>:(?P<cname>[^}\(]*))(\((?P<argstr>[^}]*)\))?)?)}'
 )
 _IDENTIFIER_PATTERN = re.compile('[A-Za-z_][A-Za-z0-9_]*$')
 

--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -92,7 +92,7 @@ def map_http_methods(resource, suffix=None):
 
     Args:
         resource: An object with *responder* methods, following the naming
-            convention *on_\**, that correspond to each method the resource
+            convention *on_\\**, that correspond to each method the resource
             supports. For example, if a resource supports GET and POST, it
             should define ``on_get(self, req, resp)`` and
             ``on_post(self, req, resp)``.

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ def load_description():
         if readme_line.startswith('.. raw::'):
             in_raw = True
         elif in_raw:
-            if readme_line and not re.match('\s', readme_line):
+            if readme_line and not re.match(r'\s', readme_line):
                 in_raw = False
 
         if not in_raw:

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -123,7 +123,7 @@ class TestDefaultRouting(object):
     def test_route_precedence_with_both_id(self, client, sink, resource):
         # NOTE(kgriffs): In case of collision, the route takes precedence.
         client.app.add_route('/books/{id}', resource)
-        client.app.add_sink(sink, '/books/\d+')
+        client.app.add_sink(sink, r'/books/\d+')
 
         response = client.simulate_request(path='/books/123')
         assert resource.called

--- a/tox.ini
+++ b/tox.ini
@@ -186,7 +186,7 @@ basepython = python2.7
 commands = flake8 \
              --max-complexity=15 \
              --exclude=.ecosystem,.eggs,.tox,.venv,build,dist,docs,examples,falcon/bench/nuts \
-             --ignore=F403 \
+             --ignore=F403,W504 \
              --max-line-length=99 \
              --import-order-style=google \
              --application-import-names=falcon \
@@ -204,7 +204,7 @@ basepython = python2.7
 
 commands = flake8 examples \
              --max-complexity=12 \
-             --ignore=F403 \
+             --ignore=F403,W504 \
              --max-line-length=99 \
              --import-order-style=google \
              --application-import-names=look \


### PR DESCRIPTION
``W504`` **is** actually among the warnings ignored by default even by the new Flake8 version (3.6.0), however by specifying our ``--ignore`` in ``tox.ini`` we seem to override the default ignore list, a breaking change in behaviour I am quite sure.

``W605`` seems a fair thing to warn on, although it could be perceived as somewhat harsh in the docstring context. But with the proposed changeset we should thereby comply.