### PR TITLE
fix(cython): properly test cythonized Falcon & make print_routes work with cythonized responders

### DIFF
--- a/tests/test_cmd_print_api.py
+++ b/tests/test_cmd_print_api.py
@@ -3,6 +3,11 @@ from falcon.cmd import print_routes
 from falcon.testing import redirected
 from falcon.util import compat
 
+try:
+    import cython
+except ImportError:
+    cython = None
+
 
 class DummyResource(object):
 
@@ -31,10 +36,16 @@ def test_traverse_with_verbose():
         get_info, options_info = options_info, get_info
 
     assert options_info.startswith('-->OPTIONS')
-    assert 'falcon/responders.py:' in options_info
+    if cython:
+        assert options_info.endswith('[unknown file]')
+    else:
+        assert 'falcon/responders.py:' in options_info
 
     assert get_info.startswith('-->GET')
-    assert 'tests/test_cmd_print_api.py:' in get_info
+    # NOTE(vytas): This builds upon the fact that on_get is defined on line 14
+    # in this file. Adjust the test if the said responder is relocated, or just
+    # check for any number if this becomes too painful to maintain.
+    assert get_info.endswith('tests/test_cmd_print_api.py:14')
 
 
 def test_traverse():

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -1,0 +1,15 @@
+import pytest
+
+import falcon
+
+try:
+    import cython
+except Exception:
+    cython = None
+
+
+class TestCythonized(object):
+
+    @pytest.mark.skipif(not cython, reason='Cython not installed')
+    def test_imported_from_c_modules(self):
+        assert 'falcon/api.py' not in str(falcon.api)

--- a/tests/test_cython.py
+++ b/tests/test_cython.py
@@ -4,7 +4,7 @@ import falcon
 
 try:
     import cython
-except Exception:
+except ImportError:
     cython = None
 
 


### PR DESCRIPTION
Closes #1400 

(see the issue for problem background and discussion).

Note that the solution is somewhat counter-intuitive and strange: removing `test/__init__.py`. This prevents `pytest` from treating `tests` as a module which in turns makes `pytest` change directory to its parent, at the same time shadowing cythonized Falcon with the local source.

Could this removal be a problem?