### PR TITLE
style: avoid builtins python names

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1158,8 +1158,8 @@ class Request(object):
 
         raise errors.HTTPMissingParam(name)
 
-    def get_param_as_int(self, name, required=False, min=None,
-                         max=None, store=None, default=None):
+    def get_param_as_int(self, name, required=False, min_value=None,
+                         max_value=None, store=None, default=None):
         """Return the value of a query string parameter as an int.
 
         Args:
@@ -1170,12 +1170,12 @@ class Request(object):
                 ``HTTPBadRequest`` instead of returning ``None`` when the
                 parameter is not found or is not an integer (default
                 ``False``).
-            min (int): Set to the minimum value allowed for this
-                param. If the param is found and it is less than min, an
+            min_value (int): Set to the minimum value allowed for this
+                param. If the param is found and it is less than min_value, an
                 ``HTTPError`` is raised.
-            max (int): Set to the maximum value allowed for this
+            max_value (int): Set to the maximum value allowed for this
                 param. If the param is found and its value is greater than
-                max, an ``HTTPError`` is raised.
+                max_value, an ``HTTPError`` is raised.
             store (dict): A ``dict``-like object in which to place
                 the value of the param, but only if the param is found
                 (default ``None``).
@@ -1192,7 +1192,7 @@ class Request(object):
                 it was required to be there, or it was found but could not
                 be converted to an ``int``. Also raised if the param's value
                 falls outside the given interval, i.e., the value must be in
-                the interval: min <= value <= max to avoid triggering an error.
+                the interval: min_value <= value <= max_value to avoid triggering an error.
 
         """
 
@@ -1211,12 +1211,12 @@ class Request(object):
                 msg = 'The value must be an integer.'
                 raise errors.HTTPInvalidParam(msg, name)
 
-            if min is not None and val < min:
-                msg = 'The value must be at least ' + str(min)
+            if min_value is not None and val < min_value:
+                msg = 'The value must be at least ' + str(min_value)
                 raise errors.HTTPInvalidParam(msg, name)
 
-            if max is not None and max < val:
-                msg = 'The value may not exceed ' + str(max)
+            if max_value is not None and max_value < val:
+                msg = 'The value may not exceed ' + str(max_value)
                 raise errors.HTTPInvalidParam(msg, name)
 
             if store is not None:
@@ -1229,8 +1229,8 @@ class Request(object):
 
         raise errors.HTTPMissingParam(name)
 
-    def get_param_as_float(self, name, required=False, min=None,
-                           max=None, store=None, default=None):
+    def get_param_as_float(self, name, required=False, min_value=None,
+                           max_value=None, store=None, default=None):
         """Return the value of a query string parameter as an float.
 
         Args:
@@ -1241,12 +1241,12 @@ class Request(object):
                 ``HTTPBadRequest`` instead of returning ``None`` when the
                 parameter is not found or is not an float (default
                 ``False``).
-            min (float): Set to the minimum value allowed for this
-                param. If the param is found and it is less than min, an
+            min_value (float): Set to the minimum value allowed for this
+                param. If the param is found and it is less than min_value, an
                 ``HTTPError`` is raised.
-            max (float): Set to the maximum value allowed for this
+            max_value (float): Set to the maximum value allowed for this
                 param. If the param is found and its value is greater than
-                max, an ``HTTPError`` is raised.
+                max_value, an ``HTTPError`` is raised.
             store (dict): A ``dict``-like object in which to place
                 the value of the param, but only if the param is found
                 (default ``None``).
@@ -1263,7 +1263,7 @@ class Request(object):
                 it was required to be there, or it was found but could not
                 be converted to an ``float``. Also raised if the param's value
                 falls outside the given interval, i.e., the value must be in
-                the interval: min <= value <= max to avoid triggering an error.
+                the interval: min_value <= value <= max_value to avoid triggering an error.
 
         """
 
@@ -1282,12 +1282,12 @@ class Request(object):
                 msg = 'The value must be a float.'
                 raise errors.HTTPInvalidParam(msg, name)
 
-            if min is not None and val < min:
-                msg = 'The value must be at least ' + str(min)
+            if min_value is not None and val < min_value:
+                msg = 'The value must be at least ' + str(min_value)
                 raise errors.HTTPInvalidParam(msg, name)
 
-            if max is not None and max < val:
-                msg = 'The value may not exceed ' + str(max)
+            if max_value is not None and max_value < val:
+                msg = 'The value may not exceed ' + str(max_value)
                 raise errors.HTTPInvalidParam(msg, name)
 
             if store is not None:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -646,9 +646,9 @@ class Request(object):
                 raise ValueError()
 
             if first:
-                return (int(first), int(last or -1))
+                return int(first), int(last or -1)
             elif last:
-                return (-int(last), -1)
+                return -int(last), -1
             else:
                 msg = 'The range offsets are missing.'
                 raise errors.HTTPInvalidHeader(msg, 'Range')
@@ -656,7 +656,7 @@ class Request(object):
         except ValueError:
             href = 'http://goo.gl/zZ6Ey'
             href_text = 'HTTP/1.1 Range Requests'
-            msg = ('It must be a range formatted according to RFC 7233.')
+            msg = 'It must be a range formatted according to RFC 7233.'
             raise errors.HTTPInvalidHeader(msg, 'Range', href=href,
                                            href_text=href_text)
 
@@ -1010,7 +1010,7 @@ class Request(object):
             # Value for the accept header was not formatted correctly
             preferred_type = ''
 
-        return (preferred_type if preferred_type else None)
+        return preferred_type if preferred_type else None
 
     def get_header(self, name, required=False, default=None):
         """Retrieve the raw string value for the given header.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -646,9 +646,9 @@ class Request(object):
                 raise ValueError()
 
             if first:
-                return int(first), int(last or -1)
+                return (int(first), int(last or -1))
             elif last:
-                return -int(last), -1
+                return (-int(last), -1)
             else:
                 msg = 'The range offsets are missing.'
                 raise errors.HTTPInvalidHeader(msg, 'Range')
@@ -1010,7 +1010,7 @@ class Request(object):
             # Value for the accept header was not formatted correctly
             preferred_type = ''
 
-        return preferred_type if preferred_type else None
+        return (preferred_type if preferred_type else None)
 
     def get_header(self, name, required=False, default=None):
         """Retrieve the raw string value for the given header.

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -297,33 +297,33 @@ class TestQueryParams(object):
         assert req.get_param_as_int('limit', store=store) == 25
         assert store['limit'] == 25
 
-        assert req.get_param_as_int('limit', min=1, max=50) == 25
+        assert req.get_param_as_int('limit', min_value=1, max_value=50) == 25
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('limit', min=0, max=10)
+            req.get_param_as_int('limit', min_value=0, max_value=10)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('limit', min=0, max=24)
+            req.get_param_as_int('limit', min_value=0, max_value=24)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('limit', min=30, max=24)
+            req.get_param_as_int('limit', min_value=30, max_value=24)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('limit', min=30, max=50)
+            req.get_param_as_int('limit', min_value=30, max_value=50)
 
-        assert req.get_param_as_int('limit', min=1) == 25
+        assert req.get_param_as_int('limit', min_value=1) == 25
 
-        assert req.get_param_as_int('limit', max=50) == 25
+        assert req.get_param_as_int('limit', max_value=50) == 25
 
-        assert req.get_param_as_int('limit', max=25) == 25
+        assert req.get_param_as_int('limit', max_value=25) == 25
 
-        assert req.get_param_as_int('limit', max=26) == 25
+        assert req.get_param_as_int('limit', max_value=26) == 25
 
-        assert req.get_param_as_int('limit', min=25) == 25
+        assert req.get_param_as_int('limit', min_value=25) == 25
 
-        assert req.get_param_as_int('limit', min=24) == 25
+        assert req.get_param_as_int('limit', min_value=24) == 25
 
-        assert req.get_param_as_int('limit', min=-24) == 25
+        assert req.get_param_as_int('limit', min_value=-24) == 25
 
     def test_int_neg(self, simulate_request, client, resource):
         client.app.add_route('/', resource)
@@ -333,21 +333,21 @@ class TestQueryParams(object):
         req = resource.captured_req
         assert req.get_param_as_int('pos') == -7
 
-        assert req.get_param_as_int('pos', min=-10, max=10) == -7
+        assert req.get_param_as_int('pos', min_value=-10, max_value=10) == -7
 
-        assert req.get_param_as_int('pos', max=10) == -7
-
-        with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('pos', min=-6, max=0)
+        assert req.get_param_as_int('pos', max_value=10) == -7
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('pos', min=-6)
+            req.get_param_as_int('pos', min_value=-6, max_value=0)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('pos', min=0, max=10)
+            req.get_param_as_int('pos', min_value=-6)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_int('pos', min=0, max=10)
+            req.get_param_as_int('pos', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('pos', min_value=0, max_value=10)
 
     def test_float(self, simulate_request, client, resource):
         client.app.add_route('/', resource)
@@ -372,33 +372,33 @@ class TestQueryParams(object):
         assert req.get_param_as_float('limit', store=store) == 25.1
         assert store['limit'] == 25.1
 
-        assert req.get_param_as_float('limit', min=1, max=50) == 25.1
+        assert req.get_param_as_float('limit', min_value=1, max_value=50) == 25.1
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('limit', min=0, max=10)
+            req.get_param_as_float('limit', min_value=0, max_value=10)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('limit', min=0, max=24)
+            req.get_param_as_float('limit', min_value=0, max_value=24)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('limit', min=30, max=24)
+            req.get_param_as_float('limit', min_value=30, max_value=24)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('limit', min=30, max=50)
+            req.get_param_as_float('limit', min_value=30, max_value=50)
 
-        assert req.get_param_as_float('limit', min=1) == 25.1
+        assert req.get_param_as_float('limit', min_value=1) == 25.1
 
-        assert req.get_param_as_float('limit', max=50) == 25.1
+        assert req.get_param_as_float('limit', max_value=50) == 25.1
 
-        assert req.get_param_as_float('limit', max=25.1) == 25.1
+        assert req.get_param_as_float('limit', max_value=25.1) == 25.1
 
-        assert req.get_param_as_float('limit', max=26) == 25.1
+        assert req.get_param_as_float('limit', max_value=26) == 25.1
 
-        assert req.get_param_as_float('limit', min=25) == 25.1
+        assert req.get_param_as_float('limit', min_value=25) == 25.1
 
-        assert req.get_param_as_float('limit', min=24) == 25.1
+        assert req.get_param_as_float('limit', min_value=24) == 25.1
 
-        assert req.get_param_as_float('limit', min=-24) == 25.1
+        assert req.get_param_as_float('limit', min_value=-24) == 25.1
 
     def test_float_neg(self, simulate_request, client, resource):
         client.app.add_route('/', resource)
@@ -408,21 +408,21 @@ class TestQueryParams(object):
         req = resource.captured_req
         assert req.get_param_as_float('pos') == -7.1
 
-        assert req.get_param_as_float('pos', min=-10, max=10) == -7.1
+        assert req.get_param_as_float('pos', min_value=-10, max_value=10) == -7.1
 
-        assert req.get_param_as_float('pos', max=10) == -7.1
-
-        with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('pos', min=-6, max=0)
+        assert req.get_param_as_float('pos', max_value=10) == -7.1
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('pos', min=-6)
+            req.get_param_as_float('pos', min_value=-6, max_value=0)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('pos', min=0, max=10)
+            req.get_param_as_float('pos', min_value=-6)
 
         with pytest.raises(falcon.HTTPBadRequest):
-            req.get_param_as_float('pos', min=0, max=10)
+            req.get_param_as_float('pos', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('pos', min_value=0, max_value=10)
 
     def test_uuid(self, simulate_request, client, resource):
         client.app.add_route('/', resource)


### PR DESCRIPTION
#1387 

@vytas7 @kgriffs In the first commit, I removed unnecessary parentheses. Also would be cool, if you have some additional places where we need to rename(arguments and etc.) let me know.