### PR TITLE
docs(CHANGES): independent_middleware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Breaking Changes
   ``False``.
 - ``RequestOptions.auto_parse_qs_csv`` now defaults to ``False`` instead of
   ``True``.
+  ``API.independent_middleware`` now defaults to ``True`` instead of ``False``.
 
 Changes to Supported Platforms
 ------------------------------


### PR DESCRIPTION
Ref: #1276 

Updates the CHANGES.rst breaking section to include the default value change for API.independent_middleware.