### PR TITLE
perf(request): Return direct reference to parsed cookies, headers objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@ Breaking Changes
   to use arbitrary ``dumps()`` and ``loads()`` functions. If you
   also need to customize ``HTTPError`` serialization, you can do so via
   ``API.set_error_serializer()``.
+- In order to improve performance, the ``Request.headers`` and
+  ``Request.cookies`` properties now return a direct reference to
+  an internal cached object, rather than making a copy each time. This
+  should normally not cause any problems with existing apps since these objects
+  are generally treated as read-only by the caller.
 
 Changes to Supported Platforms
 ------------------------------

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -25,14 +25,8 @@ request attribute:
             # ....
 
 The :py:attr:`~.Request.cookies` attribute is a regular
-:py:class:`dict` object.
-
-.. tip ::
-
-    The :py:attr:`~.Request.cookies` attribute returns a
-    copy of the response cookie dictionary. Assign it to a variable, as
-    shown in the above example, to improve performance when you need to
-    look up more than one cookie.
+:py:class:`dict` object. The returned object should be treated as
+read-only to avoid unintended side-effects.
 
 .. _setting-cookies:
 

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -29,6 +29,11 @@ Breaking Changes
   to use arbitrary ``dumps()`` and ``loads()`` functions. If you
   also need to customize :class:`~.HTTPError` serialization, you can do so via
   :meth:`~.API.set_error_serializer`.
+- In order to improve performance, the :attr:`falcon.Request.headers` and
+  :attr:`falcon.Request.cookies` properties now return a direct reference to
+  an internal cached object, rather than making a copy each time. This
+  should normally not cause any problems with existing apps since these objects
+  are generally treated as read-only by the caller.
 
 Changes to Supported Platforms
 ------------------------------

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -383,10 +383,11 @@ class Request(object):
         headers (dict): Raw HTTP headers from the request with
             canonical dash-separated names. Parsing all the headers
             to create this dict is done the first time this attribute
-            is accessed. This parsing can be costly, so unless you
-            need all the headers in this format, you should use the
-            `get_header` method or one of the convenience attributes
-            instead, to get a value for a specific header.
+            is accessed, and the returned object should be treated as
+            read-only. Note that this parsing can be costly, so unless you
+            need all the headers in this format, you should instead use the
+            ``get_header()`` method or one of the convenience attributes
+            to get a value for a specific header.
 
         params (dict): The mapping of request query parameter names to their
             values.  Where the parameter appears multiple times in the query
@@ -852,7 +853,7 @@ class Request(object):
                 elif name in WSGI_CONTENT_HEADERS:
                     headers[name.replace('_', '-')] = value
 
-        return self._cached_headers.copy()
+        return self._cached_headers
 
     @property
     def params(self):
@@ -877,7 +878,7 @@ class Request(object):
 
             self._cookies = cookies
 
-        return self._cookies.copy()
+        return self._cookies
 
     @property
     def access_route(self):


### PR DESCRIPTION
Rather than trying to protect app developers from themselves, error on the
side of performance and return direct references to the cookies and headers
dictionaries once they are constructed and cached.