### PR TITLE
fix(errors): call custom serializers even for errors without represention

### DIFF
--- a/falcon/api.py
+++ b/falcon/api.py
@@ -547,6 +547,14 @@ class API(object):
             "+json" or "+xml" suffix, the default serializer will
             convert the error to JSON or XML, respectively.
 
+        Note:
+            The default serializer will not render any response body for
+            :class:`~.HTTPError` instances where the `has_representation`
+            property evaluates to ``False``, for example, instances of classes
+            deriving from :class:`falcon.http_error.NoRepresentation`. However,
+            a custom serializer will be called regardless of the property
+            value, and it may choose to override the representation logic.
+
         The :class:`~.HTTPError` class contains helper methods,
         such as `to_json()` and `to_dict()`, that can be used from
         within custom serializers. For example::
@@ -557,7 +565,7 @@ class API(object):
                 preferred = req.client_prefers(('application/x-yaml',
                                                 'application/json'))
 
-                if preferred is not None:
+                if exception.has_representation and preferred is not None:
                     if preferred == 'application/json':
                         representation = exception.to_json()
                     else:
@@ -679,8 +687,7 @@ class API(object):
         if error.headers is not None:
             resp.set_headers(error.headers)
 
-        if error.has_representation:
-            self._serialize_error(req, resp, error)
+        self._serialize_error(req, resp, error)
 
     def _http_status_handler(self, req, resp, status, params):
         self._compose_status_response(req, resp, status)

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -561,8 +561,8 @@ class API(object):
             :class:`~.HTTPError` instances where the `has_representation`
             property evaluates to ``False`` (such as in the case of types
             that subclass :class:`falcon.http_error.NoRepresentation`). 
-            However a custom serializer will be called regardless of the 
-            property value, and it may choose to override the 
+            However a custom serializer will be called regardless of the
+            property value, and it may choose to override the
             representation logic.
 
         The :class:`~.HTTPError` class contains helper methods,

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -560,7 +560,7 @@ class API(object):
             The default serializer will not render any response body for
             :class:`~.HTTPError` instances where the `has_representation`
             property evaluates to ``False`` (such as in the case of types
-            that subclass :class:`falcon.http_error.NoRepresentation`). 
+            that subclass :class:`falcon.http_error.NoRepresentation`).
             However a custom serializer will be called regardless of the
             property value, and it may choose to override the
             representation logic.

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -550,10 +550,11 @@ class API(object):
         Note:
             The default serializer will not render any response body for
             :class:`~.HTTPError` instances where the `has_representation`
-            property evaluates to ``False``, for example, instances of classes
-            deriving from :class:`falcon.http_error.NoRepresentation`. However,
-            a custom serializer will be called regardless of the property
-            value, and it may choose to override the representation logic.
+            property evaluates to ``False`` (such as in the case of types
+            that subclass :class:`falcon.http_error.NoRepresentation`). 
+            However a custom serializer will be called regardless of the 
+            property value, and it may choose to override the 
+            representation logic.
 
         The :class:`~.HTTPError` class contains helper methods,
         such as `to_json()` and `to_dict()`, that can be used from

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -137,6 +137,9 @@ def default_serialize_error(req, resp, exception):
         resp: Instance of ``falcon.Response``
         exception: Instance of ``falcon.HTTPError``
     """
+    if not exception.has_representation:
+        return
+
     representation = None
 
     preferred = req.client_prefers(('application/xml',

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -47,6 +47,11 @@ class HTTPError(Exception):
 
             (See also: :class:`falcon.http_error.NoRepresentation`)
 
+            Note:
+                A custom error serializer
+                (see :meth:`~.API.set_error_serializer`) may choose to set a
+                response body regardless of the value of this property.
+
         title (str): Error title to send to the client.
         description (str): Description of the error to send to the client.
         headers (dict): Extra headers to add to the response.


### PR DESCRIPTION
Addresses https://github.com/falconry/falcon/issues/1422

This is still somewhat work in progress, I am sharing this to speed things up for the impending 2.0 release.
If the general direction looks good, I will update `CHANGES.rst` etc.