### PR TITLE
refactor: Import abstract base classes from collections.abc under Python 3

### DIFF
--- a/falcon/util/compat.py
+++ b/falcon/util/compat.py
@@ -10,6 +10,7 @@ PY3 = sys.version_info.major == 3
 if PY3:
     from http import cookies as http_cookies  # NOQA: F401
     from collections import UserDict  # NOQA: F401
+    from collections.abc import Mapping, MutableMapping  # NOQA: F401
     from io import StringIO  # NOQA: F401
     from urllib.parse import quote, unquote_plus  # NOQA: F401
 
@@ -19,6 +20,7 @@ if PY3:
 
     get_method_self = op.attrgetter('__self__')
 else:
+    from collections import Mapping, MutableMapping  # NOQA: F401
     import Cookie as http_cookies  # NOQA: F401
     from UserDict import UserDict  # NOQA: F401
     from StringIO import StringIO  # NOQA: F401

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -27,17 +27,17 @@ for convenience::
 
 """
 
-import collections
+from collections.abc import Mapping, MutableMapping
 
 
 # TODO(kgriffs): If we ever diverge from what is upstream in Requests,
 # then we will need write tests and remove the "no cover" pragma.
-class CaseInsensitiveDict(collections.MutableMapping):  # pragma: no cover
+class CaseInsensitiveDict(MutableMapping):  # pragma: no cover
     """
     A case-insensitive ``dict``-like object.
 
     Implements all methods and operations of
-    ``collections.MutableMapping`` as well as dict's `copy`. Also
+    ``collections.abc.MutableMapping`` as well as dict's `copy`. Also
     provides `lower_items`.
 
     All keys are expected to be strings. The structure remembers the
@@ -92,7 +92,7 @@ class CaseInsensitiveDict(collections.MutableMapping):  # pragma: no cover
         )
 
     def __eq__(self, other):
-        if isinstance(other, collections.Mapping):
+        if isinstance(other, Mapping):
             other = CaseInsensitiveDict(other)
         else:
             return NotImplemented

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -27,7 +27,7 @@ for convenience::
 
 """
 
-from collections.abc import Mapping, MutableMapping
+from falcon.util.compat import Mapping, MutableMapping
 
 
 # TODO(kgriffs): If we ever diverge from what is upstream in Requests,


### PR DESCRIPTION
Update the import path for [abstract base classes](https://docs.python.org/3/library/collections.abc.html), which changed from `collections` to `collections.abc` in Python 3.3.

This resolves warnings like this:

```
.../site-packages/falcon/util/structures.py:35: DeprecationWarning:
  Using or importing the ABCs from 'collections' instead of from
  'collections.abc' is deprecated, and in 3.8 it will stop working
    class CaseInsensitiveDict(collections.MutableMapping):  # pragma: no cover
```