### PR TITLE
cleanup(Request): Remove automatic wrapping of Request.stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,10 @@ Breaking Changes
   to use arbitrary ``dumps()`` and ``loads()`` functions. If you
   also need to customize ``HTTPError`` serialization, you can do so via
   ``API.set_error_serializer()``.
+- ``Request.stream`` is no longer wrapped in a bounded stream when
+  Falcon detects that it is running on the wsgiref server. If you
+  need to normalize stream semantics between wsgiref and a production WSGI
+  server, ``Request.bounded_stream`` may be used instead.
 
 Changes to Supported Platforms
 ------------------------------

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -29,6 +29,10 @@ Breaking Changes
   to use arbitrary ``dumps()`` and ``loads()`` functions. If you
   also need to customize :class:`~.HTTPError` serialization, you can do so via
   :meth:`~.API.set_error_serializer`.
+- The :attr:`falcon.Request.stream` attribute is no longer wrapped in a bounded
+  stream when Falcon detects that it is running on the wsgiref server. If you
+  need to normalize stream semantics between wsgiref and a production WSGI
+  server, :attr:`~.Request.bounded_stream` may be used instead.
 
 Changes to Supported Platforms
 ------------------------------

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -13,21 +13,7 @@
 """Request class."""
 
 from datetime import datetime
-
-try:
-    # NOTE(kgrifs): In Python 2.7, socket._fileobject is a
-    # standard way of exposing a socket as a file-like object, and
-    # is used by wsgiref for wsgi.input.
-    import socket
-    NativeStream = socket._fileobject
-except AttributeError:
-    # NOTE(kgriffs): In Python 3.3, wsgiref implements wsgi.input
-    # using _io.BufferedReader which is an alias of io.BufferedReader
-    import io
-    NativeStream = io.BufferedReader
-
-from uuid import UUID  # NOQA: I202
-from wsgiref.validate import InputWrapper
+from uuid import UUID
 
 from falcon import DEFAULT_MEDIA_TYPE
 from falcon import errors
@@ -426,7 +412,6 @@ class Request(object):
     context_type = type('RequestContext', (dict,), {})
 
     _wsgi_input_type_known = False
-    _always_wrap_wsgi_input = False
 
     def __init__(self, env, options=None):
         self.env = env
@@ -486,29 +471,8 @@ class Request(object):
         except KeyError:
             self.content_type = None
 
-        # NOTE(kgriffs): Wrap wsgi.input if needed to make read() more robust,
-        # normalizing semantics between, e.g., gunicorn and wsgiref.
-        #
-        # PERF(kgriffs): Accessing via self when reading is faster than
-        # via the class name. But we must set the variables using the
-        # class name so they are picked up by all future instantiations
-        # of the class.
-        if not self._wsgi_input_type_known:
-            Request._always_wrap_wsgi_input = isinstance(
-                env['wsgi.input'],
-                (NativeStream, InputWrapper)
-            )
-
-            Request._wsgi_input_type_known = True
-
-        if self._always_wrap_wsgi_input:
-            # TODO(kgriffs): In Falcon 2.0, stop wrapping stream since it is
-            # less useful now that we have bounded_stream.
-            self.stream = self._get_wrapped_wsgi_input()
-            self._bounded_stream = self.stream
-        else:
-            self.stream = env['wsgi.input']
-            self._bounded_stream = None  # Lazy wrapping
+        self.stream = env['wsgi.input']
+        self._bounded_stream = None  # Lazy wrapping
 
         # PERF(kgriffs): Technically, we should spend a few more
         # cycles and parse the content type for real, but

--- a/tests/test_before_hooks.py
+++ b/tests/test_before_hooks.py
@@ -41,7 +41,7 @@ def validate_field(req, resp, params, field_name='test'):
 def parse_body(req, resp, params):
     length = req.content_length or 0
     if length != 0:
-        params['doc'] = json.load(io.TextIOWrapper(req.stream, 'utf-8'))
+        params['doc'] = json.load(io.TextIOWrapper(req.bounded_stream, 'utf-8'))
 
 
 def bunnies(req, resp, params):

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -103,7 +103,7 @@ class JSONTranslator(object):
             # Nothing to do
             return
 
-        body = req.stream.read()
+        body = req.bounded_stream.read()
         if not body:
             raise falcon.HTTPBadRequest('Empty request body',
                                         'A valid JSON document is required.')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -558,7 +558,7 @@ class TestFalconTestingUtils(object):
         json_types = ('application/json', 'application/json; charset=UTF-8')
         client = testing.TestClient(app)
         client.simulate_post('/', json=document)
-        captured_body = resource.captured_req.stream.read().decode('utf-8')
+        captured_body = resource.captured_req.bounded_stream.read().decode('utf-8')
         assert json.loads(captured_body) == document
         assert resource.captured_req.content_type in json_types
 

--- a/tests/test_wsgiref_inputwrapper_with_size.py
+++ b/tests/test_wsgiref_inputwrapper_with_size.py
@@ -10,10 +10,8 @@ class TypeResource(testing.SimpleTestResource):
     def on_post(self, req, resp, **kwargs):
         resp.status = falcon.HTTP_200
         # NOTE(masterkale): No size needs to be specified here because we're
-        # emulating a stream read in production. The request should be wrapped
-        # well enough to automatically specify a size when calling `read()`
-        # during either production or when running tests
-        resp.body = json.dumps({'data': req.stream.read().decode('utf-8')})
+        # emulating a stream read in production.
+        resp.body = json.dumps({'data': req.bounded_stream.read().decode('utf-8')})
 
 
 class TestWsgiRefInputWrapper(object):


### PR DESCRIPTION
BREAKING CHANGE: Now that we have Request.bounded_stream, it is no longer
        necessary to wrap wsgiref's stream to avoid hangs. In fact, we've been
        warning in the docs about unexpected behavior like this for quite some
        time, so not many app developers should be relying on our automatic wrapping
        at this point.