### PR TITLE
refactor(Response): Remove stream_len property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,11 @@ matrix:
           env: TOXENV=py36_smoke_cython
         - python: 2.7
           env: TOXENV=docs
-        - python: 3.6
-          env: TOXENV=hug
+
+        # TODO(kgriffs): Re-enable once we have mitigated the stream_len
+        #   breaking change in hug.
+        # - python: 3.6
+        #   env: TOXENV=hug
 
 script: tox
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Breaking Changes
   ``False``.
 - ``RequestOptions.auto_parse_qs_csv`` now defaults to ``False`` instead of
   ``True``.
+- The deprecated ``stream_len`` property was removed from the ``Response``
+  class. Please use ``Response.set_stream()`` or ``Response.content_length``
+  instead.
 
 Changes to Supported Platforms
 ------------------------------

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -16,6 +16,9 @@ Breaking Changes
   instead of ``False``.
 - :attr:`~.RequestOptions.auto_parse_qs_csv` now defaults to ``False``
   instead of ``True``.
+- The deprecated ``stream_len`` property was removed from the
+  :class:`~.Response` class. Please use :meth:`~.Response.set_stream` or
+  :attr:`~.Response.content_length` instead.
 
 Changes to Supported Platforms
 ------------------------------

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # Copyright 2013 by Rackspace Hosting, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -280,10 +282,11 @@ class API(object):
             body = []
         else:
             body, length = self._get_body(resp, env.get('wsgi.file_wrapper'))
-            if resp.content_length is None and length is not None:
+
+            # PERF(kgriffs): Böse mußt sein. Operate directly on resp._headers
+            #   to reduce overhead since this is a hot/critical code path.
+            if 'content-length' not in resp._headers and length is not None:
                 resp._headers['content-length'] = str(length)
-            elif resp.content_length is not None:
-                resp._headers['content-length'] = str(resp.content_length)
 
         # NOTE(kgriffs): Based on wsgiref.validate's interpretation of
         # RFC 2616, as commented in that module's source code. The
@@ -730,13 +733,15 @@ class API(object):
             The length is returned as ``None`` when unknown. The
             iterable is determined as follows:
 
-                * If resp.body is not ``None``, returns [resp.body],
+                * If resp.body is not ``None``, returns
+                  ([resp.body], len(resp.body)),
                   encoded as UTF-8 if it is a Unicode string.
                   Bytestrings are returned as-is.
-                * If resp.data is not ``None``, returns [resp.data]
+                * If resp.data is not ``None``, returns ([resp.data], len(resp.data))
                 * If resp.stream is not ``None``, returns resp.stream
-                  iterable using wsgi.file_wrapper, if possible.
-                * Otherwise, returns []
+                  iterable using wsgi.file_wrapper, if necessary:
+                  (closeable_iterator, None)
+                * Otherwise, returns ([], 0)
 
         """
         body = resp.body
@@ -767,9 +772,6 @@ class API(object):
             else:
                 iterable = stream
 
-            # NOTE(pshello): resp.stream_len is deprecated in favor of
-            # resp.content_length. The caller of _get_body should give
-            # preference to resp.content_length if it has been set.
-            return iterable, resp.stream_len
+            return iterable, None
 
         return [], 0

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -59,7 +59,7 @@ class HelloResource(object):
                 resp.set_stream(stream, stream_len)
             else:
                 resp.stream = stream
-                resp.stream_len = stream_len
+                resp.content_length = stream_len
 
         if 'body' in self.mode:
             if 'bytes' in self.mode:
@@ -173,7 +173,7 @@ class TestHelloWorld(object):
         result = client.simulate_get('/stream')
         assert resource.called
 
-        expected_len = resource.resp.stream_len
+        expected_len = int(resource.resp.content_length)
         actual_len = int(result.headers['content-length'])
         assert actual_len == expected_len
         assert len(result.content) == expected_len
@@ -187,7 +187,7 @@ class TestHelloWorld(object):
             result = client.simulate_get('/filelike', file_wrapper=file_wrapper)
             assert resource.called
 
-            expected_len = resource.resp.stream_len
+            expected_len = int(resource.resp.content_length)
             actual_len = int(result.headers['content-length'])
             assert actual_len == expected_len
             assert len(result.content) == expected_len
@@ -196,7 +196,7 @@ class TestHelloWorld(object):
             result = client.simulate_get('/filelike', file_wrapper=file_wrapper)
             assert resource.called
 
-            expected_len = resource.resp.stream_len
+            expected_len = int(resource.resp.content_length)
             actual_len = int(result.headers['content-length'])
             assert actual_len == expected_len
             assert len(result.content) == expected_len
@@ -212,7 +212,7 @@ class TestHelloWorld(object):
         result = client.simulate_get('/filelike-closing', file_wrapper=None)
         assert resource.called
 
-        expected_len = resource.resp.stream_len
+        expected_len = int(resource.resp.content_length)
         actual_len = int(result.headers['content-length'])
         assert actual_len == expected_len
         assert len(result.content) == expected_len
@@ -227,7 +227,7 @@ class TestHelloWorld(object):
         result = client.simulate_get('/filelike-helper')
         assert resource.called
 
-        expected_len = resource.resp.stream_len
+        expected_len = int(resource.resp.content_length)
         actual_len = int(result.headers['content-length'])
         assert actual_len == expected_len
         assert len(result.content) == expected_len

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -46,3 +46,13 @@ def test_response_attempt_to_set_read_only_headers():
     assert headers['x-things1'] == 'thing-1'
     assert headers['x-things2'] == 'thing-2'
     assert headers['x-things3'] == 'thing-3a, thing-3b'
+
+
+def test_response_removed_stream_len():
+    resp = falcon.Response()
+
+    with pytest.raises(AttributeError):
+        resp.stream_len = 128
+
+    with pytest.raises(AttributeError):
+        resp.stream_len


### PR DESCRIPTION
This patch "removes" the deprecated stream_len property, fully replacing it's use by the content-length property/header. Along the way, the way API uses content-length (in lieu of stream_len) was optimized.