### PR TITLE
fix(sphinx): add wraps in jsonschema.validate decorator

### DIFF
--- a/falcon/media/validators/jsonschema.py
+++ b/falcon/media/validators/jsonschema.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from functools import wraps
+
 import falcon
 
 try:
@@ -46,6 +48,7 @@ def validate(req_schema=None, resp_schema=None):
     """
 
     def decorator(func):
+        @wraps(func)
         def wrapper(self, req, resp, *args, **kwargs):
             if req_schema is not None:
                 try:


### PR DESCRIPTION
the usage of `@jsonschema.validate` on methods loses the doc-string
    when using sphinx to create documents.
`@wraps` will preserve the doc-string

issue #1431