### PR TITLE
docs(changes) independent middleware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Breaking Changes
   ``False``.
 - ``RequestOptions.auto_parse_qs_csv`` now defaults to ``False`` instead of
   ``True``.
-- `independent_middleware` kwarg on ``falcon.API`` now defaults to ``True``
+- ``independent_middleware`` kwarg on ``falcon.API`` now defaults to ``True``
   instead of ``False``.
 
 Changes to Supported Platforms

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Breaking Changes
   ``False``.
 - ``RequestOptions.auto_parse_qs_csv`` now defaults to ``False`` instead of
   ``True``.
+- `independent_middleware` kwarg on ``falcon.API`` now defaults to ``True``
+  instead of ``False``.
 
 Changes to Supported Platforms
 ------------------------------

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -16,6 +16,8 @@ Breaking Changes
   instead of ``False``.
 - :attr:`~.RequestOptions.auto_parse_qs_csv` now defaults to ``False``
   instead of ``True``.
+- `independent_middleware` kwarg on :class:`falcon.API` now defaults to 
+  ``True`` instead of ``False``.
 
 Changes to Supported Platforms
 ------------------------------

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -16,7 +16,7 @@ Breaking Changes
   instead of ``False``.
 - :attr:`~.RequestOptions.auto_parse_qs_csv` now defaults to ``False``
   instead of ``True``.
-- `independent_middleware` kwarg on :class:`falcon.API` now defaults to 
+- ``independent_middleware`` kwarg on :class:`falcon.API` now defaults to 
   ``True`` instead of ``False``.
 
 Changes to Supported Platforms


### PR DESCRIPTION
References closed issue, #1276 

Something went screwy with my old branch for this PR, sorry to recreate a new one.
- Updated terminology to use 'kwarg'
- Updated 2.0.0rst, although not sure why the syntax style is a little different between changes.rst and 2.0.0rst, tried to stay consistent