### PR TITLE
refactor(falcon.request): Change etag headers to return a list of ETag

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -19,3 +19,6 @@ Miscellaneous
 
 .. autoclass:: falcon.TimezoneGMT
     :members:
+
+.. autoclass:: falcon.ETag
+    :members:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -364,6 +364,11 @@ class Request(object):
             This property is determined by the value of ``HTTP_IF_MATCH``
             in the WSGI environment dict.
 
+            Note:
+                This property includes strong and weakness entity-tags and that
+                means that two entity-tags are equivalent if both are not weak
+                and their opaque-tags match character-by-character.
+
         if_none_match (list): A list containing all the etags in the
             If-None-Match header.
 

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -368,7 +368,7 @@ class Request(object):
                 This property includes strong and weak entity-tags. Per
                 `RFC 7239`_, two entity-tags are equivalent if both are not
                 weak and their opaque-tags match character-by-character.
-            
+
             (See also: RFC 7239, Section 3.1)
 
         if_none_match (list): Value of the If-None-Match header, as a parsed

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -358,22 +358,33 @@ class Request(object):
             accessed.)
         range_unit (str): Unit of the range parsed from the value of the
             Range header, or ``None`` if the header is missing
-        if_match (list): A list containing all the etags in the If-Match
-            header.
+        if_match (list): Value of the If-Match header, as a parsed list of
+            :class:`falcon.ETag` objects or ``None`` if the header is missing.
 
             This property is determined by the value of ``HTTP_IF_MATCH``
             in the WSGI environment dict.
 
             Note:
-                This property includes strong and weakness entity-tags and that
-                means that two entity-tags are equivalent if both are not weak
-                and their opaque-tags match character-by-character.
+                This property includes strong and weak entity-tags. Per
+                `RFC 7239`_, two entity-tags are equivalent if both are not
+                weak and their opaque-tags match character-by-character.
+            
+            (See also: RFC 7239, Section 3.1)
 
-        if_none_match (list): A list containing all the etags in the
-            If-None-Match header.
+        if_none_match (list): Value of the If-None-Match header, as a parsed
+            list of :class:`falcon.ETag` objects or ``None`` if the header is
+            missing.
 
             This property is determined by the value of ``HTTP_IF_NONE_MATCH``
             in the WSGI environment dict.
+
+            Note:
+                This property includes strong and weak entity-tags. Per
+                `RFC 7239`_, two entity-tags are equivalent if their
+                opaque-tags match character-by-character, regardless of
+                either or both being tagged as weak.
+
+            (See also: RFC 7239, Section 3.2)
 
         if_modified_since (datetime): Value of the If-Modified-Since header,
             or ``None`` if the header is missing.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -358,10 +358,10 @@ class Request(object):
             accessed.)
         range_unit (str): Unit of the range parsed from the value of the
             Range header, or ``None`` if the header is missing
-        if_match (str): Value of the If-Match header, or ``None`` if the
-            header is missing.
-        if_none_match (str): Value of the If-None-Match header, or ``None``
-            if the header is missing.
+        if_match (list): A list containing all the etags in the If-Match
+            header.
+        if_none_match (list): A list containing all the etags in the
+            If-None-Match header.
         if_modified_since (datetime): Value of the If-Modified-Since header,
             or ``None`` if the header is missing.
         if_unmodified_since (datetime): Value of the If-Unmodified-Since
@@ -529,8 +529,6 @@ class Request(object):
 
     expect = helpers.header_property('HTTP_EXPECT')
 
-    if_match = helpers.header_property('HTTP_IF_MATCH')
-    if_none_match = helpers.header_property('HTTP_IF_NONE_MATCH')
     if_range = helpers.header_property('HTTP_IF_RANGE')
 
     referer = helpers.header_property('HTTP_REFERER')
@@ -619,6 +617,14 @@ class Request(object):
     @property
     def date(self):
         return self.get_header_as_datetime('Date')
+
+    @property
+    def if_match(self):
+        return helpers.parse_etags(self.env.get('HTTP_IF_MATCH'))
+
+    @property
+    def if_none_match(self):
+        return helpers.parse_etags(self.env.get('HTTP_IF_NONE_MATCH'))
 
     @property
     def if_modified_since(self):

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -360,8 +360,16 @@ class Request(object):
             Range header, or ``None`` if the header is missing
         if_match (list): A list containing all the etags in the If-Match
             header.
+
+            This property is determined by the value of ``HTTP_IF_MATCH``
+            in the WSGI environment dict.
+
         if_none_match (list): A list containing all the etags in the
             If-None-Match header.
+
+            This property is determined by the value of ``HTTP_IF_NONE_MATCH``
+            in the WSGI environment dict.
+
         if_modified_since (datetime): Value of the If-Modified-Since header,
             or ``None`` if the header is missing.
         if_unmodified_since (datetime): Value of the If-Unmodified-Since

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -95,7 +95,9 @@ def parse_etags(etag_str):
             if match is None:
                 break
             is_weak, quoted, raw = match.groups()
-            etags.append(make_etag(quoted or raw, bool(is_weak)))
+            value = quoted or raw
+            if value:
+                etags.append(make_etag(value, bool(is_weak)))
             pos = match.end()
 
     return etags

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -17,7 +17,7 @@
 import io
 import re
 
-from falcon.util.structures import ETag
+from falcon.util import ETag
 
 
 _ETAG_PATTERN = re.compile(r'([Ww]/)?(?:"(.*?)"|(.*?))(?:\s*,\s*|$)')
@@ -45,7 +45,16 @@ def header_property(wsgi_name):
 
 
 def make_etag(value, is_weak=False):
-    """Creates and returns a ETag object."""
+    """Creates and returns a ETag object.
+
+    Args:
+        value (str): Unquated entity tag value
+        is_weak (bool): The weakness indicator
+
+    Returns:
+        A ``str``-like Etag instance with weakness indicator.
+
+    """
     etag = ETag(value)
     etag.is_weak = is_weak
     return etag
@@ -65,11 +74,10 @@ def parse_etags(etag_str):
         A list of unquoted ETags or ``['*']`` if all ETags should be matched.
 
     """
-    etags = []
-
     if etag_str is None:
-        return etags
+        return None
 
+    etags = []
     etag_str = etag_str.strip()
     if not etag_str:
         return etags

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -92,8 +92,6 @@ def parse_etags(etag_str):
         end = len(etag_str)
         while pos < end:
             match = _ETAG_PATTERN.match(etag_str, pos)
-            if match is None:
-                break
             is_weak, quoted, raw = match.groups()
             value = quoted or raw
             if value:

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -26,8 +26,6 @@ except ImportError:
     import json  # NOQA
 
 # Hoist misc. utils
-from falcon.util import structures
+from falcon.util.structures import *  # NOQA
 from falcon.util.misc import *  # NOQA
 from falcon.util.time import *  # NOQA
-
-CaseInsensitiveDict = structures.CaseInsensitiveDict

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -118,7 +118,7 @@ class ETag(str):
 
     def to_header(self):
         """Convert the ETag into a HTTP header string.
-        
+
         Returns:
             str: An opaque quoted string, possibly prefixed by a weakness
             indicator ``W/``.

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -105,3 +105,19 @@ class CaseInsensitiveDict(collections.MutableMapping):  # pragma: no cover
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, dict(self.items()))
+
+
+class ETag(str):
+    """An entity-tag ``str``-like object with the weakness indicator.
+
+    Attributes:
+        is_weak (bool): The weakness indicator.
+
+    """
+    is_weak = False
+
+    def to_header(self):
+        """Convert the etag into a HTTP header string."""
+        if self.is_weak:
+            return 'W/"%s"' % self
+        return '"%s"' % self

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -117,7 +117,13 @@ class ETag(str):
     is_weak = False
 
     def to_header(self):
-        """Convert the etag into a HTTP header string."""
+        """Convert the ETag into a HTTP header string.
+        
+        Returns:
+            str: An opaque quoted string, possibly prefixed by a weakness
+            indicator ``W/``.
+
+        """
         if self.is_weak:
             return 'W/"%s"' % self
         return '"%s"' % self

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -5,6 +5,7 @@ import pytest
 
 import falcon
 from falcon.request import Request, RequestOptions
+from falcon.request_helpers import make_etag
 import falcon.testing as testing
 import falcon.uri
 from falcon.util import compat
@@ -784,17 +785,31 @@ class TestRequestAttributes(object):
         assert req.app == ''
 
     @pytest.mark.parametrize('etag,expected', [
-        ('W/"67ab43"', ['67ab43']),
-        ('w/"67ab43"', ['67ab43']),
-        ('W/"67ab43", "54ed21"', ['67ab43', '54ed21']),
-        ('  W/"67ab43" , "54ed21"', ['67ab43', '54ed21']),
-        ('W/"67ab43"  ,  "54ed21"', ['67ab43', '54ed21']),
-        ('W/"67ab43" ,"54ed21"', ['67ab43', '54ed21']),
-        ('W/"67ab43", unquoted, "54ed21"', ['67ab43', '54ed21']),
-        ('*', ['*']),
-        (' * ', ['*']),
-        ('empty', []),
         (None, []),
+        ('', []),
+        ('*', ['*']),
+        (
+            'W/"67ab43"',
+            [make_etag('67ab43', is_weak=True)]
+        ),
+        (
+            'w/"67ab43"',
+            [make_etag('67ab43', is_weak=True)]
+        ),
+        (
+            '"67ab43"',
+            [make_etag('67ab43', is_weak=True)]
+        ),
+        (
+            '67ab43',
+            [make_etag("67ab43", is_weak=False)]
+        ),
+        (
+            'W/"67ab43", "54ed21", 67ab43',
+            [make_etag('67ab43', is_weak=True),
+             make_etag('54ed21', is_weak=False),
+             make_etag('67ab43', is_weak=False)]
+        ),
     ])
     def test_etag(self, etag, expected):
         self._test_header_expected_value('If-Match', etag, 'if_match', expected)

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -787,6 +787,7 @@ class TestRequestAttributes(object):
     @pytest.mark.parametrize('etag,expected', [
         (None, []),
         ('', []),
+        (',', []),
         ('*', ['*']),
         (
             'W/"67ab43"',
@@ -805,10 +806,10 @@ class TestRequestAttributes(object):
             [make_etag('67ab43', is_weak=False)]
         ),
         (
-            'W/"67ab43", "54ed21", 67ab43',
+            'W/"67ab43", "54ed21", 42we85',
             [make_etag('67ab43', is_weak=True),
              make_etag('54ed21', is_weak=False),
-             make_etag('67ab43', is_weak=False)]
+             make_etag('42we85', is_weak=False)]
         ),
     ])
     def test_etag(self, etag, expected):

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -785,7 +785,6 @@ class TestRequestAttributes(object):
         assert req.app == ''
 
     @pytest.mark.parametrize('etag,expected', [
-        (None, []),
         ('', []),
         (',', []),
         ('*', ['*']),
@@ -815,6 +814,10 @@ class TestRequestAttributes(object):
     def test_etag(self, etag, expected):
         self._test_header_expected_value('If-Match', etag, 'if_match', expected)
         self._test_header_expected_value('If-None-Match', etag, 'if_none_match', expected)
+
+    def test_etag_is_missing(self):
+        assert self.req.if_match == []
+        assert self.req.if_none_match == []
 
     # -------------------------------------------------------------------------
     # Helpers

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -802,7 +802,7 @@ class TestRequestAttributes(object):
         ),
         (
             '67ab43',
-            [make_etag("67ab43", is_weak=False)]
+            [make_etag('67ab43', is_weak=False)]
         ),
         (
             'W/"67ab43", "54ed21", 67ab43',

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -816,8 +816,8 @@ class TestRequestAttributes(object):
         self._test_header_expected_value('If-None-Match', etag, 'if_none_match', expected)
 
     def test_etag_is_missing(self):
-        assert self.req.if_match == []
-        assert self.req.if_none_match == []
+        assert self.req.if_match is None
+        assert self.req.if_none_match is None
 
     # -------------------------------------------------------------------------
     # Helpers

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import falcon
 from falcon import testing
 from falcon import util
-from falcon.util import compat, json, uri
+from falcon.util import compat, json, uri, structures
 
 
 def _arbitrary_uris(count, length):
@@ -317,6 +317,12 @@ class TestFalconUtils(object):
         with pytest.raises(ValueError):
             falcon.get_http_status('-404.3')
         assert falcon.get_http_status(123, 'Go Away') == '123 Go Away'
+
+    def test_etag_to_header(self):
+        etag = structures.ETag('67ab43')
+        assert etag.to_header() == '"67ab43"'
+        etag.is_weak = True
+        assert etag.to_header() == 'W/"67ab43"'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import falcon
 from falcon import testing
 from falcon import util
-from falcon.util import compat, json, uri, structures
+from falcon.util import compat, json, structures, uri
 
 
 def _arbitrary_uris(count, length):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 import falcon
 from falcon import testing
 from falcon import util
-from falcon.util import compat, json, structures, uri
+from falcon.util import compat, json, misc, structures, uri
 
 
 def _arbitrary_uris(count, length):


### PR DESCRIPTION
Closes #1211

`W/` prefix was simply ignored as proposed in the issue by @kgriffs.