### PR TITLE
chore: add official support for CPython 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
+
+dist: xenial
 sudo: false
+
 install: pip install tox coveralls
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ matrix:
         - python: 2.7
           env: TOXENV=py27
         - python: 2.7
-          env: TOXENV=py27_ujson
-        - python: 2.7
           env: TOXENV=py27_smoke
         - python: 2.7
           env: TOXENV=py27_cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 dist: xenial
-sudo: false
 
 install: pip install tox coveralls
 cache:
@@ -59,6 +58,8 @@ notifications:
     on_failure: always
 
 before_install:
+  - sudo apt-get update
+  - sudo apt-get install -y libunwind-dev
   - pip install codecov
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
           env: TOXENV=py37_smoke_cython
         - python: 2.7
           env: TOXENV=docs
-        - python: 3.7
+        - python: 3.6
           env: TOXENV=hug
 
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache:
 
 matrix:
     include:
-        - python: pypy
+        - python: pypy2.7-6.0
           env: TOXENV=pypy
-        - python: pypy3
+        - python: pypy3.5-6.0
           env: TOXENV=pypy3
         - python: 2.7
           env: TOXENV=pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,19 @@ matrix:
           env: TOXENV=py35
         - python: 3.6
           env: TOXENV=py36
-        - python: 3.6
-          env: TOXENV=py36_ujson
-        - python: 3.6
-          env: TOXENV=py36_cython
-        - python: 3.6
-          env: TOXENV=py36_smoke
-        - python: 3.6
-          env: TOXENV=py36_smoke_cython
+        - python: 3.7
+          env: TOXENV=py37
+        - python: 3.7
+          env: TOXENV=py37_ujson
+        - python: 3.7
+          env: TOXENV=py37_cython
+        - python: 3.7
+          env: TOXENV=py37_smoke
+        - python: 3.7
+          env: TOXENV=py37_smoke_cython
         - python: 2.7
           env: TOXENV=docs
-        - python: 3.6
+        - python: 3.7
           env: TOXENV=hug
 
 script: tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Breaking Changes
 Changes to Supported Platforms
 ------------------------------
 
+- CPython 3.7 is now fully supported.
+
 New & Improved
 --------------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,19 @@ Please note that all contributors and maintainers of this project are subject to
 
 Before submitting a pull request, please ensure you have added or updated tests as appropriate, and that all existing tests still pass with your changes on both Python 2 and Python 3. Please also ensure that your coding style follows PEP 8.
 
-You can check all this by running the following from within the Falcon project directory (requires Python 2.7 and Python 3.6 to be installed on your system):
+You can check all this by running the following from within the Falcon project directory (requires Python 2.7 and Python 3.7 to be installed on your system):
 
 ```bash
 $ pip install tox
-$ tox -e py27,py36,pep8
+$ tox -e py27,py37,pep8
 ```
 
-You may also use Python 3.4 or 3.5 if you don't have 3.6 installed on your system. This is just a quick sanity check to verify that your patch works across both Python 2 and Python 3.
+You may also use Python 3.5 or 3.6 if you don't have 3.7 installed on your system. This is just a quick sanity check to verify that your patch works across both Python 2 and Python 3.
 
 If you are using pyenv and get an error along the lines of "failed to get version_info", you will need to activate all the Python versions required by tox before trying again. For example:
 
 ```bash
-$ pyenv shell 2.7.14 3.6.4
+$ pyenv shell 2.7.14 3.7.2
 ```
 
 #### Reviews
@@ -101,8 +101,8 @@ $ tox -e py27_bench -- -b falcon -i 20000
 Alternatively, you may run falcon-bench directly by creating a new virtual environment and installing falcon directly in development mode. In this example we use pyenv with pyenv-virtualenv from within a falcon source directory:
 
 ```bash
-$ pyenv virtualenv 3.6.2 falcon-sandbox-36
-$ pyenv shell falcon-sandbox-36
+$ pyenv virtualenv 3.7.2 falcon-sandbox-37
+$ pyenv shell falcon-sandbox-37
 $ pip install -r requirements/bench
 $ pip install -e .
 $ falcon-bench

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,14 +3,14 @@ all: build-benchmark-images
 build-benchmark-images:
 	sudo docker pull python:2.7-slim
 	sudo docker pull python:2.7
-	sudo docker pull python:3.6-slim
-	sudo docker pull python:3.6
+	sudo docker pull python:3.7-slim
+	sudo docker pull python:3.7
 	sudo docker pull pypy:2-slim
 	sudo docker pull pypy:3-slim
 
 	sudo docker build -t falconry/falcon-bench:py27 -f bench_py27.Dockerfile ./
 	sudo docker build -t falconry/falcon-bench:py27-cython -f bench_py27_cython.Dockerfile ./
-	sudo docker build -t falconry/falcon-bench:py36 -f bench_py36.Dockerfile ./
-	sudo docker build -t falconry/falcon-bench:py36-cython -f bench_py36_cython.Dockerfile ./
+	sudo docker build -t falconry/falcon-bench:py37 -f bench_py37.Dockerfile ./
+	sudo docker build -t falconry/falcon-bench:py37-cython -f bench_py37_cython.Dockerfile ./
 	sudo docker build -t falconry/falcon-bench:pypy2 -f bench_pypy2.Dockerfile ./
 	sudo docker build -t falconry/falcon-bench:pypy3 -f bench_pypy3.Dockerfile ./

--- a/docker/bench_py27_cython.Dockerfile
+++ b/docker/bench_py27_cython.Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Falcon Framework Maintainers
 RUN pip install cython
 
 # We don't currently benchmark JSON deserialization, but in the future we might
-RUN pip install ujson
+# RUN pip install ujson
 
 RUN pip install -v --no-cache-dir --no-binary :all: falcon
 RUN pip install --no-cache-dir bottle "django<2" flask

--- a/docker/bench_py37.Dockerfile
+++ b/docker/bench_py37.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.7-slim
 MAINTAINER Falcon Framework Maintainers
 
 RUN pip install --no-cache-dir falcon

--- a/docker/bench_py37_cython.Dockerfile
+++ b/docker/bench_py37_cython.Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Falcon Framework Maintainers
 RUN pip install cython
 
 # We don't currently benchmark JSON deserialization, but in the future we might
-RUN pip install ujson
+# RUN pip install orjson
 
 RUN pip install -v --no-cache-dir --no-binary :all: falcon
 RUN pip install --no-cache-dir bottle "django<2" flask

--- a/docker/bench_py37_cython.Dockerfile
+++ b/docker/bench_py37_cython.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER Falcon Framework Maintainers
 
 RUN pip install cython

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -30,6 +30,8 @@ Breaking Changes
 Changes to Supported Platforms
 ------------------------------
 
+- CPython 3.7 is now fully supported.
+
 New & Improved
 --------------
 

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='wsgi web api framework rest http cloud',
     author='Kurt Griffiths',

--- a/tools/mintest.sh
+++ b/tools/mintest.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 rm -f .coverage.*
-tox -e py27,py36,pep8 && tools/testing/combine_coverage.sh
+tox -e py27,py37,pep8 && tools/testing/combine_coverage.sh

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 # --------------------------------------------------------------------
 #
-# NOTE(kgriffs): The py27, and py36 envs are required when
+# NOTE(kgriffs): The py27, and py37 envs are required when
 # checking combined coverage. To check coverage:
 #
 #   $ tools/mintest.sh
@@ -10,7 +10,7 @@
 # Which is equivalent to:
 #
 #   $ rm -f .coverage.*
-#   $ tox -e py27,py36,pep8 && tools/testing/combine_coverage.sh
+#   $ tox -e py27,py37,pep8 && tools/testing/combine_coverage.sh
 #
 # You can then drill down into coverage details by opening the HTML
 # report at ".coverage_html/index.html".
@@ -20,12 +20,12 @@
 # the python version required by tox before trying again. For
 # example:
 #
-#   $ pyenv shell 2.7.13 3.6.2
+#   $ pyenv shell 2.7.13 3.7.2
 #
 # --------------------------------------------------------------------
 
 envlist = py27,
-          py36,
+          py37,
           pep8,
           docs
 
@@ -111,6 +111,10 @@ deps = {[with-ujson]deps}
 basepython = python3.6
 deps = {[with-ujson]deps}
 
+[testenv:py37_ujson]
+basepython = python3.7
+deps = {[with-ujson]deps}
+
 # --------------------------------------------------------------------
 # Cython
 # --------------------------------------------------------------------
@@ -135,6 +139,10 @@ deps = {[with-cython]deps}
 basepython = python3.6
 deps = {[with-cython]deps}
 
+[testenv:py37_cython]
+basepython = python3.7
+deps = {[with-cython]deps}
+
 # --------------------------------------------------------------------
 # Smoke testing with a sample app
 # --------------------------------------------------------------------
@@ -153,13 +161,13 @@ deps = -r{toxinidir}/requirements/bench
        cython
 commands = {[smoke-test]commands}
 
-[testenv:py36_smoke]
-basepython = python3.6
+[testenv:py37_smoke]
+basepython = python3.7
 deps = -r{toxinidir}/requirements/bench
 commands = {[smoke-test]commands}
 
-[testenv:py36_smoke_cython]
-basepython = python3.6
+[testenv:py37_smoke_cython]
+basepython = python3.7
 deps = -r{toxinidir}/requirements/bench
        cython
 commands = {[smoke-test]commands}
@@ -224,8 +232,8 @@ basepython = python2.7
 deps = gunicorn
 commands = gunicorn -b localhost:8000 tests.dump_wsgi
 
-[testenv:py36_dump_gunicorn]
-basepython = python3.6
+[testenv:py37_dump_gunicorn]
+basepython = python3.7
 deps = gunicorn
 commands = gunicorn -b localhost:8000 tests.dump_wsgi
 
@@ -238,8 +246,8 @@ commands = waitress-serve --listen=localhost:8000 tests.dump_wsgi:application
 basepython = python2.7
 commands = python tests/dump_wsgi.py
 
-[testenv:py36_dump_wsgiref]
-basepython = python3.6
+[testenv:py37_dump_wsgiref]
+basepython = python3.7
 commands = python tests/dump_wsgi.py
 
 # --------------------------------------------------------------------
@@ -290,6 +298,17 @@ deps = -r{toxinidir}/requirements/bench
        cython
 commands = falcon-bench []
 
+[testenv:py37_bench]
+basepython = python3.7
+deps = -r{toxinidir}/requirements/bench
+commands = falcon-bench []
+
+[testenv:py37_bench_cython]
+basepython = python3.7
+deps = -r{toxinidir}/requirements/bench
+       cython
+commands = falcon-bench []
+
 [testenv:pypy_bench]
 basepython = pypy
 deps = -r{toxinidir}/requirements/bench
@@ -315,7 +334,7 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:hug]
-basepython = python3.6
+basepython = python3.7
 deps = virtualenv
 commands =
      {toxinidir}/tools/testing/install_hug.sh

--- a/tox.ini
+++ b/tox.ini
@@ -334,7 +334,7 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:hug]
-basepython = python3.7
+basepython = python3.6
 deps = virtualenv
 commands =
      {toxinidir}/tools/testing/install_hug.sh


### PR DESCRIPTION
Addresses https://github.com/falconry/falcon/issues/1405

For the reference: I am leaving Hug tests at CPython 3.6, it seems that Hug's pinned build requirements fail to install under 3.7.
Filed as: https://github.com/timothycrosley/hug/issues/725