### PR TITLE
feat(Request): Improve request cookie handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ Breaking Changes
   Falcon detects that it is running on the wsgiref server. If you
   need to normalize stream semantics between wsgiref and a production WSGI
   server, ``Request.bounded_stream`` may be used instead.
+- ``Request.cookies`` now gives precedence to the first value
+  encountered in the Cookie header for a given cookie name, rather than the
+  last.
 
 Changes to Supported Platforms
 ------------------------------
@@ -109,6 +112,11 @@ New & Improved
   ``dumps()`` and ``loads()`` functions. This enables support not only for
   using any of a number of third-party JSON libraries, but also for
   customizing the keyword arguments used when (de)serializing objects.
+- Added a new method, ``get_cookie_values()``, to the ``Request``
+  class. The new method supports getting all values provided for a given
+  cookie, and is now the preferred mechanism for reading request cookies.
+- Optimized request cookie parsing. It is now roughly an order of magnitude
+  faster.
 - ``append_header()`` now supports appending raw Set-Cookie header values.
 
 Fixed

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -3,15 +3,16 @@
 Cookies
 -------
 
-Cookie support is available in Falcon version 0.3 or later.
-
 .. _getting-cookies:
 
 Getting Cookies
 ~~~~~~~~~~~~~~~
 
-Cookies can be read from a request via the :py:attr:`~.Request.cookies`
-request attribute:
+Cookies can be read from a request either via the
+:py:meth:`~.Request.get_cookie_values` method or the :py:attr:`~.Request.cookies`
+attribute on the :py:class:`~.Request` object. Generally speaking, the
+:py:meth:`~.Request.get_cookie_values` method should be used unless you need a
+collection of all the cookies in the request.
 
 .. code:: python
 
@@ -20,13 +21,13 @@ request attribute:
 
             cookies = req.cookies
 
-            if 'my_cookie' in cookies:
-                my_cookie_value = cookies['my_cookie']
-            # ....
+            my_cookie_values = req.get_cookie_values('my_cookie')
+            if my_cookie_values:
+                # NOTE: If there are multiple values set for the cookie, you
+                # will need to choose how to handle the additional values.
+                v = my_cookie_values[0]
 
-The :py:attr:`~.Request.cookies` attribute is a regular
-:py:class:`dict` object. The returned object should be treated as
-read-only to avoid unintended side-effects.
+                # ...
 
 .. _setting-cookies:
 

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -64,6 +64,9 @@ Breaking Changes
   stream when Falcon detects that it is running on the wsgiref server. If you
   need to normalize stream semantics between wsgiref and a production WSGI
   server, :attr:`~.Request.bounded_stream` may be used instead.
+- :attr:`falcon.Request.cookies` now gives precedence to the first value
+  encountered in the Cookie header for a given cookie name, rather than the
+  last.
 
 Changes to Supported Platforms
 ------------------------------
@@ -120,6 +123,12 @@ New & Improved
   ``dumps()`` and ``loads()`` functions. This enables support not only for
   using any of a number of third-party JSON libraries, but also for
   customizing the keyword arguments used when (de)serializing objects.
+- Added a new method, :meth:`~.Request.get_cookie_values`, to the
+  :class:`~.Request` class. The new method supports getting all values
+  provided for a given cookie, and is now the preferred mechanism for
+  reading request cookies.
+- Optimized request cookie parsing. It is now roughly an order of magnitude
+  faster.
 - :meth:`~.Response.append_header` now supports appending raw Set-Cookie header values.
 
 Fixed

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -15,6 +15,78 @@
 """Utilities for the Request class."""
 
 import io
+import re
+
+from falcon.util.compat import http_cookies
+
+# https://tools.ietf.org/html/rfc6265#section-4.1.1
+#
+# NOTE(kgriffs): Fortunately we don't have to worry about code points in
+#   header strings outside the range 0x0000 - 0x00FF per PEP 3333
+#   (see also: https://www.python.org/dev/peps/pep-3333/#unicode-issues)
+#
+_COOKIE_NAME_RESERVED_CHARS = re.compile('[\x00-\x1F\x7F-\xFF()<>@,;:\\\\"/[\\]?={} \x09]')
+
+
+def parse_cookie_header(header_value):
+    """Parse a Cookie header value into a dict of named values.
+
+    (See also: RFC 6265, Section 5.4)
+
+    Args:
+        header_value (str): Value of a Cookie header
+
+    Returns:
+        dict: Map of cookie names to a list of all cookie values found in the
+        header for that name. If a cookie is specified more than once in the
+        header, the order of the values will be preserved.
+    """
+
+    # See also:
+    #
+    #   https://tools.ietf.org/html/rfc6265#section-5.4
+    #   https://tools.ietf.org/html/rfc6265#section-4.1.1
+    #
+
+    cookies = {}
+
+    for token in header_value.split(';'):
+        name, __, value = token.partition('=')
+
+        # NOTE(kgriffs): RFC6265 is more strict about whitespace, but we
+        # are more lenient here to better handle old user agents and to
+        # mirror Python's standard library cookie parsing behavior
+        name = name.strip()
+        value = value.strip()
+
+        # NOTE(kgriffs): Skip malformed cookie-pair
+        if not name:
+            continue
+
+        # NOTE(kgriffs): Skip cookies with invalid names
+        if _COOKIE_NAME_RESERVED_CHARS.search(name):
+            continue
+
+        # NOTE(kgriffs): To maximize compatibility, we mimic the support in the
+        # standard library for escaped characters within a double-quoted
+        # cookie value according to the obsolete RFC 2109. However, we do not
+        # expect to see this encoding used much in practice, since Base64 is
+        # the current de-facto standard, as recommended by RFC 6265.
+        #
+        # PERF(kgriffs): These checks have been hoisted from within _unquote()
+        # to avoid the extra function call in the majority of the cases when it
+        # is not needed.
+        if len(value) > 2 and value[0] == '"' and value[-1] == '"':
+            value = http_cookies._unquote(value)
+
+        # PERF(kgriffs): This is slightly more performant as
+        # compared to using dict.setdefault()
+        if name in cookies:
+            cookies[name].append(value)
+        else:
+            cookies[name] = [value]
+
+    return cookies
 
 
 def header_property(wsgi_name):

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -241,7 +241,9 @@ def test_request_cookie_parsing():
             'Cookie',
             """
             logged_in=no;_gh_sess=eyJzZXXzaW9uX2lkIjoiN2;
-            tz=Europe/Berlin; _ga=GA1.2.332347814.1422308165;
+            tz=Europe/Berlin; _ga =GA1.2.332347814.1422308165;
+            tz2=Europe/Paris ; _ga2="line1\\012line2";
+            tz3=Europe/Madrid ;_ga3= GA3.2.332347814.1422308165;
             _gat=1;
             _octo=GH1.1.201722077.1422308165
             """
@@ -251,39 +253,75 @@ def test_request_cookie_parsing():
     environ = testing.create_environ(headers=headers)
     req = falcon.Request(environ)
 
-    assert req.cookies['logged_in'] == 'no'
-    assert req.cookies['tz'] == 'Europe/Berlin'
-    assert req.cookies['_octo'] == 'GH1.1.201722077.1422308165'
+    # NOTE(kgriffs): Test case-sensitivity
+    assert req.get_cookie_values('TZ') is None
+    assert 'TZ' not in req.cookies
+    with pytest.raises(KeyError):
+        req.cookies['TZ']
 
-    assert 'logged_in' in req.cookies
-    assert '_gh_sess' in req.cookies
-    assert 'tz' in req.cookies
-    assert '_ga' in req.cookies
-    assert '_gat' in req.cookies
-    assert '_octo' in req.cookies
+    for name, value in [
+        ('logged_in', 'no'),
+        ('_gh_sess', 'eyJzZXXzaW9uX2lkIjoiN2'),
+        ('tz', 'Europe/Berlin'),
+        ('tz2', 'Europe/Paris'),
+        ('tz3', 'Europe/Madrid'),
+        ('_ga', 'GA1.2.332347814.1422308165'),
+        ('_ga2', 'line1\nline2'),
+        ('_ga3', 'GA3.2.332347814.1422308165'),
+        ('_gat', '1'),
+        ('_octo', 'GH1.1.201722077.1422308165'),
+    ]:
+        assert name in req.cookies
+        assert req.cookies[name] == value
+        assert req.get_cookie_values(name) == [value]
 
 
 def test_invalid_cookies_are_ignored():
+    vals = [chr(i) for i in range(0x1F)]
+    vals += [chr(i) for i in range(0x7F, 0xFF)]
+    vals += '()<>@,;:\\"/[]?={} \x09'.split()
+
+    for c in vals:
+        headers = [
+            (
+                'Cookie',
+                'good_cookie=foo;bad' + c + 'cookie=bar'
+            ),
+        ]
+
+        environ = testing.create_environ(headers=headers)
+        req = falcon.Request(environ)
+
+        assert req.cookies['good_cookie'] == 'foo'
+        assert 'bad' + c + 'cookie' not in req.cookies
+
+
+def test_duplicate_cookie():
     headers = [
         (
             'Cookie',
-            """
-            good_cookie=foo;
-            bad{cookie=bar
-            """
+            'x=1;bad{cookie=bar; x=2;x=3 ; x=4;'
         ),
     ]
 
     environ = testing.create_environ(headers=headers)
     req = falcon.Request(environ)
 
-    assert req.cookies['good_cookie'] == 'foo'
-    assert 'bad{cookie' not in req.cookies
+    assert req.cookies['x'] == '1'
+    assert req.get_cookie_values('x') == ['1', '2', '3', '4']
 
 
 def test_cookie_header_is_missing():
     environ = testing.create_environ(headers={})
+
     req = falcon.Request(environ)
+    assert req.cookies == {}
+    assert req.get_cookie_values('x') is None
+
+    # NOTE(kgriffs): Test again with a new object to cover calling in the
+    #   opposite order.
+    req = falcon.Request(environ)
+    assert req.get_cookie_values('x') is None
     assert req.cookies == {}
 
 


### PR DESCRIPTION
This patch provides support for getting all values for a given cookie (when
the same cookie is included multiple times in the request), and also optimizes
request cookie parsing to make it an order of magnitude faster.

BREAKING CHANGE: Request.cookies now gives precedence to the first value
  encountered in the Cookie header for a given cookie name, rather than the
  last.

BREAKING CHANGE: Request cookie parsing no longer uses the standard library
	for most of the parsing logic. This may lead to subtley different results
	for archaic cookie header formats, since the new implementation is based on
	the latest RFC 6265.

Closes #1107
Closes #1046