### PR TITLE
docs(style): block highlighting

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -55,7 +55,9 @@ code.xref.docutils.literal {
 }
 
 div.viewcode-block:target {
-    background: inherit;
+    background:#dadada;
+    border-radius: 5px;
+    padding: 5px;
 }
 
 a:hover, div.sphinxsidebar a:hover, a.reference:hover, a.reference.internal:hover code {

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -55,7 +55,8 @@ code.xref.docutils.literal {
 }
 
 div.viewcode-block:target {
-    background:#dadada;
+    background: inherit;
+    background-color: #dadada;
     border-radius: 5px;
     padding: 5px;
 }


### PR DESCRIPTION
Closes #1323 

I checked several different pages, and for anything that doesn't overflow it looks good. Since I changed the color just slightly so `self` was more readable here's a screenshot.

![new_style](https://user-images.githubusercontent.com/3630841/52526084-9b55b700-2c81-11e9-947d-9ded5eae92ba.PNG)

We have some overflow in the current docs, just based on our source line length and what the current docs css can handle. May want to create a new ticket for fixing overflow.

See:
![overflow](https://user-images.githubusercontent.com/3630841/52526053-0e126280-2c81-11e9-99b5-2d810c4f9e75.png)

