### PR TITLE
An API Builder object that allows for custom methods on routes

### DIFF
--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -28,6 +28,7 @@ the framework's classes, functions, and variables::
 from falcon.version import __version__  # NOQA
 from falcon.constants import *  # NOQA
 from falcon.api import API  # NOQA
+from falcon.api_builder import APIBuilder  # NOQA
 from falcon.status_codes import *  # NOQA
 from falcon.errors import *  # NOQA
 from falcon.redirects import *  # NOQA

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -1,0 +1,219 @@
+
+from falcon import api_helpers as helpers, API, DEFAULT_MEDIA_TYPE, routing
+from falcon.request import Request
+from falcon.response import Response
+
+import sys
+import inspect
+
+
+class APIBuilder:
+
+    def __init__(self):
+        self._media_type = DEFAULT_MEDIA_TYPE
+        self._call_response_middleware_on_request_middleware_exception = True
+        self._middlewares = []
+        self._request_type = Request
+        self._response_type = Response
+        self._router = routing.DefaultRouter()
+        self._error_serializer = helpers.default_serialize_error
+        self._routes = {}
+        self._error_handling_functions = []
+        self._sinks = []
+        self._static_routes = []
+
+    def set_media_type(self, media_type):
+        self._media_type = media_type
+        return self
+
+    def set_call_response_middleware_on_request_middleware_exception(self, should_call):
+        self._call_response_middleware_on_request_middleware_exception = should_call
+        return self
+
+    def set_request_type(self, request_type):
+        self._request_type = request_type
+        return self
+
+    def set_response_type(self, response_type):
+        self._response_type = response_type
+        return self
+
+    def set_router(self, router):
+        self._router = router
+        return self
+
+    def set_error_serializer(self, serializer):
+        self._error_serializer = serializer
+        return self
+
+    def add_middleware(self, middleware):
+        if isinstance(middleware, list):
+            raise APIBuildException(
+                "Should only add a single middleware using `add_middleware`, "
+                "call `add_middlewares` for a collection.")
+        self._middlewares.append(middleware)
+        return self
+
+    def add_middlewares(self, middlewares):
+        self._middlewares.extend(middlewares)
+        return self
+
+    def add_get_route(self, uri, route_func, **kwargs):
+        return self._add_route("GET", uri, route_func, **kwargs)
+
+    def add_post_route(self, uri, route_func, **kwargs):
+        return self._add_route("POST", uri, route_func, **kwargs)
+
+    def add_put_route(self, uri, route_func, **kwargs):
+        return self._add_route("PUT", uri, route_func, **kwargs)
+
+    def add_delete_route(self, uri, route_func, **kwargs):
+        return self._add_route("DELETE", uri, route_func, **kwargs)
+
+    def add_error_route(self, exception, on_exception_func):
+        self._error_handling_functions.append(ExceptionHandlingFunction(exception, on_exception_func))
+        return self
+
+    def add_sink(self, sink, prefix=r'/'):
+        self._sinks.append(APISink(sink, prefix))
+        return self
+
+    def add_static_route(self, prefix, directory, downloadable=False, fallback_filename=None):
+        self._static_routes.append(APIStaticRoute(prefix, directory, downloadable, fallback_filename))
+        return self
+
+    def build(self):
+
+        api = API(
+            media_type=self._media_type,
+            request_type=self._request_type,
+            response_type=self._response_type,
+            middleware=self._middlewares,
+        )
+
+        this = self
+
+        class ResourceWrapper:
+            pass
+
+        merged_kwargs = {}
+        for uri, uri_method_routes in self._routes.items():
+            resource = ResourceWrapper()
+
+            if "GET" in uri_method_routes:
+                def on_get(self, request, response):
+                    uri_method_routes["GET"].function()(request, response)
+                resource.on_get = on_get.__get__(resource)
+                merged_kwargs.update(uri_method_routes["GET"].kwargs)  # TODO: What about collisions?
+
+            if "POST" in uri_method_routes:
+                def on_post(self, request, response):
+                    uri_method_routes["POST"].function()(request, response)
+                resource.on_post = on_post.__get__(resource)
+                merged_kwargs.update(uri_method_routes["POST"].kwargs)
+
+            if "PUT" in uri_method_routes:
+                def on_put(self, request, response):
+                    uri_method_routes["PUT"].function()(request, response)
+                resource.on_put = on_put.__get__(resource)
+                merged_kwargs.update(uri_method_routes["PUT"].kwargs)
+
+            if "DELETE" in uri_method_routes:
+                def on_delete(self, request, response):
+                    uri_method_routes["DELETE"].function()(request, response)
+                resource.on_delete = on_delete.__get__(resource)
+                merged_kwargs.update(uri_method_routes["DELETE"].kwargs)
+            api.add_route(uri, resource, **merged_kwargs)
+
+        for error_func in self._error_handling_functions:
+            api.add_error_handler(error_func.exception, error_func.func)
+
+        for sink in self._sinks:
+            api.add_sink(sink.sink, sink.prefix)
+
+        api.set_error_serializer(self._error_serializer)
+        return api
+
+    def _add_route(self, http_method, uri, route_func, **kwargs):
+        if uri not in self._routes:
+            self._routes[uri] = {}
+        if http_method in self._routes[uri]:
+            raise APIBuildException(
+                "A route already exists for {method} on uri: {uri}. Only set 1 route per uri and HTTP Method."
+                    .format(method=http_method, uri=uri))
+        self._routes[uri]["GET"] = APIRouteFunction(route_func, **kwargs)
+        return self
+
+
+class APIRouteFunction:
+
+    def __init__(self, func, **kwargs):
+        self._function = func
+        self._kwargs = kwargs
+
+    @property
+    def function(self):
+        return self._function
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+
+class ExceptionHandlingFunction:
+
+    def __init__(self, exception, func):
+        self._function = func
+        self._exception = exception
+
+    @property
+    def func(self):
+        return self._function
+
+    @property
+    def exception(self):
+        return self._exception
+
+
+class APISink:
+
+    def __init__(self, sink, prefix):
+        self._sink = sink
+        self._prefix = prefix
+
+    @property
+    def sink(self):
+        return self._sink
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+
+class APIStaticRoute:
+
+    def __init__(self, prefix, directory, downloadable, fallback_filename):
+        self._prefix = prefix
+        self._directory = directory
+        self._downloadable = downloadable
+        self._fallback_filename = fallback_filename
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+    @property
+    def directory(self):
+        return self._directory
+
+    @property
+    def downloadable(self):
+        return self._downloadable
+
+    @property
+    def fallback_filename(self):
+        return self._fallback_filename
+
+
+class APIBuildException(Exception):
+    pass

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -1,3 +1,18 @@
+# Copyright 2013 by Rackspace Hosting, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""falcon APIBuilder class."""
 
 import functools
 
@@ -9,22 +24,35 @@ from falcon.response import Response
 
 class APIBuilder:
     """
-    Improved for several reasons:
-        1) Separates the concerns of building an API from using and API
-        2) Mutation methods return self, allowing for chained style building in addition
-            to unchained
-        3) Allows for adding of uri routing to functions without having to subscribe a
-            naming convention (of on_get, on_put, etc), which allows for more explicit
-            function names like (get_user, create_user, update_password, etc).
-        4) Allows for non hard-rest resource style mappings:
-            4.1) can just have a route execute a top level function, it does not HAVE to
-                be a method on a resource
-            4.2) a resource can have multiple functions, it does not have to care about
-                uris or method types, so a single resource could have multiple uri/resource
-                pairs direct to it (as long as they are unique). For example we could have
-                an update_password, update_username, update_email function all on the Users
-                resource, all with PUT method pointed at them, and all using slightly
+    This class wraps the API class of falcon to provide several benefits when
+    building a new API:
+        1) This class separates the concerns of building an API from using
+            an API
+        2) The mutation methods in this class return self, allowing for
+            chained style building in addition to unchained. For example:
+                app = APIBuilder() \
+                    .add_get_route('/', foo_resource.get_foos) \
+                    .build()
+        3) This builder frees users from using the falcon expected function
+            names in their resources.  We no longer need to name our
+            functions using the 'on' prefixed to the method type like 'on_get',
+            'on_head', etc.  Now we can name our functions 'get_user',
+            'create_user', or 'update_password', if we so choose.
+        4) This builder frees users from using hard-REST resource style
+            mappings:
+            4.1) This means we can just have a route execute a top level
+                function, it does not HAVE to be a method on a class at all.
+            4.2) Also, a resource can have multiple functions which are pointed
+                to using the same HTTP method.  That is, it does not care about
+                uris or method types, so a single resource could have multiple
+                uri/resource pairs direct to it (as long as they are unique).
+                For example we could have an update_password, update_username,
+                update_email function all on the Users resource, all with the
+                PUT HTTP method pointed at them, and all using slightly
                 different uris (eg. /password, /username, /email).
+
+    Calling the 'build' method of this object returns a WSGI compliant falcon
+    API.
     """
 
     def __init__(self):
@@ -41,30 +69,113 @@ class APIBuilder:
         self._static_routes = []
 
     def set_media_type(self, media_type):
+        """Changes the media type from the default to the given value
+
+        Args:
+            media_type (str): the media type to use as the
+                value for the Content-Type header on responses (default
+                'application/json'). The ``falcon`` module provides a
+                number of constants for common media types, such as
+                ``falcon.MEDIA_MSGPACK``, ``falcon.MEDIA_YAML``,
+                ``falcon.MEDIA_XML``, etc.
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._media_type = media_type
         return self
 
     def set_call_response_middleware_on_request_middleware_exception(self, should_call):
+        """Changes the value of ``independent_middleware`` in the API
+
+        Args:
+            should_call (bool): Set to ``False`` if response
+                middleware should not be executed independently of whether or
+                not request middleware raises an exception (default
+                ``True``). When this option is set to ``False``, a middleware
+                component's ``process_response()`` method will NOT be called
+                when that same component's ``process_request()`` (or that of
+                a component higher up in the stack) raises an exception.
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._call_response_middleware_on_request_middleware_exception = should_call
         return self
 
     def set_request_type(self, request_type):
+        """Changes the request type class from falcon's default
+
+        Args:
+            request_type (Request): ``Request``-like class to use instead
+                of Falcon's default class. Among other things, this feature
+                affords inheriting from ``falcon.request.Request`` in order
+                to override the ``context_type`` class variable.
+                (default ``falcon.request.Request``)
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._request_type = request_type
         return self
 
     def set_response_type(self, response_type):
+        """Changes the response type class from falcon's default
+
+        Args:
+            response_type (Response): ``Response``-like class to use
+                instead of Falcon's default class. (default
+                ``falcon.response.Response``)
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._response_type = response_type
         return self
 
     def set_router(self, router):
+        """Changes the router from falcon's default
+
+        Args:
+            router (object): An instance of a custom router
+                to use in lieu of the default engine.
+                (See also: :ref:`Custom Routers <routing_custom>`)
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._router = router
         return self
 
     def set_error_serializer(self, serializer):
+        """Changes the error serializer from falcon's default
+
+        Args:
+            serializer (callable): A function which takes a
+                request, response, and exception and serializes
+                the error.
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._error_serializer = serializer
         return self
 
     def add_middleware(self, middleware):
+        """Adds a single instance of middleware to the api
+
+        Args:
+            middleware(object): A single object (instantiated
+                classes) that implement the middleware component
+                interface outlined in api.py
+
+        Raises:
+            APIBuildException: if the given middleware is a list
+                meant for the add_middlewares function instead.
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         if isinstance(middleware, list):
             raise APIBuildException(
                 'Should only add a single middleware using `add_middleware`, '
@@ -73,32 +184,323 @@ class APIBuilder:
         return self
 
     def add_middlewares(self, middlewares):
+        """Adds a list of of middlewares to the api
+
+        Args:
+            middlewares(list): A list of objects (instantiated
+                classes) that implement the middleware component
+                interface outlined in api.py
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._middlewares.extend(middlewares)
         return self
 
     def add_get_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the GET HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a GET method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('GET', uri, route_func, **kwargs)
 
     def add_post_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the POST HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a POST method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('POST', uri, route_func, **kwargs)
 
     def add_put_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the PUT HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a PUT method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('PUT', uri, route_func, **kwargs)
 
     def add_delete_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the DELETE HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a DELETE method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('DELETE', uri, route_func, **kwargs)
 
     def add_patch_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the PATCH HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a PATCH method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('PATCH', uri, route_func, **kwargs)
 
     def add_head_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the HEAD HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a HEAD method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('HEAD', uri, route_func, **kwargs)
 
     def add_options_route(self, uri, route_func, **kwargs):
+        """Adds a route to a function using the OPTIONS HTTP method.
+
+        Args:
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a OPTIONS method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         return self.add_method_route('OPTIONS', uri, route_func, **kwargs)
 
     def add_method_route(self, http_method, uri, route_func, **kwargs):
+        """Adds a route to a function using the given HTTP method.
 
+        Args:
+            http_method(str): One of falcons HTTP_METHODS by which to
+                map this route to this function.
+            uri(str): A templatized URI. Care must be
+                taken to ensure the template does not mask any sink
+                patterns, if any are registered.
+            route_func(callable): A function which takes a request
+                and response, and mutates the response into what
+                should be returned to the caller.
+
+        Keyword Args:
+            suffix (str): Optional responder name suffix for this route.
+                This is largely a throwback to the original Falcon api
+                and is no longer really needed thanks to passing in a
+                named function.  If you use this, the underlying
+                generated resource will have the suffix attached
+                to the function name.
+
+        Raises:
+            APIBuildException: if the given route adds a uri which
+                is already mapped for a HTTP method or if a kwarg
+                overwrites another preset kwarg for the same URI.
+
+        Returns:
+            The Builder object so that the call can be chained.
+
+        Note:
+            Any additional keyword arguments not defined above are passed
+            through to the underlying router's ``add_route()`` method. The
+            default router ignores any additional keyword arguments, but
+            custom routers may take advantage of this feature to receive
+            additional options when setting up routes. Custom routers MUST
+            accept such arguments using the variadic pattern (``**kwargs``), and
+            ignore any keyword arguments that they don't support.
+        """
         self._raise_on_invalid_http_method_types(http_method)
 
         if uri not in self._routes:
@@ -111,20 +513,149 @@ class APIBuilder:
         return self
 
     def add_error_route(self, exception, on_exception_func=None):
+        """Adds a method for handling a certain type of exception.
+
+        Error handlers may be registered for any type, including
+        :class:`~.HTTPError`. This feature provides a central location
+        for logging and otherwise handling exceptions raised by
+        responders, hooks, and middleware components.
+
+        A handler can raise an instance of :class:`~.HTTPError` or
+        :class:`~.HTTPStatus` to communicate information about the issue to
+        the client.  Alternatively, a handler may modify `resp`
+        directly.
+
+        Error handlers are matched in LIFO order. In other words, when
+        searching for an error handler to match a raised exception, and
+        more than one handler matches the exception type, the framework
+        will choose the one that was most recently registered.
+        Therefore, more general error handlers (e.g., for the
+        standard ``Exception`` type) should be added first, to avoid
+        masking more specific handlers for subclassed types.
+
+        Args:
+            exception (type): Whenever an error occurs when handling a request
+                that is an instance of this exception class, the associated
+                handler will be called.
+            on_exception_func (callable): A function or callable object taking the form
+                ``func(req, resp, ex, params)``.
+
+                If not specified explicitly, the handler will default to
+                ``exception.handle``, where ``exception`` is the error
+                type specified above, and ``handle`` is a static method
+                (i.e., decorated with @staticmethod) that accepts
+                the same params just described. For example::
+
+                    class CustomException(CustomBaseException):
+
+                        @staticmethod
+                        def handle(req, resp, ex, params):
+                            # TODO: Log the error
+                            # Convert to an instance of falcon.HTTPError
+                            raise falcon.HTTPError(falcon.HTTP_792)
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._error_handling_functions.append(
             ExceptionHandlingFunction(exception, on_exception_func))
         return self
 
     def add_sink(self, sink, prefix=r'/'):
+        """Adds a sink method for the API.
+
+        If no route matches a request, but the path in the requested URI
+        matches a sink prefix, Falcon will pass control to the
+        associated sink, regardless of the HTTP method requested.
+
+        Using sinks, you can drain and dynamically handle a large number
+        of routes, when creating static resources and responders would be
+        impractical. For example, you might use a sink to create a smart
+        proxy that forwards requests to one or more backend services.
+
+        Args:
+            sink (callable): A callable taking the form ``func(req, resp)``.
+
+            prefix (str): A regex string, typically starting with '/', which
+                will trigger the sink if it matches the path portion of the
+                request's URI. Both strings and precompiled regex objects
+                may be specified. Characters are matched starting at the
+                beginning of the URI path.
+
+                Note:
+                    Named groups are converted to kwargs and passed to
+                    the sink as such.
+
+                Warning:
+                    If the prefix overlaps a registered route template,
+                    the route will take precedence and mask the sink.
+
+                    (See also: :meth:`~.add_route`)
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._sinks.append(APISink(sink, prefix))
         return self
 
     def add_static_route(self, prefix, directory, downloadable=False, fallback_filename=None):
+        """Adds a route to a directory of static files.
+
+        Static routes provide a way to serve files directly. This
+        feature provides an alternative to serving files at the web server
+        level when you don't have that option, when authorization is
+        required, or for testing purposes.
+
+        Warning:
+            Serving files directly from the web server,
+            rather than through the Python app, will always be more efficient,
+            and therefore should be preferred in production deployments.
+            For security reasons, the directory and the fallback_filename (if provided)
+            should be read only for the account running the application.
+
+        Static routes are matched in LIFO order. Therefore, if the same
+        prefix is used for two routes, the second one will override the
+        first. This also means that more specific routes should be added
+        *after* less specific ones. For example, the following sequence
+        would result in ``'/foo/bar/thing.js'`` being mapped to the
+        ``'/foo/bar'`` route, and ``'/foo/xyz/thing.js'`` being mapped to the
+        ``'/foo'`` route::
+
+            api.add_static_route('/foo', foo_path)
+            api.add_static_route('/foo/bar', foobar_path)
+
+        Args:
+            prefix (str): The path prefix to match for this route. If the
+                path in the requested URI starts with this string, the remainder
+                of the path will be appended to the source directory to
+                determine the file to serve. This is done in a secure manner
+                to prevent an attacker from requesting a file outside the
+                specified directory.
+
+                Note that static routes are matched in LIFO order, and are only
+                attempted after checking dynamic routes and sinks.
+
+            directory (str): The source directory from which to serve files.
+            downloadable (bool): Set to ``True`` to include a
+                Content-Disposition header in the response. The "filename"
+                directive is simply set to the name of the requested file.
+            fallback_filename (str): Fallback filename used when the requested file
+                is not found. Can be a relative path inside the prefix folder or any valid
+                absolute path.
+
+        Returns:
+            The Builder object so that the call can be chained.
+        """
         self._static_routes.append(
             APIStaticRoute(prefix, directory, downloadable, fallback_filename))
         return self
 
     def build(self):
+        """Builds the configured API object
+
+        Returns:
+            A WSGI compliant API: An instance of the API in api.py
+        """
 
         api = API(
             router=self._router,
@@ -161,18 +692,15 @@ class APIBuilder:
         return api
 
     class BlankResource:
+        """A empty class for monkey-patching a resource into"""
         pass
 
     @staticmethod
     def _compose_new_resource(resource_method_routes):
-
+        """Monkey patch a resource for a given method route map"""
         resource = APIBuilder.BlankResource()
 
         for http_method in resource_method_routes:
-
-            # TODO: Document this -> the suffix stuff makes a lot less sense with this builder
-            # TODO:     because we can now used named functions.  We add it here to maintain
-            # TODO:     exact equality between the two usages (API vs APIBuilder)
             suffix = ''
             if 'suffix' in resource_method_routes[http_method].kwargs:
                 suffix = '_' + resource_method_routes[http_method].kwargs['suffix']
@@ -186,18 +714,21 @@ class APIBuilder:
 
     @staticmethod
     def _generate_wrapped_partial_for_resource(router_function):
+        """Use functools to apply function information to new function"""
         return functools.update_wrapper(
             functools.partial(router_function.function),
             router_function.function)
 
     @staticmethod
     def _raise_on_invalid_http_method_types(http_method):
+        """raise an exception if an unknown HTTP method is used."""
         if http_method not in HTTP_METHODS + WEBDAV_METHODS:
             raise APIBuildException(
                 'HTTP METHOD must be one of {methods} of which {method}'
                 'is not.'.format(methods=HTTP_METHODS + WEBDAV_METHODS, method=http_method))
 
     def _raise_on_overwrite_attempt_for_kwargs_on_uri(self, uri, **new_kwargs):
+        """raise an exception if we try to overwrite a previously set kwarg for a uri"""
         for http_method, route_func in self._routes[uri].items():
             for existing_key, existing_value in route_func.kwargs.items():
                 if existing_key in new_kwargs and existing_value != new_kwargs[existing_key]:
@@ -207,6 +738,7 @@ class APIBuilder:
                         'resource.'.format(key=existing_key, uri=uri))
 
     def _raise_on_adding_non_unique_uri_method_pair(self, uri, http_method):
+        """raise an exception if we try to add a uri-method pair that has already been added"""
         if http_method in self._routes[uri]:
             raise APIBuildException(
                 'A route already exists for {method} on uri: {uri}. Only set 1 route per uri and '
@@ -214,11 +746,12 @@ class APIBuilder:
 
 
 class APIBuildException(Exception):
+    """Raised from builder if bad configuration is given."""
     pass
 
 
 class APIRouteFunction:
-
+    """A Named Data Class for the values of an API routes function."""
     def __init__(self, func, **kwargs):
         self._function = func
         self._kwargs = kwargs
@@ -233,7 +766,7 @@ class APIRouteFunction:
 
 
 class ExceptionHandlingFunction:
-
+    """A Named Data Class for the values of an Exception Handling function."""
     def __init__(self, exception, func):
         self._function = func
         self._exception = exception
@@ -248,7 +781,7 @@ class ExceptionHandlingFunction:
 
 
 class APISink:
-
+    """A Named Data class for an API sink."""
     def __init__(self, sink, prefix):
         self._sink = sink
         self._prefix = prefix
@@ -263,7 +796,7 @@ class APISink:
 
 
 class APIStaticRoute:
-
+    """A Named Data class for an API static route."""
     def __init__(self, prefix, directory, downloadable, fallback_filename):
         self._prefix = prefix
         self._directory = directory

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -227,12 +227,13 @@ class APIBuilder:
         api.set_error_serializer(self._error_serializer)
         return api
 
+    class BlankResource:
+        pass
+
     @staticmethod
     def _compose_new_resource(resource_method_routes):
-        class BlankResource:
-            pass
 
-        resource = BlankResource()
+        resource = APIBuilder.BlankResource()
 
         for http_method in resource_method_routes:
 

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -201,10 +201,12 @@ class APIBuilder:
     def build(self):
 
         api = API(
+            router=self._router,
             media_type=self._media_type,
             request_type=self._request_type,
             response_type=self._response_type,
             middleware=self._middlewares,
+            independent_middleware=self._call_response_middleware_on_request_middleware_exception
         )
 
         for uri, uri_method_routes in self._routes.items():

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -7,80 +7,6 @@ from falcon.request import Request
 from falcon.response import Response
 
 
-class APIBuildException(Exception):
-    pass
-
-
-class APIRouteFunction:
-
-    def __init__(self, func, **kwargs):
-        self._function = func
-        self._kwargs = kwargs
-
-    @property
-    def function(self):
-        return self._function
-
-    @property
-    def kwargs(self):
-        return self._kwargs
-
-
-class ExceptionHandlingFunction:
-
-    def __init__(self, exception, func):
-        self._function = func
-        self._exception = exception
-
-    @property
-    def func(self):
-        return self._function
-
-    @property
-    def exception(self):
-        return self._exception
-
-
-class APISink:
-
-    def __init__(self, sink, prefix):
-        self._sink = sink
-        self._prefix = prefix
-
-    @property
-    def sink(self):
-        return self._sink
-
-    @property
-    def prefix(self):
-        return self._prefix
-
-
-class APIStaticRoute:
-
-    def __init__(self, prefix, directory, downloadable, fallback_filename):
-        self._prefix = prefix
-        self._directory = directory
-        self._downloadable = downloadable
-        self._fallback_filename = fallback_filename
-
-    @property
-    def prefix(self):
-        return self._prefix
-
-    @property
-    def directory(self):
-        return self._directory
-
-    @property
-    def downloadable(self):
-        return self._downloadable
-
-    @property
-    def fallback_filename(self):
-        return self._fallback_filename
-
-
 class APIBuilder:
     """
     Improved for several reasons:
@@ -285,3 +211,77 @@ class APIBuilder:
             raise APIBuildException(
                 'A route already exists for {method} on uri: {uri}. Only set 1 route per uri and '
                 'HTTP Method.'.format(method=http_method, uri=uri))
+
+
+class APIBuildException(Exception):
+    pass
+
+
+class APIRouteFunction:
+
+    def __init__(self, func, **kwargs):
+        self._function = func
+        self._kwargs = kwargs
+
+    @property
+    def function(self):
+        return self._function
+
+    @property
+    def kwargs(self):
+        return self._kwargs
+
+
+class ExceptionHandlingFunction:
+
+    def __init__(self, exception, func):
+        self._function = func
+        self._exception = exception
+
+    @property
+    def func(self):
+        return self._function
+
+    @property
+    def exception(self):
+        return self._exception
+
+
+class APISink:
+
+    def __init__(self, sink, prefix):
+        self._sink = sink
+        self._prefix = prefix
+
+    @property
+    def sink(self):
+        return self._sink
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+
+class APIStaticRoute:
+
+    def __init__(self, prefix, directory, downloadable, fallback_filename):
+        self._prefix = prefix
+        self._directory = directory
+        self._downloadable = downloadable
+        self._fallback_filename = fallback_filename
+
+    @property
+    def prefix(self):
+        return self._prefix
+
+    @property
+    def directory(self):
+        return self._directory
+
+    @property
+    def downloadable(self):
+        return self._downloadable
+
+    @property
+    def fallback_filename(self):
+        return self._fallback_filename

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -151,9 +151,11 @@ class APIBuilder:
         """Changes the error serializer from falcon's default
 
         Args:
-            serializer (callable): A function which takes a
-                request, response, and exception and serializes
-                the error.
+            serializer (callable): A function taking the form
+                ``func(req, resp, exception)``, where `req` is the request
+                object that was passed to the responder method, `resp` is
+                the response object, and `exception` is an instance of
+                ``falcon.HTTPError``.
 
         Returns:
             The Builder object so that the call can be chained.
@@ -194,6 +196,11 @@ class APIBuilder:
         Returns:
             The Builder object so that the call can be chained.
         """
+        if not isinstance(middlewares, list):
+            raise APIBuildException(
+                'Should only give a list of middlewares to `add_middleware`, '
+                'call `add_middleware` for a single value.')
+
         self._middlewares.extend(middlewares)
         return self
 

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -224,6 +224,13 @@ class APIBuilder:
         for sink in self._sinks:
             api.add_sink(sink.sink, sink.prefix)
 
+        for static_route in self._static_routes:
+            api.add_static_route(
+                static_route.prefix,
+                static_route.directory,
+                static_route.downloadable,
+                static_route.fallback_filename)
+
         api.set_error_serializer(self._error_serializer)
         return api
 

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -184,7 +184,7 @@ class APIBuilder:
         self._routes[uri][http_method] = APIRouteFunction(route_func, **kwargs)
         return self
 
-    def add_error_route(self, exception, on_exception_func):
+    def add_error_route(self, exception, on_exception_func=None):
         self._error_handling_functions.append(
             ExceptionHandlingFunction(exception, on_exception_func))
         return self

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -1,148 +1,14 @@
 
-from falcon import api_helpers as helpers, API, DEFAULT_MEDIA_TYPE, routing
+import functools
+
+from falcon import API, api_helpers, routing
+from falcon.constants import DEFAULT_MEDIA_TYPE, HTTP_METHODS, WEBDAV_METHODS
 from falcon.request import Request
 from falcon.response import Response
 
-import sys
-import inspect
 
-
-class APIBuilder:
-
-    def __init__(self):
-        self._media_type = DEFAULT_MEDIA_TYPE
-        self._call_response_middleware_on_request_middleware_exception = True
-        self._middlewares = []
-        self._request_type = Request
-        self._response_type = Response
-        self._router = routing.DefaultRouter()
-        self._error_serializer = helpers.default_serialize_error
-        self._routes = {}
-        self._error_handling_functions = []
-        self._sinks = []
-        self._static_routes = []
-
-    def set_media_type(self, media_type):
-        self._media_type = media_type
-        return self
-
-    def set_call_response_middleware_on_request_middleware_exception(self, should_call):
-        self._call_response_middleware_on_request_middleware_exception = should_call
-        return self
-
-    def set_request_type(self, request_type):
-        self._request_type = request_type
-        return self
-
-    def set_response_type(self, response_type):
-        self._response_type = response_type
-        return self
-
-    def set_router(self, router):
-        self._router = router
-        return self
-
-    def set_error_serializer(self, serializer):
-        self._error_serializer = serializer
-        return self
-
-    def add_middleware(self, middleware):
-        if isinstance(middleware, list):
-            raise APIBuildException(
-                "Should only add a single middleware using `add_middleware`, "
-                "call `add_middlewares` for a collection.")
-        self._middlewares.append(middleware)
-        return self
-
-    def add_middlewares(self, middlewares):
-        self._middlewares.extend(middlewares)
-        return self
-
-    def add_get_route(self, uri, route_func, **kwargs):
-        return self._add_route("GET", uri, route_func, **kwargs)
-
-    def add_post_route(self, uri, route_func, **kwargs):
-        return self._add_route("POST", uri, route_func, **kwargs)
-
-    def add_put_route(self, uri, route_func, **kwargs):
-        return self._add_route("PUT", uri, route_func, **kwargs)
-
-    def add_delete_route(self, uri, route_func, **kwargs):
-        return self._add_route("DELETE", uri, route_func, **kwargs)
-
-    def add_error_route(self, exception, on_exception_func):
-        self._error_handling_functions.append(ExceptionHandlingFunction(exception, on_exception_func))
-        return self
-
-    def add_sink(self, sink, prefix=r'/'):
-        self._sinks.append(APISink(sink, prefix))
-        return self
-
-    def add_static_route(self, prefix, directory, downloadable=False, fallback_filename=None):
-        self._static_routes.append(APIStaticRoute(prefix, directory, downloadable, fallback_filename))
-        return self
-
-    def build(self):
-
-        api = API(
-            media_type=self._media_type,
-            request_type=self._request_type,
-            response_type=self._response_type,
-            middleware=self._middlewares,
-        )
-
-        this = self
-
-        class ResourceWrapper:
-            pass
-
-        merged_kwargs = {}
-        for uri, uri_method_routes in self._routes.items():
-            resource = ResourceWrapper()
-
-            if "GET" in uri_method_routes:
-                def on_get(self, request, response):
-                    uri_method_routes["GET"].function()(request, response)
-                resource.on_get = on_get.__get__(resource)
-                merged_kwargs.update(uri_method_routes["GET"].kwargs)  # TODO: What about collisions?
-
-            if "POST" in uri_method_routes:
-                def on_post(self, request, response):
-                    uri_method_routes["POST"].function()(request, response)
-                resource.on_post = on_post.__get__(resource)
-                merged_kwargs.update(uri_method_routes["POST"].kwargs)
-
-            if "PUT" in uri_method_routes:
-                def on_put(self, request, response):
-                    uri_method_routes["PUT"].function()(request, response)
-                resource.on_put = on_put.__get__(resource)
-                merged_kwargs.update(uri_method_routes["PUT"].kwargs)
-
-            if "DELETE" in uri_method_routes:
-                def on_delete(self, request, response):
-                    uri_method_routes["DELETE"].function()(request, response)
-                resource.on_delete = on_delete.__get__(resource)
-                merged_kwargs.update(uri_method_routes["DELETE"].kwargs)
-            api.add_route(uri, resource, **merged_kwargs)
-
-        for error_func in self._error_handling_functions:
-            api.add_error_handler(error_func.exception, error_func.func)
-
-        for sink in self._sinks:
-            api.add_sink(sink.sink, sink.prefix)
-
-        api.set_error_serializer(self._error_serializer)
-        return api
-
-    def _add_route(self, http_method, uri, route_func, **kwargs):
-        if uri not in self._routes:
-            self._routes[uri] = {}
-        if http_method in self._routes[uri]:
-            raise APIBuildException(
-                "A route already exists for {method} on uri: {uri}. Only set 1 route per uri and HTTP Method."
-                    .format(method=http_method, uri=uri))
-        self._routes[uri]["GET"] = APIRouteFunction(route_func, **kwargs)
-        return self
+class APIBuildException(Exception):
+    pass
 
 
 class APIRouteFunction:
@@ -215,5 +81,193 @@ class APIStaticRoute:
         return self._fallback_filename
 
 
-class APIBuildException(Exception):
-    pass
+class APIBuilder:
+    """
+    Improved for several reasons:
+        1) Separates the concerns of building an API from using and API
+        2) Mutation methods return self, allowing for chained style building in addition
+            to unchained
+        3) Allows for adding of uri routing to functions without having to subscribe a
+            naming convention (of on_get, on_put, etc), which allows for more explicit
+            function names like (get_user, create_user, update_password, etc).
+        4) Allows for non hard-rest resource style mappings:
+            4.1) can just have a route execute a top level function, or even a lambda,
+                it does not HAVE to be a method on a resource
+            4.2) a resource can have multiple functions, it does not have to care about
+                uris or method types, so a single resource could have multiple uri/resource
+                pairs direct to it (as long as they are unique). For example we could have
+                an update_password, update_username, update_email function all on the Users
+                resource, all with PUT method pointed at them, and all using slightly
+                different uris (eg. /password, /username, /email).
+    """
+
+    def __init__(self):
+        self._media_type = DEFAULT_MEDIA_TYPE
+        self._call_response_middleware_on_request_middleware_exception = True
+        self._middlewares = []
+        self._request_type = Request
+        self._response_type = Response
+        self._router = routing.DefaultRouter()
+        self._error_serializer = api_helpers.default_serialize_error
+        self._routes = {}
+        self._error_handling_functions = []
+        self._sinks = []
+        self._static_routes = []
+
+    def set_media_type(self, media_type):
+        self._media_type = media_type
+        return self
+
+    def set_call_response_middleware_on_request_middleware_exception(self, should_call):
+        self._call_response_middleware_on_request_middleware_exception = should_call
+        return self
+
+    def set_request_type(self, request_type):
+        self._request_type = request_type
+        return self
+
+    def set_response_type(self, response_type):
+        self._response_type = response_type
+        return self
+
+    def set_router(self, router):
+        self._router = router
+        return self
+
+    def set_error_serializer(self, serializer):
+        self._error_serializer = serializer
+        return self
+
+    def add_middleware(self, middleware):
+        if isinstance(middleware, list):
+            raise APIBuildException(
+                'Should only add a single middleware using `add_middleware`, '
+                'call `add_middlewares` for a collection.')
+        self._middlewares.append(middleware)
+        return self
+
+    def add_middlewares(self, middlewares):
+        self._middlewares.extend(middlewares)
+        return self
+
+    def add_get_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('GET', uri, route_func, **kwargs)
+
+    def add_post_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('POST', uri, route_func, **kwargs)
+
+    def add_put_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('PUT', uri, route_func, **kwargs)
+
+    def add_delete_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('DELETE', uri, route_func, **kwargs)
+
+    def add_patch_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('PATCH', uri, route_func, **kwargs)
+
+    def add_head_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('HEAD', uri, route_func, **kwargs)
+
+    def add_options_route(self, uri, route_func, **kwargs):
+        return self.add_method_route('OPTIONS', uri, route_func, **kwargs)
+
+    def add_method_route(self, http_method, uri, route_func, **kwargs):
+
+        self._validate_http_method_type_or_raise(http_method)
+
+        if uri not in self._routes:
+            self._routes[uri] = {}
+
+        self._validate_unique_route_for_uri_and_method_or_raise(uri, http_method)
+        self._validate_non_overwriting_kwargs_for_uri_or_raise(uri)
+
+        self._routes[uri][http_method] = APIRouteFunction(route_func, **kwargs)
+        return self
+
+    def add_error_route(self, exception, on_exception_func):
+        self._error_handling_functions.append(
+            ExceptionHandlingFunction(exception, on_exception_func))
+        return self
+
+    def add_sink(self, sink, prefix=r'/'):
+        self._sinks.append(APISink(sink, prefix))
+        return self
+
+    def add_static_route(self, prefix, directory, downloadable=False, fallback_filename=None):
+        self._static_routes.append(
+            APIStaticRoute(prefix, directory, downloadable, fallback_filename))
+        return self
+
+    def build(self):
+
+        api = API(
+            media_type=self._media_type,
+            request_type=self._request_type,
+            response_type=self._response_type,
+            middleware=self._middlewares,
+        )
+
+        merged_kwargs = {}
+        for uri, uri_method_routes in self._routes.items():
+
+            resource = self._compose_new_resource(uri_method_routes)
+            for http_method, api_route_function in uri_method_routes.items():
+                merged_kwargs.update(api_route_function.kwargs)
+
+            api.add_route(uri, resource, **merged_kwargs)
+
+        for error_func in self._error_handling_functions:
+            api.add_error_handler(error_func.exception, error_func.func)
+
+        for sink in self._sinks:
+            api.add_sink(sink.sink, sink.prefix)
+
+        api.set_error_serializer(self._error_serializer)
+        return api
+
+    @staticmethod
+    def _compose_new_resource(resource_method_routes):
+        class BlankResource:
+            pass
+
+        resource = BlankResource()
+
+        for http_method in HTTP_METHODS + WEBDAV_METHODS:
+
+            if http_method not in resource_method_routes:
+                continue
+
+            falcon_expected_method_name = 'on_' + http_method.lower()
+            setattr(resource,
+                    falcon_expected_method_name,
+                    APIBuilder._generate_wrapped_partial_for_resource(
+                        resource_method_routes[http_method]))
+        return resource
+
+    @staticmethod
+    def _generate_wrapped_partial_for_resource(router_function):
+        return functools.update_wrapper(
+            functools.partial(router_function.function),
+            router_function.function)
+
+    def _validate_http_method_type_or_raise(self, http_method):
+        if http_method not in HTTP_METHODS + WEBDAV_METHODS:
+            raise APIBuildException(
+                'HTTP METHOD must be one of {methods} of which {method}'
+                'is not.'.format(methods=HTTP_METHODS + WEBDAV_METHODS, method=http_method))
+
+    def _validate_non_overwriting_kwargs_for_uri_or_raise(self, uri, **kwargs):
+        for resource_method in self._routes[uri]:
+            existing_kwargs = self._routes[uri][resource_method].kwargs
+            for existing_key, existing_value in existing_kwargs.items():
+                if existing_key in kwargs and existing_value != kwargs[existing_key]:
+                    raise APIBuildException(
+                        'A kwarg by name {key} already has a set value on the resource '
+                        'mapped to {uri}. You can only set a single key value per '
+                        'resource.'.format(key=existing_key, uri=uri))
+
+    def _validate_unique_route_for_uri_and_method_or_raise(self, uri, http_method):
+        if http_method in self._routes[uri]:
+            raise APIBuildException(
+                'A route already exists for {method} on uri: {uri}. Only set 1 route per uri and '
+                'HTTP Method.'.format(method=http_method, uri=uri))

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -81,12 +81,6 @@ class APIStaticRoute:
         return self._fallback_filename
 
 
-# TODO: Write a test using a free function
-# TODO: Write a test using a resource with named functions
-# TODO: Write a test using a resource with multiple functions for same method but different uri
-# TODO: Write a test for each BuilderException
-# TODO:
-
 class APIBuilder:
     """
     Improved for several reasons:

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -185,7 +185,7 @@ class APIBuilder:
             self._routes[uri] = {}
 
         self._raise_on_adding_non_unique_uri_method_pair(uri, http_method)
-        self._raise_on_overwrite_attempt_for_kwargs_on_uri(uri)
+        self._raise_on_overwrite_attempt_for_kwargs_on_uri(uri, **kwargs)
 
         self._routes[uri][http_method] = APIRouteFunction(route_func, **kwargs)
         return self
@@ -267,11 +267,10 @@ class APIBuilder:
                 'HTTP METHOD must be one of {methods} of which {method}'
                 'is not.'.format(methods=HTTP_METHODS + WEBDAV_METHODS, method=http_method))
 
-    def _raise_on_overwrite_attempt_for_kwargs_on_uri(self, uri, **kwargs):
-        for resource_method in self._routes[uri]:
-            existing_kwargs = self._routes[uri][resource_method].kwargs
-            for existing_key, existing_value in existing_kwargs.items():
-                if existing_key in kwargs and existing_value != kwargs[existing_key]:
+    def _raise_on_overwrite_attempt_for_kwargs_on_uri(self, uri, **new_kwargs):
+        for http_method, route_func in self._routes[uri].items():
+            for existing_key, existing_value in route_func.kwargs.items():
+                if existing_key in new_kwargs and existing_value != new_kwargs[existing_key]:
                     raise APIBuildException(
                         'A kwarg by name {key} already has a set value on the resource '
                         'mapped to {uri}. You can only set a single key value per '

--- a/falcon/api_builder.py
+++ b/falcon/api_builder.py
@@ -237,7 +237,15 @@ class APIBuilder:
             if http_method not in resource_method_routes:
                 continue
 
-            falcon_expected_method_name = 'on_' + http_method.lower()
+            # TODO: Document this -> the suffix stuff makes a lot less sense with this builder
+            # TODO:     because we can now used named functions.  We add it here to maintain
+            # TODO:     exact equality between the two usages (API vs APIBuilder)
+            suffix = ''
+            if 'suffix' in resource_method_routes[http_method].kwargs:
+                suffix = '_' + resource_method_routes[http_method].kwargs['suffix']
+
+            falcon_expected_method_name = 'on_' + http_method.lower() + suffix
+
             setattr(resource,
                     falcon_expected_method_name,
                     APIBuilder._generate_wrapped_partial_for_resource(

--- a/tests/test_after_hooks_builder.py
+++ b/tests/test_after_hooks_builder.py
@@ -397,7 +397,7 @@ def test_after_hooks_on_suffixed_resource(seed, uri, expected):
         .add_put_route('/seed', resource.on_put) \
         .add_get_route('/once', resource.on_get_once, suffix='once') \
         .add_get_route('/twice', resource.on_get_twice, suffix='twice') \
-        .add_get_route('/thrice', resource.on_get_thrice, suffix='trice') \
+        .add_get_route('/thrice', resource.on_get_thrice, suffix='thrice') \
         .build()
 
     game_client = testing.TestClient(app)

--- a/tests/test_after_hooks_builder.py
+++ b/tests/test_after_hooks_builder.py
@@ -1,0 +1,409 @@
+import functools
+
+import pytest
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+import falcon
+from falcon import testing
+
+
+# --------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------
+
+
+@pytest.fixture
+def wrapped_resource_aware():
+    return ClassResourceWithAwareHooks()
+
+
+# --------------------------------------------------------------------
+# Hooks
+# --------------------------------------------------------------------
+
+
+def validate_output(req, resp):
+    raise falcon.HTTPError(falcon.HTTP_723, 'Tricky')
+
+
+def serialize_body(req, resp):
+    body = resp.body
+    if body is not None:
+        resp.body = json.dumps(body)
+    else:
+        resp.body = 'Nothing to see here. Move along.'
+
+
+def fluffiness(req, resp, animal=''):
+    resp.body = 'fluffy'
+    if animal:
+        resp.set_header('X-Animal', animal)
+
+
+def resource_aware_fluffiness(req, resp, resource):
+    assert resource
+    fluffiness(req, resp)
+
+
+class ResourceAwareFluffiness(object):
+    def __call__(self, req, resp, resource):
+        assert resource
+        fluffiness(req, resp)
+
+
+def cuteness(req, resp, check, postfix=' and cute'):
+    if resp.body == check:
+        resp.body += postfix
+
+
+def resource_aware_cuteness(req, resp, resource):
+    assert resource
+    cuteness(req, resp, 'fluffy')
+
+
+class Smartness(object):
+    def __call__(self, req, resp):
+        if resp.body:
+            resp.body += ' and smart'
+        else:
+            resp.body = 'smart'
+
+
+# NOTE(kgriffs): Use partial methods for these next two in order
+# to make sure we handle that correctly.
+def things_in_the_head(header, value, req, resp):
+    resp.set_header(header, value)
+
+
+bunnies_in_the_head = functools.partial(things_in_the_head,
+                                        'X-Bunnies', 'fluffy')
+
+
+cuteness_in_the_head = functools.partial(things_in_the_head,
+                                         'X-Cuteness', 'cute')
+
+
+def fluffiness_in_the_head(req, resp, value='fluffy'):
+    resp.set_header('X-Fluffiness', value)
+
+
+# --------------------------------------------------------------------
+# Resources
+# --------------------------------------------------------------------
+
+
+class WrappedRespondersResource(object):
+
+    @falcon.after(serialize_body)
+    @falcon.after(validate_output)
+    def on_get(self, req, resp):
+        self.req = req
+        self.resp = resp
+
+    @falcon.after(serialize_body)
+    def on_put(self, req, resp):
+        self.req = req
+        self.resp = resp
+        resp.body = {'animal': 'falcon'}
+
+    @falcon.after(Smartness())
+    def on_post(self, req, resp):
+        pass
+
+
+@falcon.after(cuteness, 'fluffy', postfix=' and innocent')
+@falcon.after(fluffiness, 'kitten')
+class WrappedClassResource(object):
+
+    # Test that the decorator skips non-callables
+    on_post = False
+
+    def __init__(self):
+        # Test that the decorator skips non-callables
+        self.on_patch = []
+
+    def on_get(self, req, resp):
+        self.req = req
+        self.resp = resp
+
+    @falcon.after(fluffiness_in_the_head)
+    @falcon.after(cuteness_in_the_head)
+    def on_head(self, req, resp):
+        self.req = req
+        self.resp = resp
+
+
+class WrappedClassResourceChild(WrappedClassResource):
+    def on_head(self, req, resp):
+        # Test passing no extra args
+        super(WrappedClassResourceChild, self).on_head(req, resp)
+
+
+class ClassResourceWithURIFields(object):
+
+    @falcon.after(fluffiness_in_the_head, 'fluffy')
+    def on_get(self, req, resp, field1, field2):
+        self.fields = (field1, field2)
+
+
+class ClassResourceWithURIFieldsChild(ClassResourceWithURIFields):
+
+    def on_get(self, req, resp, field1, field2):
+        # Test passing mixed args and kwargs
+        super(ClassResourceWithURIFieldsChild, self).on_get(
+            req,
+            resp,
+            field1,
+            field2=field2
+        )
+
+
+# NOTE(swistakm): we use both type of hooks (class and method)
+# at once for the sake of simplicity
+@falcon.after(resource_aware_cuteness)
+class ClassResourceWithAwareHooks(object):
+
+    # Test that the decorator skips non-callables
+    on_post = False
+
+    hook_as_class = ResourceAwareFluffiness()
+
+    def __init__(self):
+        # Test that the decorator skips non-callables
+        self.on_patch = []
+
+    @falcon.after(resource_aware_fluffiness)
+    def on_get(self, req, resp):
+        self._capture(req, resp)
+
+    @falcon.after(resource_aware_fluffiness)
+    def on_head(self, req, resp):
+        self._capture(req, resp)
+
+    @falcon.after(hook_as_class)
+    def on_put(self, req, resp):
+        self._capture(req, resp)
+
+    @falcon.after(hook_as_class.__call__)
+    def on_post(self, req, resp):
+        self._capture(req, resp)
+
+    def _capture(self, req, resp):
+        self.req = req
+        self.resp = resp
+
+
+# --------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------
+
+
+def test_output_validator():
+    resource = WrappedRespondersResource()
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .add_put_route('/', resource.on_put) \
+        .add_post_route('/', resource.on_post) \
+        .build()
+
+    client = testing.TestClient(app)
+    result = client.simulate_get()
+    assert result.status_code == 723
+    assert result.text == json.dumps({'title': 'Tricky'})
+
+
+def test_serializer():
+    resource = WrappedRespondersResource()
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .add_put_route('/', resource.on_put) \
+        .add_post_route('/', resource.on_post) \
+        .build()
+    app.add_route('/', resource)
+    client = testing.TestClient(app)
+    result = client.simulate_put()
+    assert result.text == json.dumps({'animal': 'falcon'})
+
+
+def test_hook_as_callable_class():
+    resource = WrappedRespondersResource()
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .add_put_route('/', resource.on_put) \
+        .add_post_route('/', resource.on_post) \
+        .build()
+    client = testing.TestClient(app)
+    result = client.simulate_post()
+    assert 'smart' == result.text
+
+
+@pytest.mark.parametrize(
+    'resource',
+    [
+        ClassResourceWithURIFields(),
+        ClassResourceWithURIFieldsChild()
+    ]
+)
+def test_resource_with_uri_fields(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/{field1}/{field2}', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/82074/58927')
+
+    assert result.status_code == 200
+    assert result.headers['X-Fluffiness'] == 'fluffy'
+    assert 'X-Cuteness' not in result.headers
+    assert resource.fields == ('82074', '58927')
+
+
+@pytest.mark.parametrize(
+    'resource',
+    [
+        WrappedClassResource(),
+        WrappedClassResourceChild()
+    ]
+)
+def test_wrapped_resource(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .add_head_route('/', resource.on_head) \
+        .build()
+    client = testing.TestClient(app)
+
+    client.app.add_route('/wrapped', resource)
+    result = client.simulate_get('/wrapped')
+    assert result.status_code == 200
+    assert result.text == 'fluffy and innocent'
+    assert result.headers['X-Animal'] == 'kitten'
+
+    result = client.simulate_head('/wrapped')
+    assert result.status_code == 200
+    assert result.headers['X-Fluffiness'] == 'fluffy'
+    assert result.headers['X-Cuteness'] == 'cute'
+    assert result.headers['X-Animal'] == 'kitten'
+
+    result = client.simulate_post('/wrapped')
+    assert result.status_code == 405
+
+    result = client.simulate_patch('/wrapped')
+    assert result.status_code == 405
+
+    # Decorator should not affect the default on_options responder
+    result = client.simulate_options('/wrapped')
+    assert result.status_code == 200
+    assert not result.text
+    assert 'X-Animal' not in result.headers
+
+
+def test_wrapped_resource_with_hooks_aware_of_resource(wrapped_resource_aware):
+    app = falcon.APIBuilder() \
+        .add_get_route('/wrapped_aware', wrapped_resource_aware.on_get) \
+        .add_head_route('/wrapped_aware', wrapped_resource_aware.on_head) \
+        .add_put_route('/wrapped_aware', wrapped_resource_aware.on_put) \
+        .add_post_route('/wrapped_aware', wrapped_resource_aware.on_post) \
+        .build()
+    client = testing.TestClient(app)
+    expected = 'fluffy and cute'
+
+    result = client.simulate_get('/wrapped_aware')
+    assert result.status_code == 200
+    assert expected == result.text
+
+    for test in (
+        client.simulate_head,
+        client.simulate_put,
+        client.simulate_post,
+    ):
+        result = test(path='/wrapped_aware')
+        assert result.status_code == 200
+        assert wrapped_resource_aware.resp.body == expected
+
+    result = client.simulate_patch('/wrapped_aware')
+    assert result.status_code == 405
+
+    # Decorator should not affect the default on_options responder
+    result = client.simulate_options('/wrapped_aware')
+    assert result.status_code == 200
+    assert not result.text
+
+
+class ResourceAwareGameHook(object):
+
+    VALUES = ('rock', 'scissors', 'paper')
+
+    @classmethod
+    def __call__(cls, req, resp, resource):
+        assert resource
+        assert resource.seed in cls.VALUES
+        assert resp.text == 'Responder called.'
+
+        header = resp.get_header('X-Hook-Game')
+        values = header.split(', ') if header else []
+        if values:
+            last = cls.VALUES.index(values[-1])
+            values.append(cls.VALUES[(last + 1) % len(cls.VALUES)])
+        else:
+            values.append(resource.seed)
+        resp.set_header('X-Hook-Game', ', '.join(values))
+
+
+_game_hook = ResourceAwareGameHook()
+
+
+@falcon.after(_game_hook)
+@falcon.after(_game_hook)
+class HandGame(object):
+
+    def __init__(self):
+        self.seed = None
+
+    @falcon.after(_game_hook)
+    def on_put(self, req, resp):
+        self.seed = req.media
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    def on_get_once(self, req, resp):
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    def on_get_twice(self, req, resp):
+        resp.text = 'Responder called.'
+
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    @falcon.after(_game_hook)
+    def on_get_thrice(self, req, resp):
+        resp.text = 'Responder called.'
+
+
+@pytest.mark.parametrize('seed,uri,expected', [
+    ('paper', '/once', 'paper, rock, scissors'),
+    ('scissors', '/twice', 'scissors, paper, rock, scissors'),
+    ('rock', '/thrice', 'rock, scissors, paper, rock, scissors'),
+    ('paper', '/thrice', 'paper, rock, scissors, paper, rock'),
+])
+def test_after_hooks_on_suffixed_resource(seed, uri, expected):
+    resource = HandGame()
+
+    app = falcon.APIBuilder() \
+        .add_put_route('/seed', resource.on_put) \
+        .add_get_route('/once', resource.on_get_once, suffix='once') \
+        .add_get_route('/twice', resource.on_get_twice, suffix='twice') \
+        .add_get_route('/thrice', resource.on_get_thrice, suffix='trice') \
+        .build()
+
+    game_client = testing.TestClient(app)
+
+    game_client.simulate_put('/seed', json=seed)
+
+    resp = game_client.simulate_get(uri)
+    assert resp.status_code == 200
+    assert resp.headers['X-Hook-Game'] == expected

--- a/tests/test_api_builder.py
+++ b/tests/test_api_builder.py
@@ -134,3 +134,61 @@ def test_raise_on_using_same_uri_and_method():
             .add_get_route('/fizz', example_route_func) \
             .add_get_route('/fizz', example_route_func) \
             .build()
+
+
+def test_raise_on_setting_multipe_middleware_with_single_method():
+    class FakeMiddleware():
+        pass
+
+    with pytest.raises(APIBuildException):
+        falcon.APIBuilder() \
+            .add_middleware([FakeMiddleware()])
+
+
+def test_raise_on_setting_single_middleware_with_multi_method():
+    class FakeMiddleware():
+        pass
+
+    with pytest.raises(APIBuildException):
+        falcon.APIBuilder() \
+            .add_middlewares(FakeMiddleware())
+
+
+def test_request_type_passes_through():
+    class FakeRequest(falcon.request.Request):
+        pass
+
+    builder_app = falcon.APIBuilder() \
+        .set_request_type(FakeRequest) \
+        .build()
+
+    original_app = falcon.API(request_type=FakeRequest)
+
+    assert builder_app._request_type == original_app._request_type
+
+
+def test_response_type_passes_through():
+    class FakeResponse(falcon.response.Response):
+        pass
+
+    builder_app = falcon.APIBuilder() \
+        .set_response_type(FakeResponse) \
+        .build()
+
+    original_app = falcon.API(response_type=FakeResponse)
+
+    assert builder_app._response_type == original_app._response_type
+
+
+def test_error_serializer_passes_through():
+    def fake_error_serializer(request, response, error):
+        pass
+
+    builder_app = falcon.APIBuilder() \
+        .set_error_serializer(fake_error_serializer) \
+        .build()
+
+    original_app = falcon.API()
+    original_app.set_error_serializer(fake_error_serializer)
+
+    assert builder_app._serialize_error == original_app._serialize_error

--- a/tests/test_api_builder.py
+++ b/tests/test_api_builder.py
@@ -1,0 +1,136 @@
+
+import pytest
+
+import falcon
+from falcon import testing
+from falcon.api_builder import APIBuildException
+
+
+def test_lambda_route():
+
+    def example_route_func(request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'Falcon'
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/', example_route_func) \
+        .build()
+
+    client = testing.TestClient(app)
+    result = client.simulate_get()
+    assert result.status_code == 200
+    assert result.text == 'Falcon'
+
+
+def test_resource_with_named_functions():
+
+    class ResourceWithNamedRoutes:
+
+        def __init__(self):
+            self._initial_stuff = None
+
+        def get_stuff(self, request, response):
+            if self._initial_stuff:
+                response.status = falcon.HTTP_200
+                response.body = self._initial_stuff
+            else:
+                response.status = falcon.HTTP_404
+
+        def create_stuff(self, request, response):
+            self._initial_stuff = request.media
+            response.status = falcon.HTTP_201
+
+        def update_stuff(self, request, response):
+            self._initial_stuff = request.media
+            response.status = falcon.HTTP_200
+
+    resource = ResourceWithNamedRoutes()
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/stuff', resource.get_stuff) \
+        .add_post_route('/stuff', resource.create_stuff) \
+        .add_put_route('/stuff', resource.update_stuff) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/stuff')
+    assert result.status_code == 404
+
+    result = client.simulate_post('/stuff', json='STUFF')
+    assert result.status_code == 201
+
+    result = client.simulate_get('/stuff')
+    assert result.status_code == 200
+    assert result.text == 'STUFF'
+
+    result = client.simulate_put('/stuff', json='OTHER_STUFF')
+    assert result.status_code == 200
+
+    result = client.simulate_get('/stuff')
+    assert result.status_code == 200
+    assert result.text == 'OTHER_STUFF'
+
+
+def test_resource_with_multiple_equal_methods():
+
+    class ResourceWithManyGets:
+
+        def get_foo(self, request, response):
+            response.status = falcon.HTTP_200
+            response.body = 'Foo'
+
+        def get_foos(self, request, response):
+            response.status = falcon.HTTP_200
+            response.body = 'Foo, FOO, foo, fOO'
+
+    resource = ResourceWithManyGets()
+    app = falcon.APIBuilder() \
+        .add_get_route('/foo', resource.get_foo) \
+        .add_get_route('/foos', resource.get_foos) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/foo')
+    assert result.status_code == 200
+    assert result.text == 'Foo'
+
+    result = client.simulate_get('/foos')
+    assert result.status_code == 200
+    assert result.text == 'Foo, FOO, foo, fOO'
+
+
+def test_raises_on_invalid_method_add():
+    def example_route_func(request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'Falcon'
+
+    with pytest.raises(APIBuildException):
+        falcon.APIBuilder() \
+            .add_method_route('PANTS', '/fizz', example_route_func) \
+            .build()
+
+
+def test_raises_on_overwriting_of_kwarg_for_uri():
+    def example_route_func(request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'Falcon'
+
+    with pytest.raises(APIBuildException):
+        falcon.APIBuilder() \
+            .add_get_route('/fizz', example_route_func, buzz='buzz') \
+            .add_put_route('/fizz', example_route_func, buzz='fizz') \
+            .build()
+
+
+def test_raise_on_using_same_uri_and_method():
+    def example_route_func(request, response):
+        response.status = falcon.HTTP_200
+        response.body = 'Falcon'
+
+    with pytest.raises(APIBuildException):
+        falcon.APIBuilder() \
+            .add_get_route('/fizz', example_route_func) \
+            .add_get_route('/fizz', example_route_func) \
+            .build()

--- a/tests/test_before_hooks_builder.py
+++ b/tests/test_before_hooks_builder.py
@@ -1,0 +1,513 @@
+import functools
+import io
+
+import pytest
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+import falcon
+import falcon.testing as testing
+
+
+def validate(req, resp, params):
+    raise falcon.HTTPBadRequest('Invalid thing', 'Your thing was not '
+                                'formatted correctly.')
+
+
+def validate_param(req, resp, params, param_name, maxval=100):
+    limit = req.get_param_as_int(param_name)
+    if limit and int(limit) > maxval:
+        msg = '{0} must be <= {1}'.format(param_name, maxval)
+        raise falcon.HTTPBadRequest('Out of Range', msg)
+
+
+def resource_aware_validate_param(req, resp, resource, params, param_name, maxval=100):
+    assert resource
+    validate_param(req, resp, params, param_name, maxval)
+
+
+class ResourceAwareValidateParam(object):
+    def __call__(self, req, resp, resource, params):
+        assert resource
+        validate_param(req, resp, params, 'limit')
+
+
+def validate_field(req, resp, params, field_name='test'):
+    try:
+        params[field_name] = int(params[field_name])
+    except ValueError:
+        raise falcon.HTTPBadRequest()
+
+
+def parse_body(req, resp, params):
+    length = req.content_length or 0
+    if length != 0:
+        params['doc'] = json.load(io.TextIOWrapper(req.stream, 'utf-8'))
+
+
+def bunnies(req, resp, params):
+    params['bunnies'] = 'fuzzy'
+
+
+def resource_aware_bunnies(req, resp, resource, params):
+    assert resource
+    bunnies(req, resp, params)
+
+
+def frogs(req, resp, params):
+    if 'bunnies' in params:
+        params['bunnies'] = 'fluffy'
+
+    params['frogs'] = 'not fluffy'
+
+
+class Fish(object):
+    def __call__(self, req, resp, params):
+        params['fish'] = 'slippery'
+
+    def hook(self, req, resp, resource, params):
+        params['fish'] = 'wet'
+
+
+# NOTE(kgriffs): Use partial methods for these next two in order
+# to make sure we handle that correctly.
+def things_in_the_head(header, value, req, resp, resource, params):
+    resp.set_header(header, value)
+
+
+bunnies_in_the_head = functools.partial(
+    things_in_the_head,
+    'X-Bunnies',
+    'fluffy'
+)
+
+frogs_in_the_head = functools.partial(
+    things_in_the_head,
+    'X-Frogs',
+    'not fluffy'
+)
+
+
+class WrappedRespondersResource(object):
+
+    @falcon.before(validate_param, 'limit', 100)
+    @falcon.before(parse_body)
+    def on_get(self, req, resp, doc):
+        self.req = req
+        self.resp = resp
+        self.doc = doc
+
+    @falcon.before(validate)
+    def on_put(self, req, resp):
+        self.req = req
+        self.resp = resp
+
+
+class WrappedRespondersResourceChild(WrappedRespondersResource):
+
+    @falcon.before(validate_param, 'x', maxval=1000)
+    def on_get(self, req, resp):
+        pass
+
+    def on_put(self, req, resp):
+        # Test passing no extra args
+        super(WrappedRespondersResourceChild, self).on_put(req, resp)
+
+
+@falcon.before(bunnies)
+class WrappedClassResource(object):
+
+    _some_fish = Fish()
+
+    # Test non-callable should be skipped by decorator
+    on_patch = {}
+
+    @falcon.before(validate_param, 'limit')
+    def on_get(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    @falcon.before(validate_param, 'limit')
+    def on_head(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    @falcon.before(_some_fish)
+    def on_post(self, req, resp, fish, bunnies):
+        self._capture(req, resp, bunnies)
+        self.fish = fish
+
+    @falcon.before(_some_fish.hook)
+    def on_put(self, req, resp, fish, bunnies):
+        self._capture(req, resp, bunnies)
+        self.fish = fish
+
+    def _capture(self, req, resp, bunnies):
+        self.req = req
+        self.resp = resp
+        self.bunnies = bunnies
+
+
+# NOTE(swistakm): we use both type of hooks (class and method)
+# at once for the sake of simplicity
+@falcon.before(resource_aware_bunnies)
+class ClassResourceWithAwareHooks(object):
+    hook_as_class = ResourceAwareValidateParam()
+
+    @falcon.before(resource_aware_validate_param, 'limit', 10)
+    def on_get(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    @falcon.before(resource_aware_validate_param, 'limit')
+    def on_head(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    @falcon.before(hook_as_class)
+    def on_put(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    @falcon.before(hook_as_class.__call__)
+    def on_post(self, req, resp, bunnies):
+        self._capture(req, resp, bunnies)
+
+    def _capture(self, req, resp, bunnies):
+        self.req = req
+        self.resp = resp
+        self.bunnies = bunnies
+
+
+class TestFieldResource(object):
+
+    @falcon.before(validate_field, field_name='id')
+    def on_get(self, req, resp, id):
+        self.id = id
+
+
+class TestFieldResourceChild(TestFieldResource):
+
+    def on_get(self, req, resp, id):
+        # Test passing a single extra arg
+        super(TestFieldResourceChild, self).on_get(req, resp, id)
+
+
+class TestFieldResourceChildToo(TestFieldResource):
+
+    def on_get(self, req, resp, id):
+        # Test passing a single kwarg, but no extra args
+        super(TestFieldResourceChildToo, self).on_get(req, resp, id=id)
+
+
+@falcon.before(bunnies)
+@falcon.before(frogs)
+@falcon.before(Fish())
+@falcon.before(bunnies_in_the_head)
+@falcon.before(frogs_in_the_head)
+class ZooResource(object):
+
+    def on_get(self, req, resp, bunnies, frogs, fish):
+        self.bunnies = bunnies
+        self.frogs = frogs
+        self.fish = fish
+
+
+class ZooResourceChild(ZooResource):
+
+    def on_get(self, req, resp):
+        super(ZooResourceChild, self).on_get(
+            req,
+            resp,
+
+            # Test passing a mixture of args and kwargs
+            'fluffy',
+            'not fluffy',
+            fish='slippery'
+        )
+
+
+@pytest.fixture
+def wrapped_aware_resource():
+    return ClassResourceWithAwareHooks()
+
+
+@pytest.fixture
+def wrapped_resource():
+    return WrappedClassResource()
+
+
+@pytest.fixture
+def resource():
+    return WrappedRespondersResource()
+
+
+@pytest.mark.parametrize('resource', [ZooResource(), ZooResourceChild()])
+def test_multiple_resource_hooks(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/')
+
+    assert 'not fluffy' == result.headers['X-Frogs']
+    assert 'fluffy' == result.headers['X-Bunnies']
+
+    assert 'fluffy' == resource.bunnies
+    assert 'not fluffy' == resource.frogs
+    assert 'slippery' == resource.fish
+
+
+def test_input_validator(resource):
+    app = falcon.APIBuilder() \
+        .add_put_route('/', resource.on_put) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_put('/')
+    assert result.status_code == 400
+
+
+def test_input_validator_inherited(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .add_put_route('/', resource.on_put) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    client.app.add_route('/', WrappedRespondersResourceChild())
+    result = client.simulate_put('/')
+    assert result.status_code == 400
+
+    result = client.simulate_get('/', query_string='x=1000')
+    assert result.status_code == 200
+
+    result = client.simulate_get('/', query_string='x=1001')
+    assert result.status_code == 400
+
+
+def test_param_validator(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/', query_string='limit=10', body='{}')
+    assert result.status_code == 200
+
+    result = client.simulate_get('/', query_string='limit=101')
+    assert result.status_code == 400
+
+
+@pytest.mark.parametrize(
+    'resource',
+    [
+        TestFieldResource(),
+        TestFieldResourceChild(),
+        TestFieldResourceChildToo(),
+    ]
+)
+def test_field_validator(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/queue/{id}/messages', resource.on_get) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/queue/10/messages')
+    assert result.status_code == 200
+    assert resource.id == 10
+
+    result = client.simulate_get('/queue/bogus/messages')
+    assert result.status_code == 400
+
+
+def test_parser(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    client.simulate_get('/', body=json.dumps({'animal': 'falcon'}))
+    assert resource.doc == {'animal': 'falcon'}
+
+
+def test_wrapped_resource(wrapped_resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/wrapped', wrapped_resource.on_get) \
+        .add_head_route('/wrapped', wrapped_resource.on_head) \
+        .add_post_route('/wrapped', wrapped_resource.on_post) \
+        .add_put_route('/wrapped', wrapped_resource.on_put) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/wrapped', query_string='limit=10')
+    assert result.status_code == 200
+    assert 'fuzzy' == wrapped_resource.bunnies
+
+    result = client.simulate_head('/wrapped')
+    assert result.status_code == 200
+    assert 'fuzzy' == wrapped_resource.bunnies
+
+    result = client.simulate_post('/wrapped')
+    assert result.status_code == 200
+    assert 'slippery' == wrapped_resource.fish
+
+    result = client.simulate_get('/wrapped', query_string='limit=101')
+    assert result.status_code == 400
+    assert wrapped_resource.bunnies == 'fuzzy'
+
+
+def test_wrapped_resource_with_hooks_aware_of_resource(wrapped_aware_resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/wrapped_aware', wrapped_aware_resource.on_get) \
+        .add_head_route('/wrapped_aware', wrapped_aware_resource.on_head) \
+        .add_post_route('/wrapped_aware', wrapped_aware_resource.on_post) \
+        .add_put_route('/wrapped_aware', wrapped_aware_resource.on_put) \
+        .build()
+
+    client = testing.TestClient(app)
+
+    client.app.add_route('/wrapped_aware', wrapped_aware_resource)
+
+    result = client.simulate_patch('/wrapped_aware')
+    assert result.status_code == 405
+
+    result = client.simulate_get('/wrapped_aware', query_string='limit=10')
+    assert result.status_code == 200
+    assert wrapped_aware_resource.bunnies == 'fuzzy'
+
+    for method in ('HEAD', 'PUT', 'POST'):
+        result = client.simulate_request(method, '/wrapped_aware')
+        assert result.status_code == 200
+        assert wrapped_aware_resource.bunnies == 'fuzzy'
+
+    result = client.simulate_get('/wrapped_aware', query_string='limit=11')
+    assert result.status_code == 400
+    assert wrapped_aware_resource.bunnies == 'fuzzy'
+
+
+_another_fish = Fish()
+
+
+def header_hook(req, resp, params):
+    value = resp.get_header('X-Hook-Applied') or '0'
+    resp.set_header('X-Hook-Applied', str(int(value) + 1))
+
+
+@falcon.before(header_hook)
+class PiggybackingCollection(object):
+
+    def __init__(self):
+        self._items = {}
+        self._sequence = 0
+
+    @falcon.before(_another_fish.hook)
+    def on_delete(self, req, resp, fish, itemid):
+        del self._items[itemid]
+        resp.set_header('X-Fish-Trait', fish)
+        resp.status = falcon.HTTP_NO_CONTENT
+
+    @falcon.before(header_hook)
+    @falcon.before(_another_fish.hook)
+    @falcon.before(header_hook)
+    def on_delete_collection(self, req, resp, fish):
+        if fish != 'wet':
+            raise falcon.HTTPUnavailableForLegalReasons('fish must be wet')
+        self._items = {}
+        resp.status = falcon.HTTP_NO_CONTENT
+
+    @falcon.before(_another_fish)
+    def on_get(self, req, resp, fish, itemid):
+        resp.set_header('X-Fish-Trait', fish)
+        resp.media = self._items[itemid]
+
+    def on_get_collection(self, req, resp):
+        resp.media = sorted(self._items.values(),
+                            key=lambda item: item['itemid'])
+
+    def on_head_(self):
+        return 'I shall not be decorated.'
+
+    def on_header(self):
+        return 'I shall not be decorated.'
+
+    def on_post_collection(self, req, resp):
+        self._sequence += 1
+        itemid = self._sequence
+        self._items[itemid] = dict(req.media, itemid=itemid)
+        resp.location = '/items/{}'.format(itemid)
+        resp.status = falcon.HTTP_CREATED
+
+
+def test_piggybacking_resource_post_item():
+    items = PiggybackingCollection()
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/items/{itemid:int}', items.on_get) \
+        .add_delete_route('/items/{itemid:int}', items.on_delete) \
+        .add_get_route('/items', items.on_get_collection, suffix='collection') \
+        .add_post_route('/items', items.on_post_collection, suffix='collection') \
+        .add_delete_route('/items', items.on_delete_collection, suffix='collection') \
+        .build()
+
+    app_client = testing.TestClient(app)
+
+    resp1 = app_client.simulate_post('/items', json={'color': 'green'})
+    assert resp1.status_code == 201
+    assert 'X-Fish-Trait' not in resp1.headers
+    assert resp1.headers['Location'] == '/items/1'
+    assert resp1.headers['X-Hook-Applied'] == '1'
+
+    resp2 = app_client.simulate_get(resp1.headers['Location'])
+    assert resp2.status_code == 200
+    assert resp2.headers['X-Fish-Trait'] == 'slippery'
+    assert resp2.headers['X-Hook-Applied'] == '1'
+    assert resp2.json == {'color': 'green', 'itemid': 1}
+
+    resp3 = app_client.simulate_get('/items')
+    assert resp3.status_code == 200
+    assert 'X-Fish-Trait' not in resp3.headers
+    assert resp3.headers['X-Hook-Applied'] == '1'
+    assert resp3.json == [{'color': 'green', 'itemid': 1}]
+
+
+def test_piggybacking_resource_post_and_delete():
+    items = PiggybackingCollection()
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/items/{itemid:int}', items.on_get) \
+        .add_delete_route('/items/{itemid:int}', items.on_delete) \
+        .add_get_route('/items', items.on_get_collection, suffix='collection') \
+        .add_post_route('/items', items.on_post_collection, suffix='collection') \
+        .add_delete_route('/items', items.on_delete_collection, suffix='collection') \
+        .build()
+
+    app_client = testing.TestClient(app)
+
+    for number in range(1, 8):
+        resp = app_client.simulate_post('/items', json={'number': number})
+        assert resp.status_code == 201
+        assert resp.headers['X-Hook-Applied'] == '1'
+
+        assert len(app_client.simulate_get('/items').json) == number
+
+    resp = app_client.simulate_delete('/items/7'.format(number))
+    assert resp.status_code == 204
+    assert resp.headers['X-Fish-Trait'] == 'wet'
+    assert resp.headers['X-Hook-Applied'] == '1'
+    assert len(app_client.simulate_get('/items').json) == 6
+
+    resp = app_client.simulate_delete('/items')
+    assert resp.status_code == 204
+    assert resp.headers['X-Hook-Applied'] == '3'
+    assert app_client.simulate_get('/items').json == []
+
+
+def test_decorable_name_pattern():
+    resource = PiggybackingCollection()
+    assert resource.on_head_() == 'I shall not be decorated.'
+    assert resource.on_header() == 'I shall not be decorated.'

--- a/tests/test_cmd_print_api.py
+++ b/tests/test_cmd_print_api.py
@@ -3,7 +3,7 @@ import six
 from falcon import API
 from falcon.cmd import print_routes
 from falcon.testing import redirected
-
+from falcon.api_builder import APIBuilder
 
 class DummyResource(object):
 
@@ -43,6 +43,41 @@ def test_traverse():
     output = six.moves.StringIO()
     with redirected(stdout=output):
         print_routes.traverse(_api._router._roots, verbose=False)
+
+    route = output.getvalue().strip()
+    assert '-> /test' == route
+
+
+_api_from_builder = APIBuilder().add_get_route("/test", DummyResource.on_get).build()
+
+
+def test_traverse_with_verbose_on_builder_api():
+    """Ensure traverse() finds the proper routes and outputs verbose info."""
+
+    output = six.moves.StringIO()
+    with redirected(stdout=output):
+        print_routes.traverse(_api_from_builder._router._roots, verbose=True)
+
+    route, get_info, options_info = output.getvalue().strip().split('\n')
+    assert '-> /test' == route
+
+    # NOTE(kgriffs) We might receive these in either order, since the
+    # method map is not ordered, so check and swap if necessary.
+    if options_info.startswith('-->GET'):
+        get_info, options_info = options_info, get_info
+
+    assert options_info.startswith('-->OPTIONS')
+    assert 'falcon/responders.py:' in options_info
+
+    assert get_info.startswith('-->GET')
+    assert 'tests/test_cmd_print_api.py:' in get_info
+
+
+def test_traverse_on_builder_api():
+    """Ensure traverse() finds the proper routes."""
+    output = six.moves.StringIO()
+    with redirected(stdout=output):
+        print_routes.traverse(_api_from_builder._router._roots, verbose=False)
 
     route = output.getvalue().strip()
     assert '-> /test' == route

--- a/tests/test_cmd_print_api.py
+++ b/tests/test_cmd_print_api.py
@@ -1,9 +1,10 @@
 import six
 
 from falcon import API
+from falcon.api_builder import APIBuilder
 from falcon.cmd import print_routes
 from falcon.testing import redirected
-from falcon.api_builder import APIBuilder
+
 
 class DummyResource(object):
 
@@ -48,7 +49,7 @@ def test_traverse():
     assert '-> /test' == route
 
 
-_api_from_builder = APIBuilder().add_get_route("/test", DummyResource.on_get).build()
+_api_from_builder = APIBuilder().add_get_route('/test', DummyResource.on_get).build()
 
 
 def test_traverse_with_verbose_on_builder_api():

--- a/tests/test_custom_router_builder.py
+++ b/tests/test_custom_router_builder.py
@@ -1,0 +1,134 @@
+import pytest
+
+import falcon
+from falcon import testing
+
+
+def test_custom_router_add_route_should_be_used():
+    check = []
+
+    class CustomRouter(object):
+        def add_route(self, uri_template, *args, **kwargs):
+            check.append(uri_template)
+
+        def find(self, uri):
+            pass
+
+    app = falcon.APIBuilder() \
+        .set_router(CustomRouter()) \
+        .build()
+    app.add_route('/test', 'resource')
+
+    assert len(check) == 1
+    assert '/test' in check
+
+
+def test_custom_router_find_should_be_used():
+
+    def resource(req, resp, **kwargs):
+        resp.body = '{{"uri_template": "{0}"}}'.format(req.uri_template)
+
+    class CustomRouter(object):
+        def __init__(self):
+            self.reached_backwards_compat = False
+
+        def find(self, uri):
+            if uri == '/test/42':
+                return resource, {'GET': resource}, {}, '/test/{id}'
+
+            if uri == '/test/42/no-uri-template':
+                return resource, {'GET': resource}, {}, None
+
+            if uri == '/test/42/uri-template/backwards-compat':
+                return resource, {'GET': resource}, {}
+
+            if uri == '/404/backwards-compat':
+                self.reached_backwards_compat = True
+                return (None, None, None)
+            return None
+
+    router = CustomRouter()
+    app = falcon.APIBuilder() \
+        .set_router(router) \
+        .build()
+    client = testing.TestClient(app)
+
+    response = client.simulate_request(path='/test/42')
+    assert response.content == b'{"uri_template": "/test/{id}"}'
+
+    response = client.simulate_request(path='/test/42/no-uri-template')
+    assert response.content == b'{"uri_template": "None"}'
+
+    response = client.simulate_request(path='/test/42/uri-template/backwards-compat')
+    assert response.content == b'{"uri_template": "None"}'
+
+    for uri in ('/404', '/404/backwards-compat'):
+        response = client.simulate_request(path=uri)
+        assert not response.content
+        assert response.status == falcon.HTTP_404
+
+    assert router.reached_backwards_compat
+
+
+def test_can_pass_additional_params_to_add_route():
+
+    check = []
+
+    class CustomRouter(object):
+        def add_route(self, uri_template, resource, **kwargs):
+            name = kwargs['name']
+            self._index = {name: uri_template}
+            check.append(name)
+
+        def find(self, uri):
+            pass
+
+    app = falcon.APIBuilder() \
+        .set_router(CustomRouter()) \
+        .build()
+    app.add_route('/test', 'resource', name='my-url-name')
+
+    assert len(check) == 1
+    assert 'my-url-name' in check
+
+    # NOTE(kgriffs): Extra values must be passed as kwargs, since that makes
+    #   it a lot easier for overriden methods to simply ignore options they
+    #   don't care about.
+    with pytest.raises(TypeError):
+        app.add_route('/test', 'resource', 'xarg1', 'xarg2')
+
+
+def test_custom_router_takes_req_positional_argument():
+    def responder(req, resp):
+        resp.body = 'OK'
+
+    class CustomRouter(object):
+        def find(self, uri, req):
+            if uri == '/test' and isinstance(req, falcon.Request):
+                return responder, {'GET': responder}, {}, None
+
+    router = CustomRouter()
+    app = falcon.APIBuilder() \
+        .set_router(router) \
+        .build()
+    client = testing.TestClient(app)
+    response = client.simulate_request(path='/test')
+    assert response.content == b'OK'
+
+
+def test_custom_router_takes_req_keyword_argument():
+    def responder(req, resp):
+        resp.body = 'OK'
+
+    class CustomRouter(object):
+        def find(self, uri, req=None):
+            if uri == '/test' and isinstance(req, falcon.Request):
+                return responder, {'GET': responder}, {}, None
+
+    router = CustomRouter()
+    app = falcon.APIBuilder() \
+        .set_router(router) \
+        .build()
+    client = testing.TestClient(app)
+    response = client.simulate_request(path='/test')
+    assert response.content == b'OK'

--- a/tests/test_error_handlers_builder.py
+++ b/tests/test_error_handlers_builder.py
@@ -1,0 +1,182 @@
+import pytest
+
+import falcon
+from falcon import testing
+
+
+def capture_error(req, resp, ex, params):
+    resp.status = falcon.HTTP_723
+    resp.body = 'error: %s' % str(ex)
+
+
+def handle_error_first(req, resp, ex, params):
+    resp.status = falcon.HTTP_200
+    resp.body = 'first error handler'
+
+
+class CustomBaseException(Exception):
+    pass
+
+
+class CustomException(CustomBaseException):
+
+    @staticmethod
+    def handle(req, resp, ex, params):
+        raise falcon.HTTPError(
+            falcon.HTTP_792,
+            u'Internet crashed!',
+            u'Catastrophic weather event',
+            href=u'http://example.com/api/inconvenient-truth',
+            href_text=u'Drill, baby drill!')
+
+
+class ErroredClassResource(object):
+
+    def on_get(self, req, resp):
+        raise Exception('Plain Exception')
+
+    def on_head(self, req, resp):
+        raise CustomBaseException('CustomBaseException')
+
+    def on_delete(self, req, resp):
+        raise CustomException('CustomException')
+
+
+class TestErrorHandler(object):
+
+    def test_caught_error(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(Exception, capture_error) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.text == 'error: Plain Exception'
+
+        result = client.simulate_head()
+        assert result.status_code == 723
+        assert not result.content
+
+    def test_uncaught_error(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(CustomException, capture_error) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        with pytest.raises(Exception):
+            client.simulate_get()
+
+    def test_uncaught_error_else(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .build()
+
+        client = testing.TestClient(app)
+        with pytest.raises(Exception):
+            client.simulate_get()
+
+    def test_converted_error(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(CustomException) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_delete()
+        assert result.status_code == 792
+        assert result.json[u'title'] == u'Internet crashed!'
+
+    def test_handle_not_defined(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .build()
+
+        client = testing.TestClient(app)
+        with pytest.raises(AttributeError):
+            client.app.add_error_handler(CustomBaseException)
+
+    def test_subclass_error(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(CustomBaseException, capture_error) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_delete()
+        assert result.status_code == 723
+        assert result.text == 'error: CustomException'
+
+    def test_error_order_duplicate(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(Exception, capture_error) \
+            .add_error_route(Exception, handle_error_first) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.text == 'first error handler'
+
+    def test_error_order_subclass(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(Exception, capture_error) \
+            .add_error_route(CustomException, handle_error_first) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_delete()
+        assert result.status_code == 200
+        assert result.text == 'first error handler'
+
+        result = client.simulate_get()
+        assert result.status_code == 723
+        assert result.text == 'error: Plain Exception'
+
+    def test_error_order_subclass_masked(self):
+        resource = ErroredClassResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_get_route('/', resource.on_get) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_error_route(CustomException, handle_error_first) \
+            .add_error_route(Exception, capture_error) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_delete()
+        assert result.status_code == 723
+        assert result.text == 'error: CustomException'

--- a/tests/test_headers_builder.py
+++ b/tests/test_headers_builder.py
@@ -1,0 +1,816 @@
+from collections import defaultdict
+from datetime import datetime
+
+import pytest
+import six
+
+import falcon
+from falcon import testing
+
+
+SAMPLE_BODY = testing.rand_string(0, 128 * 1024)
+
+
+class XmlResource(object):
+    def __init__(self, content_type):
+        self.content_type = content_type
+
+    def on_get(self, req, resp):
+        resp.set_header('content-type', self.content_type)
+
+
+class HeaderHelpersResource(object):
+
+    def __init__(self, last_modified=None):
+        if last_modified is not None:
+            self.last_modified = last_modified
+        else:
+            self.last_modified = datetime.utcnow()
+
+    def _overwrite_headers(self, req, resp):
+        resp.content_type = 'x-falcon/peregrine'
+        resp.cache_control = ['no-store']
+
+    def on_get(self, req, resp):
+        resp.body = '{}'
+        resp.content_type = 'x-falcon/peregrine'
+        resp.cache_control = [
+            'public', 'private', 'no-cache', 'no-store', 'must-revalidate',
+            'proxy-revalidate', 'max-age=3600', 's-maxage=60', 'no-transform'
+        ]
+
+        resp.etag = None  # Header not set yet, so should be a noop
+        resp.etag = 'fa0d1a60ef6616bb28038515c8ea4cb2'
+        resp.last_modified = self.last_modified
+        resp.retry_after = 3601
+
+        # Relative URI's are OK per http://goo.gl/DbVqR
+        resp.location = '/things/87'
+        resp.content_location = '/things/78'
+
+        resp.downloadable_as = None  # Header not set yet, so should be a noop
+        resp.downloadable_as = 'Some File.zip'
+
+        if req.range_unit is None or req.range_unit == 'bytes':
+            # bytes 0-499/10240
+            resp.content_range = (0, 499, 10 * 1024)
+        else:
+            resp.content_range = (0, 25, 100, req.range_unit)
+
+        resp.accept_ranges = None  # Header not set yet, so should be a noop
+        resp.accept_ranges = 'bytes'
+
+        # Test the removal of custom headers
+        resp.set_header('X-Client-Should-Never-See-This', 'abc')
+        assert resp.get_header('x-client-should-never-see-this') == 'abc'
+        resp.delete_header('x-client-should-never-see-this')
+
+        self.resp = resp
+
+    def on_head(self, req, resp):
+        resp.set_header('Content-Type', 'x-swallow/unladen')
+        resp.set_header('X-Auth-Token', 'setecastronomy')
+        resp.set_header('X-AUTH-TOKEN', 'toomanysecrets')
+
+        resp.location = '/things/87'
+        del resp.location
+
+        self._overwrite_headers(req, resp)
+
+        self.resp = resp
+
+    def on_post(self, req, resp):
+        resp.set_headers([
+            ('CONTENT-TYPE', 'x-swallow/unladen'),
+            ('X-Auth-Token', 'setecastronomy'),
+            ('X-AUTH-TOKEN', 'toomanysecrets')
+        ])
+
+        self._overwrite_headers(req, resp)
+
+        self.resp = resp
+
+    def on_put(self, req, resp):
+        resp.set_headers({
+            'CONTENT-TYPE': 'x-swallow/unladen',
+            'X-aUTH-tOKEN': 'toomanysecrets'
+        })
+
+        self._overwrite_headers(req, resp)
+
+        self.resp = resp
+
+
+class LocationHeaderUnicodeResource(object):
+
+    URL1 = u'/\u00e7runchy/bacon'
+    URL2 = u'ab\u00e7' if six.PY3 else 'ab\xc3\xa7'
+
+    def on_get(self, req, resp):
+        resp.location = self.URL1
+        resp.content_location = self.URL2
+
+    def on_head(self, req, resp):
+        resp.location = self.URL2
+        resp.content_location = self.URL1
+
+
+class UnicodeHeaderResource(object):
+
+    def on_get(self, req, resp):
+        resp.set_headers([
+            (u'X-auTH-toKEN', 'toomanysecrets'),
+            ('Content-TYpE', u'application/json'),
+            (u'X-symBOl', u'@'),
+        ])
+
+    def on_post(self, req, resp):
+        resp.set_headers([
+            (u'X-symb\u00F6l', 'thing'),
+        ])
+
+    def on_put(self, req, resp):
+        resp.set_headers([
+            ('X-Thing', u'\u00FF'),
+        ])
+
+
+class VaryHeaderResource(object):
+
+    def __init__(self, vary):
+        self.vary = vary
+
+    def on_get(self, req, resp):
+        resp.body = '{}'
+        resp.vary = self.vary
+
+
+class LinkHeaderResource(object):
+
+    def __init__(self):
+        self._links = []
+
+    def add_link(self, *args, **kwargs):
+        self._links.append((args, kwargs))
+
+    def on_get(self, req, resp):
+        resp.body = '{}'
+
+        for args, kwargs in self._links:
+            resp.add_link(*args, **kwargs)
+
+
+class AppendHeaderResource(object):
+
+    def on_get(self, req, resp):
+        resp.append_header('X-Things', 'thing-1')
+        resp.append_header('X-THINGS', 'thing-2')
+        resp.append_header('x-thiNgs', 'thing-3')
+
+    def on_head(self, req, resp):
+        resp.set_header('X-things', 'thing-1')
+        resp.append_header('X-THINGS', 'thing-2')
+        resp.append_header('x-thiNgs', 'thing-3')
+
+    def on_post(self, req, resp):
+        resp.append_header('X-Things', 'thing-1')
+
+
+class RemoveHeaderResource(object):
+    def __init__(self, with_double_quotes):
+        self.with_double_quotes = with_double_quotes
+
+    def on_get(self, req, resp):
+        etag = 'fa0d1a60ef6616bb28038515c8ea4cb2'
+        if self.with_double_quotes:
+            etag = '\"' + etag + '\"'
+
+        resp.etag = etag
+        assert resp.etag == '"fa0d1a60ef6616bb28038515c8ea4cb2"'
+        resp.etag = None
+
+        resp.downloadable_as = 'foo.zip'
+        assert resp.downloadable_as == 'attachment; filename="foo.zip"'
+        resp.downloadable_as = None
+
+
+class ContentLengthHeaderResource(object):
+
+    def __init__(self, content_length, body=None):
+        self._content_length = content_length
+        self._body = body
+
+    def on_get(self, req, resp):
+        resp.content_length = self._content_length
+        resp.body = self._body
+
+
+class ExpiresHeaderResource(object):
+
+    def __init__(self, expires):
+        self._expires = expires
+
+    def on_get(self, req, resp):
+        resp.expires = self._expires
+
+
+class TestHeaders(object):
+
+    def test_content_length(self):
+        resource = testing.SimpleTestResource(body=SAMPLE_BODY)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        content_length = str(len(SAMPLE_BODY))
+        assert result.headers['Content-Length'] == content_length
+
+    def test_declare_content_length(self):
+        resource = ContentLengthHeaderResource(42)
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        assert result.headers['Content-Length'] == '42'
+
+    def test_declared_content_length_not_overriden_by_body_length(self):
+        resource = ContentLengthHeaderResource(42, body='Hello World')
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        client.app.add_route('/', resource)
+        result = client.simulate_get()
+
+        assert result.headers['Content-Length'] == '42'
+
+    def test_expires_header(self):
+        expires = datetime(2013, 1, 1, 10, 30, 30)
+        resource = ExpiresHeaderResource(expires)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        assert result.headers['Expires'] == 'Tue, 01 Jan 2013 10:30:30 GMT'
+
+    def test_default_value(self):
+        resource = testing.SimpleTestResource(body=SAMPLE_BODY)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_get()
+
+        req = resource.captured_req
+        value = req.get_header('X-Not-Found') or '876'
+        assert value == '876'
+
+        value = req.get_header('X-Not-Found', default='some-value')
+        assert value == 'some-value'
+
+    @pytest.mark.parametrize('with_double_quotes', [True, False])
+    def test_unset_header(self, with_double_quotes):
+        resource = RemoveHeaderResource(with_double_quotes)
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        assert 'Etag' not in result.headers
+        assert 'Content-Disposition' not in result.headers
+
+    def test_required_header(self):
+        resource = testing.SimpleTestResource(body=SAMPLE_BODY)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_get()
+
+        try:
+            req = resource.captured_req
+            req.get_header('X-Not-Found', required=True)
+            pytest.fail('falcon.HTTPMissingHeader not raised')
+        except falcon.HTTPMissingHeader as ex:
+            assert isinstance(ex, falcon.HTTPBadRequest)
+            assert ex.title == 'Missing header value'
+            expected_desc = 'The X-Not-Found header is required.'
+            assert ex.description == expected_desc
+
+    @pytest.mark.parametrize('status', (falcon.HTTP_204, falcon.HTTP_304))
+    def test_no_content_length(self, status):
+        resource = testing.SimpleTestResource(status=status)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/xxx', resource.on_get) \
+            .add_post_route('/xxx', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/xxx')
+        assert 'Content-Length' not in result.headers
+        assert not result.content
+
+    def test_content_header_missing(self):
+
+        environ = testing.create_environ()
+        req = falcon.Request(environ)
+        for header in ('Content-Type', 'Content-Length'):
+            assert req.get_header(header) is None
+
+    def test_passthrough_request_headers(self):
+        resource = testing.SimpleTestResource(body=SAMPLE_BODY)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        request_headers = {
+            'X-Auth-Token': 'Setec Astronomy',
+            'Content-Type': 'text/plain; charset=utf-8'
+        }
+        client.simulate_get(headers=request_headers)
+
+        for name, expected_value in request_headers.items():
+            actual_value = resource.captured_req.get_header(name)
+            assert actual_value == expected_value
+
+        client.simulate_get(headers=resource.captured_req.headers)
+
+        # Compare the request HTTP headers with the original headers
+        for name, expected_value in request_headers.items():
+            actual_value = resource.captured_req.get_header(name)
+            assert actual_value == expected_value
+
+    def test_headers_as_list(self):
+
+        headers = [
+            ('Client-ID', '692ba466-74bb-11e3-bf3f-7567c531c7ca'),
+            ('Accept', 'audio/*; q=0.2, audio/basic')
+        ]
+
+        resource = testing.SimpleTestResource(headers=headers)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        # Unit test
+        environ = testing.create_environ(headers=headers)
+        req = falcon.Request(environ)
+
+        for name, value in headers:
+            assert (name.upper(), value) in req.headers.items()
+
+        # Functional test
+        result = client.simulate_get()
+
+        for name, value in headers:
+            assert result.headers[name] == value
+
+    def test_default_media_type(self):
+        resource = testing.SimpleTestResource(body='Hello world!')
+
+        self._check_header(
+            falcon.APIBuilder(),
+            resource,
+            'Content-Type',
+            falcon.DEFAULT_MEDIA_TYPE)
+
+    @pytest.mark.parametrize('content_type,body', [
+        ('text/plain; charset=UTF-8', u'Hello Unicode! \U0001F638'),
+        # NOTE(kgriffs): This only works because the client defaults to
+        # ISO-8859-1 IFF the media type is 'text'.
+        ('text/plain', 'Hello ISO-8859-1!'),
+    ])
+    def test_override_default_media_type(self, content_type, body):
+        resource = testing.SimpleTestResource(body=body)
+
+        app = falcon.APIBuilder() \
+            .set_media_type(content_type) \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+        result = client.simulate_get()
+
+        assert result.text == body
+        assert result.headers['Content-Type'] == content_type
+
+    def test_override_default_media_type_missing_encoding(self):
+        body = u'{"msg": "Hello Unicode! \U0001F638"}'
+
+        resource = testing.SimpleTestResource(body=body)
+
+        app = falcon.APIBuilder() \
+            .set_media_type('application/json') \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        assert result.content == body.encode('utf-8')
+        assert isinstance(result.text, six.text_type)
+        assert result.text == body
+        assert result.json == {u'msg': u'Hello Unicode! \U0001F638'}
+
+    def test_response_header_helpers_on_get(self):
+
+        last_modified = datetime(2013, 1, 1, 10, 30, 30)
+        resource = HeaderHelpersResource(last_modified)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        resp = resource.resp
+
+        content_type = 'x-falcon/peregrine'
+        assert resp.content_type == content_type
+        assert result.headers['Content-Type'] == content_type
+        assert result.headers['Content-Disposition'] == 'attachment; filename="Some File.zip"'
+
+        cache_control = ('public, private, no-cache, no-store, '
+                         'must-revalidate, proxy-revalidate, max-age=3600, '
+                         's-maxage=60, no-transform')
+
+        assert resp.cache_control == cache_control
+        assert result.headers['Cache-Control'] == cache_control
+
+        etag = '"fa0d1a60ef6616bb28038515c8ea4cb2"'
+        assert resp.etag == etag
+        assert result.headers['Etag'] == etag
+
+        lm_date = 'Tue, 01 Jan 2013 10:30:30 GMT'
+        assert resp.last_modified == lm_date
+        assert result.headers['Last-Modified'] == lm_date
+
+        assert resp.retry_after == '3601'
+        assert result.headers['Retry-After'] == '3601'
+
+        assert resp.location == '/things/87'
+        assert result.headers['Location'] == '/things/87'
+
+        assert resp.content_location == '/things/78'
+        assert result.headers['Content-Location'] == '/things/78'
+
+        content_range = 'bytes 0-499/10240'
+        assert resp.content_range == content_range
+        assert result.headers['Content-Range'] == content_range
+
+        resp.content_range = (1, 499, 10 * 1024, u'bytes')
+        assert isinstance(resp.content_range, str)
+        assert resp.content_range == 'bytes 1-499/10240'
+
+        assert resp.accept_ranges == 'bytes'
+        assert result.headers['Accept-Ranges'] == 'bytes'
+
+        req_headers = {'Range': 'items=0-25'}
+        result = client.simulate_get(headers=req_headers)
+        assert result.headers['Content-Range'] == 'items 0-25/100'
+
+        # Check for duplicate headers
+        hist = defaultdict(lambda: 0)
+        for name, value in result.headers.items():
+            hist[name] += 1
+            assert 1 == hist[name]
+
+    def test_unicode_location_headers(self):
+        resource = LocationHeaderUnicodeResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_head_route('/', resource.on_head) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.headers['Location'] == '/%C3%A7runchy/bacon'
+        assert result.headers['Content-Location'] == 'ab%C3%A7'
+
+        # Test with the values swapped
+        result = client.simulate_head()
+        assert result.headers['Content-Location'] == '/%C3%A7runchy/bacon'
+        assert result.headers['Location'] == 'ab%C3%A7'
+
+    def test_unicode_headers_convertable(self):
+        resource = UnicodeHeaderResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/')
+
+        assert result.headers['Content-Type'] == 'application/json'
+        assert result.headers['X-Auth-Token'] == 'toomanysecrets'
+        assert result.headers['X-Symbol'] == '@'
+
+    @pytest.mark.skipif(six.PY3, reason='Test only applies to Python 2')
+    def test_unicode_headers_not_convertable(self):
+        resource = UnicodeHeaderResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .add_put_route('/', resource.on_put) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        with pytest.raises(UnicodeEncodeError):
+            client.simulate_post('/')
+
+        with pytest.raises(UnicodeEncodeError):
+            client.simulate_put('/')
+
+    def test_response_set_and_get_header(self):
+        resource = HeaderHelpersResource()
+        app = falcon.APIBuilder() \
+            .add_head_route('/', resource.on_head) \
+            .add_post_route('/', resource.on_post) \
+            .add_put_route('/', resource.on_put) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        for method in ('HEAD', 'POST', 'PUT'):
+            result = client.simulate_request(method=method)
+
+            content_type = 'x-falcon/peregrine'
+            assert result.headers['Content-Type'] == content_type
+            assert resource.resp.get_header('content-TyPe') == content_type
+
+            content_type_alt = 'x-falcon/merlin'
+            value = resource.resp.get_header('Content-Type', default=content_type_alt)
+            assert value == content_type
+
+            assert result.headers['Cache-Control'] == 'no-store'
+            assert result.headers['X-Auth-Token'] == 'toomanysecrets'
+
+            assert resource.resp.location is None
+            assert resource.resp.get_header('X-Header-Not-Set') is None
+            assert resource.resp.get_header('X-Header-Not-Set', 'Yes') == 'Yes'
+            assert resource.resp.get_header('X-Header-Not-Set', default='') == ''
+
+            value = resource.resp.get_header('X-Header-Not-Set', default=content_type_alt)
+            assert value == content_type_alt
+
+            # Check for duplicate headers
+            hist = defaultdict(int)
+            for name, value in result.headers.items():
+                hist[name] += 1
+                assert hist[name] == 1
+
+            # Ensure that deleted headers were not sent
+            assert resource.resp.get_header('x-client-should-never-see-this') is None
+
+    def test_response_append_header(self):
+        resource = AppendHeaderResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_head_route('/', resource.on_head) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        for method in ('HEAD', 'GET'):
+            result = client.simulate_request(method=method)
+            value = result.headers['x-things']
+            assert value == 'thing-1, thing-2, thing-3'
+
+        result = client.simulate_request(method='POST')
+        assert result.headers['x-things'] == 'thing-1'
+
+    def test_vary_star(self):
+        resource = VaryHeaderResource(['*'])
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.headers['vary'] == '*'
+
+    @pytest.mark.parametrize('vary,expected_value', [
+        (['accept-encoding'], 'accept-encoding'),
+        ([u'accept-encoding', 'x-auth-token'], 'accept-encoding, x-auth-token'),
+        (('accept-encoding', u'x-auth-token'), 'accept-encoding, x-auth-token'),
+    ])
+    def test_vary_header(self, vary, expected_value):
+        resource = VaryHeaderResource(vary)
+        self._check_header(falcon.APIBuilder(), resource, 'Vary', expected_value)
+
+    def test_content_type_no_body(self):
+        resource = testing.SimpleTestResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+
+        # NOTE(kgriffs): Even when there is no body, Content-Type
+        # should still be included per wsgiref.validate
+        assert 'Content-Type' in result.headers
+        assert result.headers['Content-Length'] == '0'
+
+    @pytest.mark.parametrize('status', (falcon.HTTP_204, falcon.HTTP_304))
+    def test_no_content_type(self, status):
+        resource = testing.SimpleTestResource(status=status)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert 'Content-Type' not in result.headers
+
+    def test_custom_content_type(self):
+
+        content_type = 'application/xml; charset=utf-8'
+        resource = XmlResource(content_type)
+        self._check_header(falcon.APIBuilder(), resource, 'Content-Type', content_type)
+
+    def test_add_link_single(self):
+
+        expected_value = '</things/2842>; rel=next'
+
+        resource = LinkHeaderResource()
+        resource.add_link('/things/2842', 'next')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_multiple(self):
+
+        expected_value = (
+            '</things/2842>; rel=next, ' +
+            '<http://%C3%A7runchy/bacon>; rel=contents, ' +
+            '<ab%C3%A7>; rel="http://example.com/ext-type", ' +
+            '<ab%C3%A7>; rel="http://example.com/%C3%A7runchy", ' +
+            '<ab%C3%A7>; rel="https://example.com/too-%C3%A7runchy", ' +
+            '</alt-thing>; rel="alternate http://example.com/%C3%A7runchy"')
+
+        uri = u'ab\u00e7' if six.PY3 else 'ab\xc3\xa7'
+
+        resource = LinkHeaderResource()
+        resource.add_link('/things/2842', 'next')
+        resource.add_link(u'http://\u00e7runchy/bacon', 'contents')
+        resource.add_link(uri, 'http://example.com/ext-type')
+        resource.add_link(uri, u'http://example.com/\u00e7runchy')
+        resource.add_link(uri, u'https://example.com/too-\u00e7runchy')
+        resource.add_link('/alt-thing',
+                          u'alternate http://example.com/\u00e7runchy')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_title(self):
+        expected_value = ('</related/thing>; rel=item; '
+                          'title="A related thing"')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'item',
+                          title='A related thing')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_title_star(self):
+        expected_value = ('</related/thing>; rel=item; '
+                          "title*=UTF-8''A%20related%20thing, "
+                          '</%C3%A7runchy/thing>; rel=item; '
+                          "title*=UTF-8'en'A%20%C3%A7runchy%20thing")
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'item',
+                          title_star=('', 'A related thing'))
+
+        resource.add_link(u'/\u00e7runchy/thing', 'item',
+                          title_star=('en', u'A \u00e7runchy thing'))
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_anchor(self):
+        expected_value = ('</related/thing>; rel=item; '
+                          'anchor="/some%20thing/or-other"')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'item',
+                          anchor='/some thing/or-other')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_hreflang(self):
+        expected_value = ('</related/thing>; rel=about; '
+                          'hreflang=en')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'about', hreflang='en')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_hreflang_multi(self):
+        expected_value = ('</related/thing>; rel=about; '
+                          'hreflang=en-GB; hreflang=de')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'about',
+                          hreflang=('en-GB', 'de'))
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_with_type_hint(self):
+        expected_value = ('</related/thing>; rel=alternate; '
+                          'type="video/mp4; codecs=avc1.640028"')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'alternate',
+                          type_hint='video/mp4; codecs=avc1.640028')
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_add_link_complex(self):
+        expected_value = ('</related/thing>; rel=alternate; '
+                          'title="A related thing"; '
+                          "title*=UTF-8'en'A%20%C3%A7runchy%20thing; "
+                          'type="application/json"; '
+                          'hreflang=en-GB; hreflang=de')
+
+        resource = LinkHeaderResource()
+        resource.add_link('/related/thing', 'alternate',
+                          title='A related thing',
+                          hreflang=('en-GB', 'de'),
+                          type_hint='application/json',
+                          title_star=('en', u'A \u00e7runchy thing'))
+
+        self._check_link_header(falcon.APIBuilder(), resource, expected_value)
+
+    def test_content_length_options(self):
+        app = falcon.APIBuilder().build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_options()
+
+        content_length = '0'
+        assert result.headers['Content-Length'] == content_length
+
+    # ----------------------------------------------------------------------
+    # Helpers
+    # ----------------------------------------------------------------------
+
+    def _check_link_header(self, app_builder, resource, expected_value):
+        self._check_header(app_builder, resource, 'Link', expected_value)
+
+    def _check_header(self, app_builder, resource, header, expected_value):
+        app = app_builder.add_get_route('/', resource.on_get).build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.headers[header] == expected_value

--- a/tests/test_hello_builder.py
+++ b/tests/test_hello_builder.py
@@ -1,0 +1,272 @@
+import io
+
+import pytest
+import six
+
+import falcon
+import falcon.testing as testing
+
+
+# NOTE(kgriffs): Concept from Gunicorn's source (wsgi.py)
+class FileWrapper(object):
+
+    def __init__(self, file_like, block_size=8192):
+        self.file_like = file_like
+        self.block_size = block_size
+
+    def __getitem__(self, key):
+        data = self.file_like.read(self.block_size)
+        if data:
+            return data
+
+        raise IndexError
+
+
+class HelloResource(object):
+    sample_status = '200 OK'
+    sample_unicode = (u'Hello World! \x80' +
+                      six.text_type(testing.rand_string(0, 0)))
+
+    sample_utf8 = sample_unicode.encode('utf-8')
+
+    def __init__(self, mode):
+        self.called = False
+        self.mode = mode
+
+    def on_get(self, req, resp):
+        self.called = True
+        self.req, self.resp = req, resp
+
+        resp.status = falcon.HTTP_200
+
+        if 'stream' in self.mode:
+            if 'filelike' in self.mode:
+                stream = io.BytesIO(self.sample_utf8)
+            else:
+                stream = [self.sample_utf8]
+
+            if 'stream_len' in self.mode:
+                stream_len = len(self.sample_utf8)
+            else:
+                stream_len = None
+
+            if 'use_helper' in self.mode:
+                resp.set_stream(stream, stream_len)
+            else:
+                resp.stream = stream
+                resp.stream_len = stream_len
+
+        if 'body' in self.mode:
+            if 'bytes' in self.mode:
+                resp.body = self.sample_utf8
+            else:
+                resp.body = self.sample_unicode
+
+        if 'data' in self.mode:
+            resp.data = self.sample_utf8
+
+    def on_head(self, req, resp):
+        self.on_get(req, resp)
+
+
+class ClosingBytesIO(io.BytesIO):
+
+    close_called = False
+
+    def close(self):
+        super(ClosingBytesIO, self).close()
+        self.close_called = True
+
+
+class NonClosingBytesIO(io.BytesIO):
+
+    # Not callable; test that CloseableStreamIterator ignores it
+    close = False
+
+
+class ClosingFilelikeHelloResource(object):
+    sample_status = '200 OK'
+    sample_unicode = (u'Hello World! \x80' +
+                      six.text_type(testing.rand_string(0, 0)))
+
+    sample_utf8 = sample_unicode.encode('utf-8')
+
+    def __init__(self, stream_factory):
+        self.called = False
+        self.stream = stream_factory(self.sample_utf8)
+        self.stream_len = len(self.sample_utf8)
+
+    def on_get(self, req, resp):
+        self.called = True
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_200
+        resp.set_stream(self.stream, self.stream_len)
+
+
+class NoStatusResource(object):
+    def on_get(self, req, resp):
+        pass
+
+
+class TestHelloWorld(object):
+
+    def test_env_headers_list_of_tuples(self):
+        env = testing.create_environ(headers=[('User-Agent', 'Falcon-Test')])
+        assert env['HTTP_USER_AGENT'] == 'Falcon-Test'
+
+    def test_root_route(self):
+        app = falcon.API()
+        client = testing.TestClient(app)
+
+        doc = {u'message': u'Hello world!'}
+        resource = testing.SimpleTestResource(json=doc)
+        client.app.add_route('/', resource)
+
+        result = client.simulate_get()
+        assert result.json == doc
+
+    def test_no_route(self):
+        app = falcon.API()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/seenoevil')
+        assert result.status_code == 404
+
+    @pytest.mark.parametrize('path,resource,get_body', [
+        ('/body', HelloResource('body'), lambda r: r.body.encode('utf-8')),
+        ('/bytes', HelloResource('body, bytes'), lambda r: r.body),
+        ('/data', HelloResource('data'), lambda r: r.data),
+    ])
+    def test_body(self, path, resource, get_body):
+        app = falcon.APIBuilder() \
+            .add_get_route(path, resource.on_get) \
+            .add_head_route(path, resource.on_head) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get(path)
+        resp = resource.resp
+
+        content_length = int(result.headers['content-length'])
+        assert content_length == len(resource.sample_utf8)
+
+        assert result.status == resource.sample_status
+        assert resp.status == resource.sample_status
+        assert get_body(resp) == resource.sample_utf8
+        assert result.content == resource.sample_utf8
+
+    def test_no_body_on_head(self):
+        resource = HelloResource('body')
+        app = falcon.APIBuilder() \
+            .add_head_route('/body', resource.on_head) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_head('/body')
+
+        assert not result.content
+        assert result.status_code == 200
+
+    def test_stream_chunked(self):
+        resource = HelloResource('stream')
+        app = falcon.APIBuilder() \
+            .add_get_route('/chunked-stream', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/chunked-stream')
+
+        assert result.content == resource.sample_utf8
+        assert 'content-length' not in result.headers
+
+    def test_stream_known_len(self):
+        resource = HelloResource('stream, stream_len')
+        app = falcon.APIBuilder() \
+            .add_get_route('/stream', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/stream')
+        assert resource.called
+
+        expected_len = resource.resp.stream_len
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+        assert result.content == resource.sample_utf8
+
+    def test_filelike(self):
+        resource = HelloResource('stream, stream_len, filelike')
+        app = falcon.APIBuilder() \
+            .add_get_route('/filelike', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        for file_wrapper in (None, FileWrapper):
+            result = client.simulate_get('/filelike', file_wrapper=file_wrapper)
+            assert resource.called
+
+            expected_len = resource.resp.stream_len
+            actual_len = int(result.headers['content-length'])
+            assert actual_len == expected_len
+            assert len(result.content) == expected_len
+
+        for file_wrapper in (None, FileWrapper):
+            result = client.simulate_get('/filelike', file_wrapper=file_wrapper)
+            assert resource.called
+
+            expected_len = resource.resp.stream_len
+            actual_len = int(result.headers['content-length'])
+            assert actual_len == expected_len
+            assert len(result.content) == expected_len
+
+    @pytest.mark.parametrize('stream_factory,assert_closed', [
+        (ClosingBytesIO, True),  # Implements close()
+        (NonClosingBytesIO, False),  # Has a non-callable "close" attr
+    ])
+    def test_filelike_closing(self, stream_factory, assert_closed):
+        resource = ClosingFilelikeHelloResource(stream_factory)
+        app = falcon.APIBuilder() \
+            .add_get_route('/filelike-closing', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/filelike-closing', file_wrapper=None)
+        assert resource.called
+
+        expected_len = resource.resp.stream_len
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+        if assert_closed:
+            assert resource.stream.close_called
+
+    def test_filelike_using_helper(self):
+        resource = HelloResource('stream, stream_len, filelike, use_helper')
+        app = falcon.APIBuilder() \
+            .add_get_route('/filelike-helper', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/filelike-helper')
+        assert resource.called
+
+        expected_len = resource.resp.stream_len
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+    def test_status_not_set(self):
+        resource = NoStatusResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/nostatus', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get('/nostatus')
+
+        assert not result.content
+        assert result.status_code == 200

--- a/tests/test_hello_builder.py
+++ b/tests/test_hello_builder.py
@@ -115,18 +115,18 @@ class TestHelloWorld(object):
         assert env['HTTP_USER_AGENT'] == 'Falcon-Test'
 
     def test_root_route(self):
-        app = falcon.API()
-        client = testing.TestClient(app)
-
         doc = {u'message': u'Hello world!'}
         resource = testing.SimpleTestResource(json=doc)
-        client.app.add_route('/', resource)
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
 
         result = client.simulate_get()
         assert result.json == doc
 
     def test_no_route(self):
-        app = falcon.API()
+        app = falcon.APIBuilder().build()
         client = testing.TestClient(app)
 
         result = client.simulate_get('/seenoevil')

--- a/tests/test_http_method_routing_builder.py
+++ b/tests/test_http_method_routing_builder.py
@@ -1,0 +1,282 @@
+from functools import wraps
+
+import pytest
+
+import falcon
+import falcon.testing as testing
+
+HTTP_METHODS = (
+    'CONNECT',
+    'DELETE',
+    'GET',
+    'HEAD',
+    'OPTIONS',
+    'POST',
+    'PUT',
+    'TRACE',
+    'PATCH'
+)
+
+
+WEBDAV_METHODS = (
+    'CHECKIN',
+    'CHECKOUT',
+    'REPORT',
+    'UNCHECKIN',
+    'UPDATE',
+    'VERSION-CONTROL',
+)
+
+
+@pytest.fixture
+def resource_things():
+    return ThingsResource()
+
+
+@pytest.fixture
+def resource_misc():
+    return MiscResource()
+
+
+@pytest.fixture
+def resource_get_with_faulty_put():
+    return GetWithFaultyPutResource()
+
+
+class ThingsResource(object):
+    def __init__(self):
+        self.called = False
+
+        # Test non-callable attribute
+        self.on_patch = {}
+
+    # Field names ordered differently than in uri template
+    def on_get(self, req, resp, sid, id):
+        self.called = True
+
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_204
+
+    # Field names ordered the same as in uri template
+    def on_head(self, req, resp, id, sid):
+        self.called = True
+
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_204
+
+    def on_put(self, req, resp, id, sid):
+        self.called = True
+
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_201
+
+    def on_report(self, req, resp, id, sid):
+        self.called = True
+
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_204
+
+
+def capture(func):
+    @wraps(func)
+    def with_capture(*args, **kwargs):
+        self = args[0]
+        self.called = True
+        self.req, self.resp = args[1:]
+        func(*args, **kwargs)
+
+    return with_capture
+
+
+def selfless_decorator(func):
+    def faulty(req, resp, foo, bar):
+        pass
+
+    return faulty
+
+
+class MiscResource(object):
+    def __init__(self):
+        self.called = False
+
+    @capture
+    def on_get(self, req, resp):
+        resp.status = falcon.HTTP_204
+
+    @capture
+    def on_head(self, req, resp):
+        resp.status = falcon.HTTP_204
+
+    @capture
+    def on_put(self, req, resp):
+        resp.status = falcon.HTTP_400
+
+    @capture
+    def on_patch(self, req, resp):
+        pass
+
+    def on_options(self, req, resp):
+        # NOTE(kgriffs): The default responder returns 200
+        resp.status = falcon.HTTP_204
+
+        # NOTE(kgriffs): This is incorrect, but only return GET so
+        # that we can verify that the default OPTIONS responder has
+        # been overridden.
+        resp.set_header('allow', 'GET')
+
+
+class GetWithFaultyPutResource(object):
+    def __init__(self):
+        self.called = False
+
+    @capture
+    def on_get(self, req, resp):
+        resp.status = falcon.HTTP_204
+
+    def on_put(self, req, resp, param):
+        raise TypeError()
+
+
+class FaultyDecoratedResource(object):
+
+    @selfless_decorator
+    def on_get(self, req, resp):
+        pass
+
+
+class TestHttpMethodRouting(object):
+
+    def test_get(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_get_route('/things/{id}/stuff/{sid}', resource_things.on_get) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things/42/stuff/57')
+        assert response.status == falcon.HTTP_204
+        assert resource_things.called
+
+    def test_put(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_put_route('/things/{id}/stuff/{sid}', resource_things.on_put) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things/42/stuff/1337', method='PUT')
+        assert response.status == falcon.HTTP_201
+        assert resource_things.called
+
+    def test_post_not_allowed(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_get_route('/things/{id}/stuff/{sid}', resource_things.on_get) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things/42/stuff/1337', method='POST')
+        assert response.status == falcon.HTTP_405
+        assert not resource_things.called
+
+    def test_report(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_method_route('REPORT', '/things/{id}/stuff/{sid}', resource_things.on_report) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things/42/stuff/1337', method='REPORT')
+        assert response.status == falcon.HTTP_204
+        assert resource_things.called
+
+    def test_misc(self, resource_misc):
+        app = falcon.APIBuilder() \
+            .add_get_route('/misc', resource_misc.on_get) \
+            .add_head_route('/misc', resource_misc.on_head) \
+            .add_put_route('/misc', resource_misc.on_put) \
+            .add_patch_route('/misc', resource_misc.on_patch) \
+            .build()
+        client = testing.TestClient(app)
+        for method in ['GET', 'HEAD', 'PUT', 'PATCH']:
+            resource_misc.called = False
+            client.simulate_request(path='/misc', method=method)
+            assert resource_misc.called
+            assert resource_misc.req.method == method
+
+    def test_resource_not_found(self):
+        app = falcon.APIBuilder().build()
+        client = testing.TestClient(app)
+        for method in ['GET', 'HEAD', 'PUT', 'PATCH']:
+            response = client.simulate_request(path='/stonewall', method=method)
+            assert response.status == falcon.HTTP_404
+
+    def test_methods_not_allowed_complex(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_get_route('/things/{id}/stuff/{sid}', resource_things.on_get) \
+            .add_put_route('/things/{id}/stuff/{sid}', resource_things.on_put) \
+            .build()
+        client = testing.TestClient(app)
+        for method in HTTP_METHODS + WEBDAV_METHODS:
+            if method in ('GET', 'PUT', 'OPTIONS'):
+                continue
+
+            resource_things.called = False
+            response = client.simulate_request(path='/things/84/stuff/65', method=method)
+
+            assert not resource_things.called
+            assert response.status == falcon.HTTP_405
+
+            headers = response.headers
+            assert headers['allow'] == 'GET, PUT, OPTIONS'
+
+    def test_method_not_allowed_with_param(self, resource_get_with_faulty_put):
+        app = falcon.APIBuilder() \
+            .add_get_route('/get_with_param/{param}', resource_get_with_faulty_put.on_get) \
+            .add_put_route('/get_with_param/{param}', resource_get_with_faulty_put.on_put) \
+            .build()
+        client = testing.TestClient(app)
+        for method in HTTP_METHODS + WEBDAV_METHODS:
+            if method in ('GET', 'PUT', 'OPTIONS'):
+                continue
+
+            resource_get_with_faulty_put.called = False
+            response = client.simulate_request(
+                method=method,
+                path='/get_with_param/bogus_param',
+            )
+
+            assert not resource_get_with_faulty_put.called
+            assert response.status == falcon.HTTP_405
+
+            headers = response.headers
+            assert headers['allow'] == 'GET, PUT, OPTIONS'
+
+    def test_default_on_options(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_get_route('/things/{id}/stuff/{sid}', resource_things.on_get) \
+            .add_put_route('/things/{id}/stuff/{sid}', resource_things.on_put) \
+            .add_head_route('/things/{id}/stuff/{sid}', resource_things.on_head) \
+            .add_method_route('REPORT', '/things/{id}/stuff/{sid}', resource_things.on_report) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things/84/stuff/65', method='OPTIONS')
+        assert response.status == falcon.HTTP_200
+
+        headers = response.headers
+        assert headers['allow'] == 'GET, HEAD, PUT, REPORT'
+
+    def test_on_options(self, resource_misc):
+        app = falcon.APIBuilder() \
+            .add_options_route('/misc', resource_misc.on_options) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/misc', method='OPTIONS')
+        assert response.status == falcon.HTTP_204
+
+        headers = response.headers
+        assert headers['allow'] == 'GET'
+
+    def test_bogus_method(self, resource_things):
+        app = falcon.APIBuilder() \
+            .add_get_route('/things', resource_things.on_get) \
+            .add_put_route('/things', resource_things.on_put) \
+            .add_head_route('/things', resource_things.on_head) \
+            .add_method_route('REPORT', '/things', resource_things.on_report) \
+            .build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/things', method='SETECASTRONOMY')
+        assert not resource_things.called
+        assert response.status == falcon.HTTP_400

--- a/tests/test_httperror_builder.py
+++ b/tests/test_httperror_builder.py
@@ -1,0 +1,1109 @@
+# -*- coding: utf-8
+
+import datetime
+import xml.etree.ElementTree as et  # noqa: I202
+
+import pytest
+import yaml
+
+import falcon
+import falcon.testing as testing
+from falcon.util import json
+
+
+class FaultyResource:
+
+    def on_get(self, req, resp):
+        status = req.get_header('X-Error-Status')
+        title = req.get_header('X-Error-Title')
+        description = req.get_header('X-Error-Description')
+        code = 10042
+
+        raise falcon.HTTPError(status, title, description, code=code)
+
+    def on_post(self, req, resp):
+        raise falcon.HTTPForbidden(
+            'Request denied',
+            'You do not have write permissions for this queue.',
+            href='http://example.com/api/rbac')
+
+    def on_put(self, req, resp):
+        raise falcon.HTTPError(
+            falcon.HTTP_792,
+            'Internet crashed',
+            'Catastrophic weather event due to climate change.',
+            href='http://example.com/api/climate',
+            href_text='Drill baby drill!',
+            code=8733224)
+
+    def on_patch(self, req, resp):
+        raise falcon.HTTPError(falcon.HTTP_400)
+
+
+class UnicodeFaultyResource(object):
+
+    def __init__(self):
+        self.called = False
+
+    def on_get(self, req, resp):
+        self.called = True
+        raise falcon.HTTPError(
+            falcon.HTTP_792,
+            u'Internet \xe7rashed!',
+            u'\xc7atastrophic weather event',
+            href=u'http://example.com/api/\xe7limate',
+            href_text=u'Drill b\xe1by drill!')
+
+
+class MiscErrorsResource:
+
+    def __init__(self, exception, needs_title):
+        self.needs_title = needs_title
+        self._exception = exception
+
+    def on_get(self, req, resp):
+        if self.needs_title:
+            raise self._exception('Excuse Us', 'Something went boink!')
+        else:
+            raise self._exception('Something went boink!')
+
+
+class UnauthorizedResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPUnauthorized('Authentication Required',
+                                      'Missing or invalid authorization.',
+                                      ['Basic realm="simple"'])
+
+    def on_post(self, req, resp):
+        raise falcon.HTTPUnauthorized('Authentication Required',
+                                      'Missing or invalid authorization.',
+                                      ['Newauth realm="apps"',
+                                       'Basic realm="simple"'])
+
+    def on_put(self, req, resp):
+        raise falcon.HTTPUnauthorized('Authentication Required',
+                                      'Missing or invalid authorization.', [])
+
+
+class NotFoundResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPNotFound()
+
+
+class NotFoundResourceWithBody:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPNotFound(description='Not Found')
+
+
+class GoneResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPGone()
+
+
+class GoneResourceWithBody:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPGone(description='Gone with the wind')
+
+
+class MethodNotAllowedResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMethodNotAllowed(['PUT'])
+
+
+class MethodNotAllowedResourceWithHeaders:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMethodNotAllowed(['PUT'],
+                                          headers={
+                                              'x-ping': 'pong'})
+
+
+class MethodNotAllowedResourceWithHeadersWithAccept:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMethodNotAllowed(['PUT'],
+                                          headers={
+                                              'x-ping': 'pong',
+                                              'accept': 'GET,PUT'})
+
+
+class MethodNotAllowedResourceWithBody:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMethodNotAllowed(['PUT'],
+                                          description='Not Allowed')
+
+
+class LengthRequiredResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPLengthRequired('title', 'description')
+
+
+class RequestEntityTooLongResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPPayloadTooLarge('Request Rejected',
+                                         'Request Body Too Large')
+
+
+class TemporaryRequestEntityTooLongResource:
+
+    def __init__(self, retry_after):
+        self.retry_after = retry_after
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPPayloadTooLarge('Request Rejected',
+                                         'Request Body Too Large',
+                                         retry_after=self.retry_after)
+
+
+class UriTooLongResource:
+
+    def __init__(self, title=None, description=None, code=None):
+        self.title = title
+        self.description = description
+        self.code = code
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPUriTooLong(self.title,
+                                    self.description,
+                                    code=self.code)
+
+
+class RangeNotSatisfiableResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPRangeNotSatisfiable(123456)
+
+
+class TooManyRequestsResource:
+
+    def __init__(self, retry_after=None):
+        self.retry_after = retry_after
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPTooManyRequests('Too many requests',
+                                         '1 per minute',
+                                         retry_after=self.retry_after)
+
+
+class ServiceUnavailableResource:
+
+    def __init__(self, retry_after):
+        self.retry_after = retry_after
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPServiceUnavailable('Oops',
+                                            'Stand by...',
+                                            retry_after=self.retry_after)
+
+
+class InvalidHeaderResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPInvalidHeader(
+            'Please provide a valid token.', 'X-Auth-Token',
+            code='A1001')
+
+
+class MissingHeaderResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMissingHeader('X-Auth-Token')
+
+
+class InvalidParamResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPInvalidParam(
+            'The value must be a hex-encoded UUID.', 'id',
+            code='P1002')
+
+
+class MissingParamResource:
+
+    def on_get(self, req, resp):
+        raise falcon.HTTPMissingParam('id', code='P1003')
+
+
+class TestHTTPError(object):
+
+    def _misc_test(self, exception, status, needs_title=True):
+        resource = FaultyResource()
+        misc_resource = MiscErrorsResource(exception, needs_title)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .add_get_route('/misc', misc_resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/misc')
+        assert response.status == status
+
+    def test_base_class(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        headers = {
+            'X-Error-Title': 'Storage service down',
+            'X-Error-Description': ('The configured storage service is not '
+                                    'responding to requests. Please contact '
+                                    'your service provider.'),
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        expected_body = {
+            'title': 'Storage service down',
+            'description': ('The configured storage service is not '
+                            'responding to requests. Please contact '
+                            'your service provider.'),
+            'code': 10042,
+        }
+
+        # Try it with Accept: */*
+        headers['Accept'] = '*/*'
+        response = client.simulate_request(path='/fail', headers=headers)
+
+        assert response.status == headers['X-Error-Status']
+        assert response.headers['vary'] == 'Accept'
+        assert expected_body == response.json
+
+        # Now try it with application/json
+        headers['Accept'] = 'application/json'
+        response = client.simulate_request(path='/fail', headers=headers)
+
+        assert response.status == headers['X-Error-Status']
+        assert response.json == expected_body
+
+    def test_no_description_json(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_patch_route('/fail', resource.on_patch) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_patch('/fail')
+        assert response.status == falcon.HTTP_400
+        assert response.json == {'title': '400 Bad Request'}
+
+    def test_no_description_xml(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_patch_route('/fail', resource.on_patch) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_patch(
+            path='/fail', headers={'Accept': 'application/xml'}
+        )
+        assert response.status == falcon.HTTP_400
+
+        expected_xml = (b'<?xml version="1.0" encoding="UTF-8"?><error>'
+                        b'<title>400 Bad Request</title></error>')
+
+        assert response.content == expected_xml
+
+    def test_client_does_not_accept_json_or_xml(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'Accept': 'application/x-yaml',
+            'X-Error-Title': 'Storage service down',
+            'X-Error-Description': ('The configured storage service is not '
+                                    'responding to requests. Please contact '
+                                    'your service provider'),
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        response = client.simulate_request(path='/fail', headers=headers)
+        assert response.status == headers['X-Error-Status']
+        assert response.headers['Vary'] == 'Accept'
+        assert not response.content
+
+    def test_custom_old_error_serializer(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'X-Error-Title': 'Storage service down',
+            'X-Error-Description': ('The configured storage service is not '
+                                    'responding to requests. Please contact '
+                                    'your service provider'),
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        expected_doc = {
+            'code': 10042,
+            'description': ('The configured storage service is not '
+                            'responding to requests. Please contact '
+                            'your service provider'),
+            'title': 'Storage service down'
+        }
+
+        def _my_serializer(req, exception):
+            representation = None
+
+            preferred = req.client_prefers(('application/x-yaml',
+                                            'application/json'))
+
+            if preferred is not None:
+                if preferred == 'application/json':
+                    representation = exception.to_json()
+                else:
+                    representation = yaml.dump(exception.to_dict(),
+                                               encoding=None)
+
+            return (preferred, representation)
+
+        def _check(media_type, deserializer):
+            headers['Accept'] = media_type
+            client.app.set_error_serializer(_my_serializer)
+            response = client.simulate_request(path='/fail', headers=headers)
+            assert response.status == headers['X-Error-Status']
+
+            actual_doc = deserializer(response.content.decode('utf-8'))
+            assert expected_doc == actual_doc
+
+        _check('application/x-yaml', yaml.load)
+        _check('application/json', json.loads)
+
+    def test_custom_old_error_serializer_no_body(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        def _my_serializer(req, exception):
+            return None, None
+
+        client.app.set_error_serializer(_my_serializer)
+        client.simulate_request(path='/fail', headers=headers)
+
+    def test_custom_new_error_serializer(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'X-Error-Title': 'Storage service down',
+            'X-Error-Description': ('The configured storage service is not '
+                                    'responding to requests. Please contact '
+                                    'your service provider'),
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        expected_doc = {
+            'code': 10042,
+            'description': ('The configured storage service is not '
+                            'responding to requests. Please contact '
+                            'your service provider'),
+            'title': 'Storage service down'
+        }
+
+        def _my_serializer(req, resp, exception):
+            representation = None
+
+            preferred = req.client_prefers(('application/x-yaml',
+                                            'application/json'))
+
+            if preferred is not None:
+                if preferred == 'application/json':
+                    representation = exception.to_json()
+                else:
+                    representation = yaml.dump(exception.to_dict(),
+                                               encoding=None)
+
+                resp.body = representation
+                resp.content_type = preferred
+
+        def _check(media_type, deserializer):
+            headers['Accept'] = media_type
+            client.app.set_error_serializer(_my_serializer)
+            response = client.simulate_request(path='/fail', headers=headers)
+            assert response.status == headers['X-Error-Status']
+
+            actual_doc = deserializer(response.content.decode('utf-8'))
+            assert expected_doc == actual_doc
+
+        _check('application/x-yaml', yaml.load)
+        _check('application/json', json.loads)
+
+    def test_client_does_not_accept_anything(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'Accept': '45087gigo;;;;',
+            'X-Error-Title': 'Storage service down',
+            'X-Error-Description': ('The configured storage service is not '
+                                    'responding to requests. Please contact '
+                                    'your service provider'),
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        response = client.simulate_request(path='/fail', headers=headers)
+        assert response.status == headers['X-Error-Status']
+        assert not response.content
+
+    @pytest.mark.parametrize('media_type', [
+        'application/json',
+        'application/vnd.company.system.project.resource+json;v=1.1',
+        'application/json-patch+json',
+    ])
+    def test_forbidden(self, media_type):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_post_route('/fail', resource.on_post) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {'Accept': media_type}
+
+        expected_body = {
+            'title': 'Request denied',
+            'description': ('You do not have write permissions for this '
+                            'queue.'),
+            'link': {
+                'text': 'Documentation related to this error',
+                'href': 'http://example.com/api/rbac',
+                'rel': 'help',
+            },
+        }
+
+        response = client.simulate_post(path='/fail', headers=headers)
+
+        assert response.status == falcon.HTTP_403
+        assert response.json == expected_body
+
+    def test_epic_fail_json(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_put_route('/fail', resource.on_put) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {'Accept': 'application/json'}
+
+        expected_body = {
+            'title': 'Internet crashed',
+            'description': 'Catastrophic weather event due to climate change.',
+            'code': 8733224,
+            'link': {
+                'text': 'Drill baby drill!',
+                'href': 'http://example.com/api/climate',
+                'rel': 'help',
+            },
+        }
+
+        response = client.simulate_put('/fail', headers=headers)
+
+        assert response.status == falcon.HTTP_792
+        assert response.json == expected_body
+
+    @pytest.mark.parametrize('media_type', [
+        'text/xml',
+        'application/xml',
+        'application/vnd.company.system.project.resource+xml;v=1.1',
+        'application/atom+xml',
+    ])
+    def test_epic_fail_xml(self, media_type):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_put_route('/fail', resource.on_put) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {'Accept': media_type}
+
+        expected_body = ('<?xml version="1.0" encoding="UTF-8"?>' +
+                         '<error>' +
+                         '<title>Internet crashed</title>' +
+                         '<description>' +
+                         'Catastrophic weather event due to climate change.' +
+                         '</description>' +
+                         '<code>8733224</code>' +
+                         '<link>' +
+                         '<text>Drill baby drill!</text>' +
+                         '<href>http://example.com/api/climate</href>' +
+                         '<rel>help</rel>' +
+                         '</link>' +
+                         '</error>')
+
+        response = client.simulate_put(path='/fail', headers=headers)
+
+        assert response.status == falcon.HTTP_792
+        try:
+            et.fromstring(response.content.decode('utf-8'))
+        except ValueError:
+            pytest.fail()
+        assert response.text == expected_body
+
+    def test_unicode_json(self):
+        unicode_resource = UnicodeFaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/unicode', unicode_resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        expected_body = {
+            'title': u'Internet \xe7rashed!',
+            'description': u'\xc7atastrophic weather event',
+            'link': {
+                'text': u'Drill b\xe1by drill!',
+                'href': 'http://example.com/api/%C3%A7limate',
+                'rel': 'help',
+            },
+        }
+
+        response = client.simulate_request(path='/unicode')
+
+        assert unicode_resource.called
+        assert response.status == falcon.HTTP_792
+        assert expected_body == response.json
+
+    def test_unicode_xml(self):
+        unicode_resource = UnicodeFaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/unicode', unicode_resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        expected_body = (u'<?xml version="1.0" encoding="UTF-8"?>' +
+                         u'<error>' +
+                         u'<title>Internet çrashed!</title>' +
+                         u'<description>' +
+                         u'Çatastrophic weather event' +
+                         u'</description>' +
+                         u'<link>' +
+                         u'<text>Drill báby drill!</text>' +
+                         u'<href>http://example.com/api/%C3%A7limate</href>' +
+                         u'<rel>help</rel>' +
+                         u'</link>' +
+                         u'</error>')
+
+        response = client.simulate_request(
+            path='/unicode',
+            headers={'accept': 'application/xml'}
+        )
+
+        assert unicode_resource.called
+        assert response.status == falcon.HTTP_792
+        assert expected_body == response.text
+
+    def test_401(self):
+        resource = UnauthorizedResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/401', resource.on_get) \
+            .add_put_route('/401', resource.on_put) \
+            .add_post_route('/401', resource.on_post) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/401')
+
+        assert response.status == falcon.HTTP_401
+        assert response.headers['www-authenticate'] == 'Basic realm="simple"'
+
+        response = client.simulate_post('/401')
+
+        assert response.status == falcon.HTTP_401
+        assert response.headers['www-authenticate'] == 'Newauth realm="apps", Basic realm="simple"'
+
+        response = client.simulate_put('/401')
+
+        assert response.status == falcon.HTTP_401
+        assert 'www-authenticate' not in response.headers
+
+    def test_404_without_body(self):
+        resource = NotFoundResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/404', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/404')
+
+        assert response.status == falcon.HTTP_404
+        assert not response.content
+
+    def test_404_with_body(self):
+        resource = NotFoundResourceWithBody()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/404', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/404')
+        assert response.status == falcon.HTTP_404
+        assert response.content
+        expected_body = {
+            u'title': u'404 Not Found',
+            u'description': u'Not Found'
+        }
+        assert response.json == expected_body
+
+    def test_405_without_body(self):
+        resource = MethodNotAllowedResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/405', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/405')
+        assert response.status == falcon.HTTP_405
+        assert not response.content
+        assert response.headers['allow'] == 'PUT'
+
+    def test_405_without_body_with_extra_headers(self):
+        resource = MethodNotAllowedResourceWithHeaders()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/405', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/405')
+        assert response.status == falcon.HTTP_405
+        assert not response.content
+        assert response.headers['allow'] == 'PUT'
+        assert response.headers['x-ping'] == 'pong'
+
+    def test_405_without_body_with_extra_headers_double_check(self):
+        resource = MethodNotAllowedResourceWithHeadersWithAccept()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/405/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/405')
+        assert response.status == falcon.HTTP_405
+        assert not response.content
+        assert response.headers['allow'] == 'PUT'
+        assert response.headers['allow'] != 'GET,PUT'
+        assert response.headers['allow'] != 'GET'
+        assert response.headers['x-ping'] == 'pong'
+
+    def test_405_with_body(self):
+        resource = MethodNotAllowedResourceWithBody()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/405', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/405')
+        assert response.status == falcon.HTTP_405
+        assert response.content
+        expected_body = {
+            u'title': u'405 Method Not Allowed',
+            u'description': u'Not Allowed'
+        }
+        assert response.json == expected_body
+        assert response.headers['allow'] == 'PUT'
+
+    def test_410_without_body(self):
+        resource = GoneResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/410', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/410')
+
+        assert response.status == falcon.HTTP_410
+        assert not response.content
+
+    def test_410_with_body(self):
+        resource = GoneResourceWithBody()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/410', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/410')
+        assert response.status == falcon.HTTP_410
+        assert response.content
+        expected_body = {
+            u'title': u'410 Gone',
+            u'description': u'Gone with the wind'
+        }
+        assert response.json == expected_body
+
+    def test_411(self):
+        resource = LengthRequiredResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/411', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/411')
+        assert response.status == falcon.HTTP_411
+
+        parsed_body = response.json
+        assert parsed_body['title'] == 'title'
+        assert parsed_body['description'] == 'description'
+
+    def test_413(self):
+        resource = RequestEntityTooLongResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/413', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/413')
+        assert response.status == falcon.HTTP_413
+
+        parsed_body = response.json
+        assert parsed_body['title'] == 'Request Rejected'
+        assert parsed_body['description'] == 'Request Body Too Large'
+        assert 'retry-after' not in response.headers
+
+    def test_temporary_413_integer_retry_after(self):
+        resource = TemporaryRequestEntityTooLongResource('6')
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/413', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/413')
+        assert response.status == falcon.HTTP_413
+
+        parsed_body = response.json
+        assert parsed_body['title'] == 'Request Rejected'
+        assert parsed_body['description'] == 'Request Body Too Large'
+        assert response.headers['retry-after'] == '6'
+
+    def test_temporary_413_datetime_retry_after(self):
+        date = datetime.datetime.now() + datetime.timedelta(minutes=5)
+        resource = TemporaryRequestEntityTooLongResource(date)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/413', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/413')
+
+        assert response.status == falcon.HTTP_413
+
+        parsed_body = response.json
+        assert parsed_body['title'] == 'Request Rejected'
+        assert parsed_body['description'] == 'Request Body Too Large'
+        assert response.headers['retry-after'] == falcon.util.dt_to_http(date)
+
+    def test_414(self):
+        resource = UriTooLongResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/414', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/414')
+        assert response.status == falcon.HTTP_414
+
+    def test_414_with_title(self):
+        title = 'Argh! Error!'
+        resource = UriTooLongResource(title=title)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/414', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/414', headers={})
+        parsed_body = json.loads(response.content.decode())
+        assert parsed_body['title'] == title
+
+    def test_414_with_description(self):
+        description = 'Be short please.'
+        resource = UriTooLongResource(description=description)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/414', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/414', headers={})
+        parsed_body = json.loads(response.content.decode())
+        assert parsed_body['description'] == description
+
+    def test_414_with_custom_kwargs(self):
+        code = 'someid'
+        resource = UriTooLongResource(code=code)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/414', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/414', headers={})
+        parsed_body = json.loads(response.content.decode())
+        assert parsed_body['code'] == code
+
+    def test_416(self):
+        resource = RangeNotSatisfiableResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/416', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/416', headers={'accept': 'text/xml'})
+
+        assert response.status == falcon.HTTP_416
+        assert not response.content
+        assert response.headers['content-range'] == 'bytes */123456'
+        assert response.headers['content-length'] == '0'
+
+    def test_429_no_retry_after(self):
+        resource = TooManyRequestsResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/429', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/429')
+        parsed_body = response.json
+
+        assert response.status == falcon.HTTP_429
+        assert parsed_body['title'] == 'Too many requests'
+        assert parsed_body['description'] == '1 per minute'
+        assert 'retry-after' not in response.headers
+
+    def test_429(self):
+        resource = TooManyRequestsResource(60)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/429', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/429')
+        parsed_body = response.json
+
+        assert response.status == falcon.HTTP_429
+        assert parsed_body['title'] == 'Too many requests'
+        assert parsed_body['description'] == '1 per minute'
+        assert response.headers['retry-after'] == '60'
+
+    def test_429_datetime(self):
+        date = datetime.datetime.now() + datetime.timedelta(minutes=1)
+        resource = TooManyRequestsResource(date)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/429', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/429')
+        parsed_body = response.json
+
+        assert response.status == falcon.HTTP_429
+        assert parsed_body['title'] == 'Too many requests'
+        assert parsed_body['description'] == '1 per minute'
+        assert response.headers['retry-after'] == falcon.util.dt_to_http(date)
+
+    def test_503_integer_retry_after(self):
+        resource = ServiceUnavailableResource(60)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/503', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/503')
+
+        expected_body = {
+            u'title': u'Oops',
+            u'description': u'Stand by...',
+        }
+
+        assert response.status == falcon.HTTP_503
+        assert response.json == expected_body
+        assert response.headers['retry-after'] == '60'
+
+    def test_503_datetime_retry_after(self):
+        date = datetime.datetime.now() + datetime.timedelta(minutes=5)
+        resource = ServiceUnavailableResource(date)
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/503', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/503')
+
+        expected_body = {
+            u'title': u'Oops',
+            u'description': u'Stand by...',
+        }
+
+        assert response.status == falcon.HTTP_503
+        assert response.json == expected_body
+        assert response.headers['retry-after'] == falcon.util.dt_to_http(date)
+
+    def test_invalid_header(self):
+        resource = InvalidHeaderResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/400', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/400')
+
+        expected_desc = (u'The value provided for the X-Auth-Token '
+                         u'header is invalid. Please provide a valid token.')
+
+        expected_body = {
+            u'title': u'Invalid header value',
+            u'description': expected_desc,
+            u'code': u'A1001',
+        }
+
+        assert response.status == falcon.HTTP_400
+        assert response.json == expected_body
+
+    def test_missing_header(self):
+        resource = MissingHeaderResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/400', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/400')
+
+        expected_body = {
+            u'title': u'Missing header value',
+            u'description': u'The X-Auth-Token header is required.',
+        }
+
+        assert response.status == falcon.HTTP_400
+        assert response.json == expected_body
+
+    def test_invalid_param(self):
+        resource = InvalidParamResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/400', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/400')
+
+        expected_desc = (u'The "id" parameter is invalid. The '
+                         u'value must be a hex-encoded UUID.')
+        expected_body = {
+            u'title': u'Invalid parameter',
+            u'description': expected_desc,
+            u'code': u'P1002',
+        }
+
+        assert response.status == falcon.HTTP_400
+        assert response.json == expected_body
+
+    def test_missing_param(self):
+        resource = MissingParamResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/400', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/400')
+
+        expected_body = {
+            u'title': u'Missing parameter',
+            u'description': u'The "id" parameter is required.',
+            u'code': u'P1003',
+        }
+
+        assert response.status == falcon.HTTP_400
+        assert response.json == expected_body
+
+    def test_misc(self):
+
+        self._misc_test(falcon.HTTPBadRequest, falcon.HTTP_400)
+        self._misc_test(falcon.HTTPNotAcceptable, falcon.HTTP_406,
+                        needs_title=False)
+        self._misc_test(falcon.HTTPConflict, falcon.HTTP_409)
+        self._misc_test(falcon.HTTPPreconditionFailed, falcon.HTTP_412)
+        self._misc_test(falcon.HTTPUnsupportedMediaType, falcon.HTTP_415,
+                        needs_title=False)
+        self._misc_test(falcon.HTTPUnprocessableEntity, falcon.HTTP_422)
+        self._misc_test(falcon.HTTPUnavailableForLegalReasons, falcon.HTTP_451,
+                        needs_title=False)
+        self._misc_test(falcon.HTTPInternalServerError, falcon.HTTP_500)
+        self._misc_test(falcon.HTTPBadGateway, falcon.HTTP_502)
+
+    def test_title_default_message_if_none(self):
+        resource = FaultyResource()
+
+        app = falcon.APIBuilder() \
+            .add_get_route('/fail', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        headers = {
+            'X-Error-Status': falcon.HTTP_503
+        }
+
+        response = client.simulate_request(path='/fail', headers=headers)
+
+        assert response.status == headers['X-Error-Status']
+        assert response.json['title'] == headers['X-Error-Status']

--- a/tests/test_middleware_builder.py
+++ b/tests/test_middleware_builder.py
@@ -1,0 +1,803 @@
+from datetime import datetime
+
+import pytest
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+import falcon
+import falcon.testing as testing
+
+_EXPECTED_BODY = {u'status': u'ok'}
+
+context = {'executed_methods': []}
+TEST_ROUTE = '/test_path'
+
+
+class CaptureResponseMiddleware(object):
+
+    def process_response(self, req, resp, resource, req_succeeded):
+        self.req = req
+        self.resp = resp
+        self.resource = resource
+        self.req_succeeded = req_succeeded
+
+
+class CaptureRequestMiddleware(object):
+
+    def process_request(self, req, resp):
+        self.req = req
+
+
+class RequestTimeMiddleware(object):
+
+    def process_request(self, req, resp):
+        global context
+        context['start_time'] = datetime.utcnow()
+
+    def process_resource(self, req, resp, resource, params):
+        global context
+        context['mid_time'] = datetime.utcnow()
+
+    def process_response(self, req, resp, resource, req_succeeded):
+        global context
+        context['end_time'] = datetime.utcnow()
+        context['req_succeeded'] = req_succeeded
+
+
+class TransactionIdMiddleware(object):
+
+    def process_request(self, req, resp):
+        global context
+        context['transaction_id'] = 'unique-req-id'
+
+    def process_response(self, req, resp, resource):
+        pass
+
+
+class ExecutedFirstMiddleware(object):
+
+    def process_request(self, req, resp):
+        global context
+        context['executed_methods'].append(
+            '{}.{}'.format(self.__class__.__name__, 'process_request'))
+
+    def process_resource(self, req, resp, resource, params):
+        global context
+        context['executed_methods'].append(
+            '{}.{}'.format(self.__class__.__name__, 'process_resource'))
+
+    # NOTE(kgriffs): This also tests that the framework can continue to
+    # call process_response() methods that do not have a 'req_succeeded'
+    # arg.
+    def process_response(self, req, resp, resource):
+        global context
+        context['executed_methods'].append(
+            '{}.{}'.format(self.__class__.__name__, 'process_response'))
+
+        context['req'] = req
+        context['resp'] = resp
+        context['resource'] = resource
+
+
+class ExecutedLastMiddleware(ExecutedFirstMiddleware):
+    pass
+
+
+class RemoveBasePathMiddleware(object):
+
+    def process_request(self, req, resp):
+        req.path = req.path.replace('/base_path', '', 1)
+
+
+class AccessParamsMiddleware(object):
+
+    def process_resource(self, req, resp, resource, params):
+        global context
+        params['added'] = True
+        context['params'] = params
+
+
+class MiddlewareClassResource(object):
+
+    def on_get(self, req, resp, **kwargs):
+        resp.status = falcon.HTTP_200
+        resp.body = json.dumps(_EXPECTED_BODY)
+
+    def on_post(self, req, resp):
+        raise falcon.HTTPForbidden(falcon.HTTP_403, 'Setec Astronomy')
+
+
+class EmptySignatureMiddleware(object):
+
+    def process_request(self):
+        pass
+
+    def process_response(self):
+        pass
+
+
+class TestMiddleware(object):
+    def setup_method(self, method):
+        # Clear context
+        global context
+        context = {'executed_methods': []}
+
+
+class TestRequestTimeMiddleware(TestMiddleware):
+
+    def test_skip_process_resource(self):
+        global context
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middleware(RequestTimeMiddleware()) \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/404')
+        assert response.status == falcon.HTTP_404
+        assert 'start_time' in context
+        assert 'mid_time' not in context
+        assert 'end_time' in context
+        assert not context['req_succeeded']
+
+    def test_add_invalid_middleware(self):
+        """Test than an invalid class can not be added as middleware"""
+        class InvalidMiddleware():
+            def process_request(self, *args):
+                pass
+
+        mw_list = [RequestTimeMiddleware(), InvalidMiddleware]
+        with pytest.raises(AttributeError):
+            falcon.APIBuilder().add_middlewares(mw_list).build()
+        mw_list = [RequestTimeMiddleware(), 'InvalidMiddleware']
+        with pytest.raises(TypeError):
+            falcon.APIBuilder().add_middlewares(mw_list).build()
+        mw_list = [{'process_request': 90}]
+        with pytest.raises(TypeError):
+            falcon.APIBuilder().add_middlewares(mw_list).build()
+
+    def test_response_middleware_raises_exception(self):
+        """Test that error in response middleware is propagated up"""
+        class RaiseErrorMiddleware(object):
+
+            def process_response(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middleware(RaiseErrorMiddleware()) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        with pytest.raises(Exception):
+            client.simulate_request(path=TEST_ROUTE)
+
+    @pytest.mark.parametrize('independent_middleware', [True, False])
+    def test_log_get_request(self, independent_middleware):
+        """Test that Log middleware is executed"""
+        global context
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(independent_middleware) \
+            .add_middleware(RequestTimeMiddleware()) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+        response = client.simulate_request(path=TEST_ROUTE)
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+
+        assert 'start_time' in context
+        assert 'mid_time' in context
+        assert 'end_time' in context
+        assert context['mid_time'] >= context['start_time'], \
+            'process_resource not executed after request'
+        assert context['end_time'] >= context['start_time'], \
+            'process_response not executed after request'
+
+        assert context['req_succeeded']
+
+
+class TestTransactionIdMiddleware(TestMiddleware):
+    def test_generate_trans_id_with_request(self):
+        """Test that TransactionIdmiddleware is executed"""
+        global context
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middleware(TransactionIdMiddleware()) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path=TEST_ROUTE)
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+        assert 'transaction_id' in context
+        assert 'unique-req-id' == context['transaction_id']
+
+
+class TestSeveralMiddlewares(TestMiddleware):
+    @pytest.mark.parametrize('independent_middleware', [True, False])
+    def test_generate_trans_id_and_time_with_request(self, independent_middleware):
+        # NOTE(kgriffs): We test both so that we can cover the code paths
+        # where only a single middleware method is implemented by a
+        # component.
+        creq = CaptureRequestMiddleware()
+        cresp = CaptureResponseMiddleware()
+
+        global context
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(independent_middleware) \
+            .add_middlewares([
+                TransactionIdMiddleware(),
+                RequestTimeMiddleware(),
+                creq,
+                cresp]) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path=TEST_ROUTE)
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+        assert 'transaction_id' in context
+        assert 'unique-req-id' == context['transaction_id']
+        assert 'start_time' in context
+        assert 'mid_time' in context
+        assert 'end_time' in context
+        assert context['mid_time'] >= context['start_time'], \
+            'process_resource not executed after request'
+        assert context['end_time'] >= context['start_time'], \
+            'process_response not executed after request'
+
+    def test_legacy_middleware_called_with_correct_args(self):
+        global context
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middleware(ExecutedFirstMiddleware()) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+        assert isinstance(context['req'], falcon.Request)
+        assert isinstance(context['resp'], falcon.Response)
+        assert isinstance(context['resource'], falcon.APIBuilder.BlankResource)
+
+    def test_middleware_execution_order(self):
+        global context
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(False) \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path=TEST_ROUTE)
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+        # as the method registration is in a list, the order also is
+        # tested
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_independent_middleware_execution_order(self):
+        global context
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(True) \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path=TEST_ROUTE)
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+        # as the method registration is in a list, the order also is
+        # tested
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_multiple_reponse_mw_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        context['req_succeeded'] = []
+
+        class RaiseStatusMiddleware(object):
+            def process_response(self, req, resp, resource):
+                raise falcon.HTTPStatus(falcon.HTTP_201)
+
+        class RaiseErrorMiddleware(object):
+            def process_response(self, req, resp, resource):
+                raise falcon.HTTPError(falcon.HTTP_748)
+
+        class ProcessResponseMiddleware(object):
+            def process_response(self, req, resp, resource, req_succeeded):
+                context['executed_methods'].append('process_response')
+                context['req_succeeded'].append(req_succeeded)
+
+        middleware_resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                ProcessResponseMiddleware(),
+                RaiseErrorMiddleware(),
+                ProcessResponseMiddleware(),
+                RaiseStatusMiddleware(),
+                ProcessResponseMiddleware()]) \
+            .add_get_route(TEST_ROUTE, middleware_resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path=TEST_ROUTE)
+
+        assert response.status == falcon.HTTP_748
+
+        expected_methods = ['process_response'] * 3
+        assert context['executed_methods'] == expected_methods
+        assert context['req_succeeded'] == [True, False, False]
+
+    def test_inner_mw_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp):
+                raise Exception('Always fail')
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                TransactionIdMiddleware(),
+                RequestTimeMiddleware(),
+                RaiseErrorMiddleware()]) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        with pytest.raises(Exception):
+            client.simulate_request(path=TEST_ROUTE)
+
+        # RequestTimeMiddleware process_response should be executed
+        assert 'transaction_id' in context
+        assert 'start_time' in context
+        assert 'mid_time' not in context
+        assert 'end_time' in context
+
+    def test_inner_mw_with_ex_handler_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            context['error_handler'] = True
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                TransactionIdMiddleware(),
+                RequestTimeMiddleware(),
+                RaiseErrorMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # RequestTimeMiddleware process_response should be executed
+        assert 'transaction_id' in context
+        assert 'start_time' in context
+        assert 'mid_time' not in context
+        assert 'end_time' in context
+        assert 'error_handler' in context
+
+    def test_outer_mw_with_ex_handler_throw_exception(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            context['error_handler'] = True
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                TransactionIdMiddleware(),
+                RaiseErrorMiddleware(),
+                RequestTimeMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        assert 'transaction_id' in context
+        assert 'start_time' not in context
+        assert 'mid_time' not in context
+        assert 'end_time' in context
+        assert 'error_handler' in context
+
+    def test_order_mw_executed_when_exception_in_resp(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_response(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_order_independent_mw_executed_when_exception_in_resp(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_response(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(True) \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_order_mw_executed_when_exception_in_req(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_order_independent_mw_executed_when_exception_in_req(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_request(self, req, resp):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(True) \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # All response middleware still executed...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_order_mw_executed_when_exception_in_rsrc(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_resource(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+
+        app = falcon.APIBuilder() \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+    def test_order_independent_mw_executed_when_exception_in_rsrc(self):
+        """Test that error in inner middleware leaves"""
+        global context
+
+        class RaiseErrorMiddleware(object):
+
+            def process_resource(self, req, resp, resource):
+                raise Exception('Always fail')
+
+        def handler(req, resp, ex, params):
+            pass
+
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(True) \
+            .add_middlewares([
+                ExecutedFirstMiddleware(),
+                RaiseErrorMiddleware(),
+                ExecutedLastMiddleware()]) \
+            .add_error_route(Exception, handler) \
+            .add_get_route(TEST_ROUTE, resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        client.simulate_request(path=TEST_ROUTE)
+
+        # Any mw is executed now...
+        expectedExecutedMethods = [
+            'ExecutedFirstMiddleware.process_request',
+            'ExecutedLastMiddleware.process_request',
+            'ExecutedFirstMiddleware.process_resource',
+            'ExecutedLastMiddleware.process_response',
+            'ExecutedFirstMiddleware.process_response'
+        ]
+        assert expectedExecutedMethods == context['executed_methods']
+
+
+class TestRemoveBasePathMiddleware(TestMiddleware):
+    def test_base_path_is_removed_before_routing(self):
+        """Test that RemoveBasePathMiddleware is executed before routing"""
+        resource = MiddlewareClassResource()
+        # We dont include /base_path as it will be removed in middleware
+        app = falcon.APIBuilder() \
+            .add_middleware(RemoveBasePathMiddleware()) \
+            .add_get_route('/sub_path', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/base_path/sub_path')
+        assert _EXPECTED_BODY == response.json
+        assert response.status == falcon.HTTP_200
+        response = client.simulate_request(path='/base_pathIncorrect/sub_path')
+        assert response.status == falcon.HTTP_404
+
+
+class TestResourceMiddleware(TestMiddleware):
+
+    @pytest.mark.parametrize('independent_middleware', [True, False])
+    def test_can_access_resource_params(self, independent_middleware):
+        """Test that params can be accessed from within process_resource"""
+        global context
+
+        class Resource:
+            def on_get(self, req, resp, **params):
+                resp.body = json.dumps(params)
+
+        resource = Resource()
+        app = falcon.APIBuilder() \
+            .set_call_response_middleware_on_request_middleware_exception(independent_middleware) \
+            .add_middleware(AccessParamsMiddleware()) \
+            .add_get_route('/path/{id}', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/path/22')
+
+        assert 'params' in context
+        assert context['params']
+        assert context['params']['id'] == '22'
+        assert response.json == {'added': True, 'id': '22'}
+
+
+class TestEmptySignatureMiddleware(TestMiddleware):
+    def test_dont_need_params_in_signature(self):
+        """
+        Verify that we don't need parameters in the process_* signatures (for
+        side-effect-only middlewares, mostly). Makes no difference on py27
+        but does affect py36.
+
+        https://github.com/falconry/falcon/issues/1254
+        """
+        falcon.APIBuilder() \
+            .add_middleware(EmptySignatureMiddleware()) \
+            .build()
+
+
+class TestErrorHandling(TestMiddleware):
+    def test_error_composed_before_resp_middleware_called(self):
+        mw = CaptureResponseMiddleware()
+        resource = MiddlewareClassResource()
+        app = falcon.APIBuilder() \
+            .add_middleware(mw) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/', method='POST')
+        assert response.status == falcon.HTTP_403
+        assert mw.resp.status == response.status
+
+        composed_body = json.loads(mw.resp.body)
+        assert composed_body['title'] == response.status
+
+        assert not mw.req_succeeded
+
+        # NOTE(kgriffs): Sanity-check the other params passed to
+        # process_response()
+        assert isinstance(mw.req, falcon.Request)
+        assert isinstance(mw.resource, falcon.APIBuilder.BlankResource)
+
+    def test_http_status_raised_from_error_handler(self):
+        mw = CaptureResponseMiddleware()
+        resource = MiddlewareClassResource()
+
+        # NOTE(kgriffs): This will take precedence over the default
+        # handler for facon.HTTPError.
+        def _http_error_handler(error, req, resp, params):
+            raise falcon.HTTPStatus(falcon.HTTP_201)
+
+        app = falcon.APIBuilder() \
+            .add_middleware(mw) \
+            .add_post_route('/', resource.on_post) \
+            .add_error_route(falcon.HTTPError, _http_error_handler) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/', method='POST')
+        assert response.status == falcon.HTTP_201
+        assert mw.resp.status == response.status

--- a/tests/test_py2_wsgi.py
+++ b/tests/test_py2_wsgi.py
@@ -30,3 +30,15 @@ def test_test_client_works_in_py2(auth_header):
     client.simulate_get('/', headers={
         'Authorization': auth_header
     })
+
+
+@pytest.mark.parametrize(
+    'auth_header',
+    [u'token blah', 'token blah']
+)
+def test_test_client_works_in_py2_with_builder(auth_header):
+    app = falcon.APIBuilder().build()
+    client = TestClient(app)
+    client.simulate_get('/', headers={
+        'Authorization': auth_header
+    })

--- a/tests/test_query_params_builder.py
+++ b/tests/test_query_params_builder.py
@@ -1,0 +1,1195 @@
+from datetime import date, datetime
+from uuid import UUID
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+import pytest
+
+import falcon
+from falcon.errors import HTTPInvalidParam
+import falcon.testing as testing
+
+
+class Resource(testing.SimpleTestResource):
+
+    @falcon.before(testing.capture_responder_args)
+    @falcon.before(testing.set_resp_defaults)
+    def on_put(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(testing.capture_responder_args)
+    @falcon.before(testing.set_resp_defaults)
+    def on_patch(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(testing.capture_responder_args)
+    @falcon.before(testing.set_resp_defaults)
+    def on_delete(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(testing.capture_responder_args)
+    @falcon.before(testing.set_resp_defaults)
+    def on_head(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(testing.capture_responder_args)
+    @falcon.before(testing.set_resp_defaults)
+    def on_options(self, req, resp, **kwargs):
+        pass
+
+
+@pytest.fixture
+def resource():
+    return Resource()
+
+
+def simulate_request_get_query_params(client, path, query_string, **kwargs):
+    return client.simulate_request(path=path, query_string=query_string, **kwargs)
+
+
+def simulate_request_post_query_params(client, path, query_string, **kwargs):
+    headers = kwargs.setdefault('headers', {})
+    headers['Content-Type'] = 'application/x-www-form-urlencoded'
+    if 'method' not in kwargs:
+        kwargs['method'] = 'POST'
+    return client.simulate_request(path=path, body=query_string, **kwargs)
+
+
+@pytest.fixture(
+    scope='session',
+    params=[
+        simulate_request_get_query_params,
+        simulate_request_post_query_params,
+    ],
+)
+def simulate_request(request):
+    return request.param
+
+
+class TestQueryParams(object):
+    def test_none(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = ''
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        store = {}
+        assert req.get_param('marker') is None
+        assert req.get_param('limit', store) is None
+        assert 'limit' not in store
+        assert req.get_param_as_int('limit') is None
+        assert req.get_param_as_float('limit') is None
+        assert req.get_param_as_bool('limit') is None
+        assert req.get_param_as_list('limit') is None
+
+    def test_default(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        default = 'foobar'
+        query_string = ''
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        store = {}
+        assert req.get_param('marker', default=default) == 'foobar'
+        assert req.get_param('limit', store, default=default) == 'foobar'
+        assert 'limit' not in store
+        assert req.get_param_as_int('limit', default=default) == 'foobar'
+        assert req.get_param_as_float('limit', default=default) == 'foobar'
+        assert req.get_param_as_bool('limit', default=default) == 'foobar'
+        assert req.get_param_as_list('limit', default=default) == 'foobar'
+
+    def test_blank(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker='
+        client.app.req_options.keep_blank_qs_values = False
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert req.get_param('marker') is None
+
+        store = {}
+        assert req.get_param('marker', store=store) is None
+        assert 'marker' not in store
+
+    def test_simple(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&limit=25'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        store = {}
+        assert req.get_param('marker', store=store) or 'nada' == 'deadbeef'
+        assert req.get_param('limit', store=store) or '0' == '25'
+
+        assert store['marker'] == 'deadbeef'
+        assert store['limit'] == '25'
+
+    def test_percent_encoded(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'id=23,42&q=%e8%b1%86+%e7%93%a3'
+        client.app.req_options.auto_parse_qs_csv = True
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        assert req.get_param('id') in [u'23', u'42']
+
+        assert req.get_param_as_list('id', int) == [23, 42]
+        assert req.get_param('q') == u'\u8c46 \u74e3'
+
+    def test_option_auto_parse_qs_csv_simple_false(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_qs_csv = False
+
+        query_string = 'id=23,42,,&id=2'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        assert req.params['id'] == [u'23,42,,', u'2']
+        assert req.get_param('id') in [u'23,42,,', u'2']
+        assert req.get_param_as_list('id') == [u'23,42,,', u'2']
+
+    def test_option_auto_parse_qs_csv_simple_true(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_qs_csv = True
+        client.app.req_options.keep_blank_qs_values = False
+
+        query_string = 'id=23,42,,&id=2'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        assert req.params['id'] == [u'23', u'42', u'2']
+        assert req.get_param('id') in [u'23', u'42', u'2']
+        assert req.get_param_as_list('id', int) == [23, 42, 2]
+
+    def test_option_auto_parse_qs_csv_complex_false(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_qs_csv = False
+        client.app.req_options.keep_blank_qs_values = False
+
+        encoded_json = '%7B%22msg%22:%22Testing%201,2,3...%22,%22code%22:857%7D'
+        decoded_json = '{"msg":"Testing 1,2,3...","code":857}'
+
+        query_string = ('colors=red,green,blue&limit=1'
+                        '&list-ish1=f,,x&list-ish2=,0&list-ish3=a,,,b'
+                        '&empty1=&empty2=,&empty3=,,'
+                        '&thing=' + encoded_json)
+
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        assert req.get_param('colors') in 'red,green,blue'
+        assert req.get_param_as_list('colors') == [u'red,green,blue']
+
+        assert req.get_param_as_list('limit') == ['1']
+
+        assert req.get_param_as_list('empty1') is None
+        assert req.get_param_as_list('empty2') == [u',']
+        assert req.get_param_as_list('empty3') == [u',,']
+
+        assert req.get_param_as_list('list-ish1') == [u'f,,x']
+        assert req.get_param_as_list('list-ish2') == [u',0']
+        assert req.get_param_as_list('list-ish3') == [u'a,,,b']
+
+        assert req.get_param('thing') == decoded_json
+
+    def test_default_auto_parse_csv_behaviour(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'id=1,2,,&id=3'
+
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        assert req.get_param('id') == '3'
+        assert req.get_param_as_list('id') == ['1,2,,', '3']
+
+    def test_bad_percentage(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'x=%%20%+%&y=peregrine&z=%a%z%zz%1%20e'
+        response = simulate_request(client=client, path='/', query_string=query_string)
+        assert response.status == falcon.HTTP_200
+
+        req = resource.captured_req
+        assert req.get_param('x') == '% % %'
+        assert req.get_param('y') == 'peregrine'
+        assert req.get_param('z') == '%a%z%zz%1 e'
+
+    def test_allowed_names(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.keep_blank_qs_values = False
+        query_string = ('p=0&p1=23&2p=foo&some-thing=that&blank=&'
+                        'some_thing=x&-bogus=foo&more.things=blah&'
+                        '_thing=42&_charset_=utf-8')
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert req.get_param('p') == '0'
+        assert req.get_param('p1') == '23'
+        assert req.get_param('2p') == 'foo'
+        assert req.get_param('some-thing') == 'that'
+        assert req.get_param('blank') is None
+        assert req.get_param('some_thing') == 'x'
+        assert req.get_param('-bogus') == 'foo'
+        assert req.get_param('more.things') == 'blah'
+        assert req.get_param('_thing') == '42'
+        assert req.get_param('_charset_') == 'utf-8'
+
+    @pytest.mark.parametrize('method_name', [
+        'get_param',
+        'get_param_as_int',
+        'get_param_as_float',
+        'get_param_as_uuid',
+        'get_param_as_bool',
+        'get_param_as_list',
+    ])
+    def test_required(self, simulate_request, resource, method_name):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = ''
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        try:
+            getattr(req, method_name)('marker', required=True)
+            pytest.fail('falcon.HTTPMissingParam not raised')
+        except falcon.HTTPMissingParam as ex:
+            assert isinstance(ex, falcon.HTTPBadRequest)
+            assert ex.title == 'Missing parameter'
+            expected_desc = 'The "marker" parameter is required.'
+            assert ex.description == expected_desc
+
+    def test_int(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&limit=25'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        try:
+            req.get_param_as_int('marker')
+        except Exception as ex:
+            assert isinstance(ex, falcon.HTTPBadRequest)
+            assert isinstance(ex, falcon.HTTPInvalidParam)
+            assert ex.title == 'Invalid parameter'
+            expected_desc = ('The "marker" parameter is invalid. '
+                             'The value must be an integer.')
+            assert ex.description == expected_desc
+
+        assert req.get_param_as_int('limit') == 25
+
+        store = {}
+        assert req.get_param_as_int('limit', store=store) == 25
+        assert store['limit'] == 25
+
+        assert req.get_param_as_int('limit', min_value=1, max_value=50) == 25
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('limit', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('limit', min_value=0, max_value=24)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('limit', min_value=30, max_value=24)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('limit', min_value=30, max_value=50)
+
+        assert req.get_param_as_int('limit', min_value=1) == 25
+
+        assert req.get_param_as_int('limit', max_value=50) == 25
+
+        assert req.get_param_as_int('limit', max_value=25) == 25
+
+        assert req.get_param_as_int('limit', max_value=26) == 25
+
+        assert req.get_param_as_int('limit', min_value=25) == 25
+
+        assert req.get_param_as_int('limit', min_value=24) == 25
+
+        assert req.get_param_as_int('limit', min_value=-24) == 25
+
+    def test_int_neg(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&pos=-7'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert req.get_param_as_int('pos') == -7
+
+        assert req.get_param_as_int('pos', min_value=-10, max_value=10) == -7
+
+        assert req.get_param_as_int('pos', max_value=10) == -7
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('pos', min_value=-6, max_value=0)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('pos', min_value=-6)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('pos', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_int('pos', min_value=0, max_value=10)
+
+    def test_float(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&limit=25.1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        try:
+            req.get_param_as_float('marker')
+        except Exception as ex:
+            assert isinstance(ex, falcon.HTTPBadRequest)
+            assert isinstance(ex, falcon.HTTPInvalidParam)
+            assert ex.title == 'Invalid parameter'
+            expected_desc = ('The "marker" parameter is invalid. '
+                             'The value must be a float.')
+            assert ex.description == expected_desc
+
+        assert req.get_param_as_float('limit') == 25.1
+
+        store = {}
+        assert req.get_param_as_float('limit', store=store) == 25.1
+        assert store['limit'] == 25.1
+
+        assert req.get_param_as_float('limit', min_value=1, max_value=50) == 25.1
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('limit', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('limit', min_value=0, max_value=24)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('limit', min_value=30, max_value=24)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('limit', min_value=30, max_value=50)
+
+        assert req.get_param_as_float('limit', min_value=1) == 25.1
+
+        assert req.get_param_as_float('limit', max_value=50) == 25.1
+
+        assert req.get_param_as_float('limit', max_value=25.1) == 25.1
+
+        assert req.get_param_as_float('limit', max_value=26) == 25.1
+
+        assert req.get_param_as_float('limit', min_value=25) == 25.1
+
+        assert req.get_param_as_float('limit', min_value=24) == 25.1
+
+        assert req.get_param_as_float('limit', min_value=-24) == 25.1
+
+    def test_float_neg(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&pos=-7.1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert req.get_param_as_float('pos') == -7.1
+
+        assert req.get_param_as_float('pos', min_value=-10, max_value=10) == -7.1
+
+        assert req.get_param_as_float('pos', max_value=10) == -7.1
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('pos', min_value=-6, max_value=0)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('pos', min_value=-6)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('pos', min_value=0, max_value=10)
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_float('pos', min_value=0, max_value=10)
+
+    def test_uuid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = ('marker1=8d76b7b3-d0dd-46ca-ad6e-3989dcd66959&'
+                        'marker2=64be949b-3433-4d36-a4a8-9f19d352fee8&'
+                        'marker2=8D76B7B3-d0dd-46ca-ad6e-3989DCD66959&'
+                        'short=4be949b-3433-4d36-a4a8-9f19d352fee8')
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        expected_uuid = UUID('8d76b7b3-d0dd-46ca-ad6e-3989dcd66959')
+        assert req.get_param_as_uuid('marker1') == expected_uuid
+        assert req.get_param_as_uuid('marker2') == expected_uuid
+        assert req.get_param_as_uuid('marker3') is None
+        assert req.get_param_as_uuid('marker3', required=False) is None
+
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_uuid('short')
+
+        store = {}
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_uuid('marker3', required=True, store=store)
+
+        assert not store
+        assert req.get_param_as_uuid('marker1', store=store)
+        assert store['marker1'] == expected_uuid
+
+    def test_boolean(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.keep_blank_qs_values = False
+        query_string = ('echo=true&doit=false&bogus=bar&bogus2=foo&'
+                        't1=True&f1=False&t2=yes&f2=no&blank&one=1&zero=0&'
+                        'checkbox1=on&checkbox2=off')
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        with pytest.raises(falcon.HTTPBadRequest):
+            req.get_param_as_bool('bogus')
+
+        try:
+            req.get_param_as_bool('bogus2')
+        except Exception as ex:
+            assert isinstance(ex, falcon.HTTPInvalidParam)
+            assert ex.title == 'Invalid parameter'
+            expected_desc = ('The "bogus2" parameter is invalid. '
+                             'The value of the parameter must be "true" '
+                             'or "false".')
+            assert ex.description == expected_desc
+
+        assert req.get_param_as_bool('echo') is True
+        assert req.get_param_as_bool('doit') is False
+
+        assert req.get_param_as_bool('t1') is True
+        assert req.get_param_as_bool('t2') is True
+        assert req.get_param_as_bool('f1') is False
+        assert req.get_param_as_bool('f2') is False
+        assert req.get_param_as_bool('one') is True
+        assert req.get_param_as_bool('zero') is False
+        assert req.get_param('blank') is None
+
+        assert req.get_param_as_bool('checkbox1') is True
+        assert req.get_param_as_bool('checkbox2') is False
+
+        store = {}
+        assert req.get_param_as_bool('echo', store=store) is True
+        assert store['echo'] is True
+
+    def test_boolean_blank(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        simulate_request(client=client, path='/', query_string='blank&blank2=')
+
+        req = resource.captured_req
+        assert req.get_param('blank') == ''
+        assert req.get_param('blank2') == ''
+
+        for param_name in ('blank', 'blank2'):
+            assert req.get_param_as_bool(param_name) is True
+            assert req.get_param_as_bool(param_name, blank_as_true=True) is True
+            assert req.get_param_as_bool(param_name, blank_as_true=False) is False
+
+        assert req.get_param_as_bool('nichts') is None
+        assert req.get_param_as_bool('nichts', default=None) is None
+        assert req.get_param_as_bool('nichts', default=False) is False
+        assert req.get_param_as_bool('nichts', default=True) is True
+
+    def test_list_type(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_qs_csv = True
+        client.app.req_options.keep_blank_qs_values = False
+        query_string = ('colors=red,green,blue&limit=1'
+                        '&list-ish1=f,,x&list-ish2=,0&list-ish3=a,,,b'
+                        '&empty1=&empty2=,&empty3=,,'
+                        '&thing_one=1,,3'
+                        '&thing_two=1&thing_two=&thing_two=3')
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        assert req.get_param('colors') in ('red', 'green', 'blue')
+
+        assert req.get_param_as_list('colors') == ['red', 'green', 'blue']
+        assert req.get_param_as_list('limit') == ['1']
+        assert req.get_param_as_list('marker') is None
+
+        assert req.get_param_as_list('empty1') is None
+        assert req.get_param_as_list('empty2') == []
+        assert req.get_param_as_list('empty3') == []
+
+        assert req.get_param_as_list('list-ish1') == ['f', 'x']
+
+        # Ensure that '0' doesn't get translated to None
+        assert req.get_param_as_list('list-ish2') == ['0']
+
+        # Ensure that '0' doesn't get translated to None
+        assert req.get_param_as_list('list-ish3') == ['a', 'b']
+
+        # Ensure consistency between list conventions
+        assert req.get_param_as_list('thing_one') == ['1', '3']
+        assert (
+            req.get_param_as_list('thing_one') ==
+            req.get_param_as_list('thing_two')
+        )
+
+        store = {}
+        assert req.get_param_as_list('limit', store=store) == ['1']
+        assert store['limit'] == ['1']
+
+    def test_list_type_blank(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = ('colors=red,green,blue&limit=1'
+                        '&list-ish1=f,,x&list-ish2=,0&list-ish3=a,,,b'
+                        '&empty1=&empty2=,&empty3=,,'
+                        '&thing_one=1,,3'
+                        '&thing_two=1&thing_two=&thing_two=3'
+                        '&empty4=&empty4&empty4='
+                        '&empty5&empty5&empty5')
+        client.app.req_options.keep_blank_qs_values = True
+        client.app.req_options.auto_parse_qs_csv = True
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        assert req.get_param('colors') in ('red', 'green', 'blue')
+
+        assert req.get_param_as_list('colors') == ['red', 'green', 'blue']
+        assert req.get_param_as_list('limit') == ['1']
+        assert req.get_param_as_list('marker') is None
+
+        assert req.get_param_as_list('empty1') == ['']
+        assert req.get_param_as_list('empty2') == ['', '']
+        assert req.get_param_as_list('empty3') == ['', '', '']
+
+        assert req.get_param_as_list('list-ish1') == ['f', '', 'x']
+
+        # Ensure that '0' doesn't get translated to None
+        assert req.get_param_as_list('list-ish2') == ['', '0']
+
+        # Ensure that '0' doesn't get translated to None
+        assert req.get_param_as_list('list-ish3') == ['a', '', '', 'b']
+
+        # Ensure consistency between list conventions
+        assert req.get_param_as_list('thing_one') == ['1', '', '3']
+        assert req.get_param_as_list('thing_one') == req.get_param_as_list('thing_two')
+
+        store = {}
+        assert req.get_param_as_list('limit', store=store) == ['1']
+        assert store['limit'] == ['1']
+
+        # Test empty elements
+        assert req.get_param_as_list('empty4') == ['', '', '']
+        assert req.get_param_as_list('empty5') == ['', '', '']
+        assert req.get_param_as_list('empty4') == req.get_param_as_list('empty5')
+
+    def test_list_transformer(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_qs_csv = True
+        client.app.req_options.keep_blank_qs_values = False
+        query_string = 'coord=1.4,13,15.1&limit=100&things=4,,1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+
+        # NOTE(kgriffs): For lists, get_param will return one of the
+        # elements, but which one it will choose is undefined.
+        assert req.get_param('coord') in ('1.4', '13', '15.1')
+
+        expected = [1.4, 13.0, 15.1]
+        actual = req.get_param_as_list('coord', transform=float)
+        assert actual == expected
+
+        expected = ['4', '1']
+        actual = req.get_param_as_list('things', transform=str)
+        assert actual == expected
+
+        expected = [4, 1]
+        actual = req.get_param_as_list('things', transform=int)
+        assert actual == expected
+
+        try:
+            req.get_param_as_list('coord', transform=int)
+        except Exception as ex:
+            assert isinstance(ex, falcon.HTTPInvalidParam)
+            assert ex.title == 'Invalid parameter'
+            expected_desc = ('The "coord" parameter is invalid. '
+                             'The value is not formatted correctly.')
+            assert ex.description == expected_desc
+
+    def test_param_property(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=4&bee=3&cat=2&dog=1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert (
+            sorted(req.params.items()) ==
+            [('ant', '4'), ('bee', '3'), ('cat', '2'), ('dog', '1')]
+        )
+
+    def test_multiple_form_keys(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=1&ant=2&bee=3&cat=6&cat=5&cat=4'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        # By definition, we cannot guarantee which of the multiple keys will
+        # be returned by .get_param().
+        assert req.get_param('ant') in ('1', '2')
+        # There is only one 'bee' key so it remains a scalar.
+        assert req.get_param('bee') == '3'
+        # There are three 'cat' keys; order is preserved.
+        assert req.get_param('cat') in ('6', '5', '4')
+
+    def test_multiple_keys_as_bool(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=true&ant=yes&ant=True'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_bool('ant') is True
+
+    def test_multiple_keys_as_int(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=1&ant=2&ant=3'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_int('ant') in (1, 2, 3)
+
+    def test_multiple_keys_as_float(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=1.1&ant=2.2&ant=3.3'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_float('ant') in (1.1, 2.2, 3.3)
+
+    def test_multiple_form_keys_as_list(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=1&ant=2&bee=3&cat=6&cat=5&cat=4'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        # There are two 'ant' keys.
+        assert req.get_param_as_list('ant') == ['1', '2']
+        # There is only one 'bee' key..
+        assert req.get_param_as_list('bee') == ['3']
+        # There are three 'cat' keys; order is preserved.
+        assert req.get_param_as_list('cat') == ['6', '5', '4']
+
+    def test_get_date_valid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = '2015-04-20'
+        query_string = 'thedate={}'.format(date_value)
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_date('thedate') == date(2015, 4, 20)
+
+    def test_get_date_missing_param(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'notthedate=2015-04-20'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_date('thedate') is None
+
+    def test_get_date_valid_with_format(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = '20150420'
+        query_string = 'thedate={}'.format(date_value)
+        format_string = '%Y%m%d'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_date('thedate', format_string=format_string) == date(2015, 4, 20)
+
+    def test_get_date_store(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = '2015-04-20'
+        query_string = 'thedate={}'.format(date_value)
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        store = {}
+        req.get_param_as_date('thedate', store=store)
+        assert len(store) != 0
+
+    def test_get_date_invalid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = 'notarealvalue'
+        query_string = 'thedate={}'.format(date_value)
+        format_string = '%Y%m%d'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        with pytest.raises(HTTPInvalidParam):
+            req.get_param_as_date('thedate', format_string=format_string)
+
+    def test_get_datetime_valid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = '2015-04-20T10:10:10Z'
+        query_string = 'thedate={}'.format(date_value)
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_datetime('thedate') == datetime(2015, 4, 20, 10, 10, 10)
+
+    def test_get_datetime_missing_param(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'notthedate=2015-04-20T10:10:10Z'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_datetime('thedate') is None
+
+    def test_get_datetime_valid_with_format(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = '20150420 10:10:10'
+        query_string = 'thedate={}'.format(date_value)
+        format_string = '%Y%m%d %H:%M:%S'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_datetime(
+            'thedate', format_string=format_string) == datetime(2015, 4, 20, 10, 10, 10)
+
+    def test_get_datetime_store(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        datetime_value = '2015-04-20T10:10:10Z'
+        query_string = 'thedate={}'.format(datetime_value)
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        store = {}
+        req.get_param_as_datetime('thedate', store=store)
+        assert len(store) != 0
+        assert store.get('thedate') == datetime(2015, 4, 20, 10, 10, 10)
+
+    def test_get_datetime_invalid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        date_value = 'notarealvalue'
+        query_string = 'thedate={}'.format(date_value)
+        format_string = '%Y%m%dT%H:%M:%S'
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        with pytest.raises(HTTPInvalidParam):
+            req.get_param_as_datetime('thedate', format_string=format_string)
+
+    def test_get_dict_valid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        payload_dict = {'foo': 'bar'}
+        query_string = 'payload={}'.format(json.dumps(payload_dict))
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_json('payload') == payload_dict
+
+    def test_get_dict_missing_param(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        payload_dict = {'foo': 'bar'}
+        query_string = 'notthepayload={}'.format(json.dumps(payload_dict))
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        assert req.get_param_as_json('payload') is None
+
+    def test_get_dict_store(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        payload_dict = {'foo': 'bar'}
+        query_string = 'payload={}'.format(json.dumps(payload_dict))
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        store = {}
+        req.get_param_as_json('payload', store=store)
+        assert len(store) != 0
+
+    def test_get_dict_invalid(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        payload_dict = 'foobar'
+        query_string = 'payload={}'.format(payload_dict)
+        simulate_request(client=client, path='/', query_string=query_string)
+        req = resource.captured_req
+        with pytest.raises(HTTPInvalidParam):
+            req.get_param_as_json('payload')
+
+    def test_has_param(self, simulate_request, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'ant=1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        # There is a 'ant' key.
+        assert req.has_param('ant')
+        # There is not a 'bee' key..
+        assert not req.has_param('bee')
+        # There is not a None key
+        assert not req.has_param(None)
+
+
+class TestPostQueryParams(object):
+    @pytest.mark.parametrize('http_method', ('POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'))
+    def test_http_methods_body_expected(self, resource, http_method):
+        app = falcon.APIBuilder() \
+            .add_post_route('/', resource.on_post) \
+            .add_put_route('/', resource.on_put) \
+            .add_patch_route('/', resource.on_patch) \
+            .add_delete_route('/', resource.on_delete) \
+            .add_options_route('/', resource.on_options) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&limit=25'
+        simulate_request_post_query_params(client=client, path='/', query_string=query_string,
+                                           method=http_method)
+
+        req = resource.captured_req
+        assert req.get_param('marker') == 'deadbeef'
+        assert req.get_param('limit') == '25'
+
+    @pytest.mark.parametrize('http_method', ('GET', 'HEAD'))
+    def test_http_methods_body_not_expected(self, resource, http_method):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_head_route('/', resource.on_head) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        query_string = 'marker=deadbeef&limit=25'
+        simulate_request_post_query_params(client=client, path='/', query_string=query_string,
+                                           method=http_method)
+
+        req = resource.captured_req
+        assert req.get_param('marker') is None
+        assert req.get_param('limit') is None
+
+    def test_non_ascii(self, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        value = u'\u8c46\u74e3'
+        query_string = b'q=' + value.encode('utf-8')
+        simulate_request_post_query_params(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        assert req.get_param('q') is None
+
+    def test_empty_body(self, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        simulate_request_post_query_params(client=client, path='/', query_string=None)
+
+        req = resource.captured_req
+        assert req.get_param('q') is None
+
+    def test_empty_body_no_content_length(self, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        simulate_request_post_query_params(client=client, path='/', query_string=None)
+
+        req = resource.captured_req
+        assert req.get_param('q') is None
+
+    def test_explicitly_disable_auto_parse(self, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        app.req_options.auto_parse_form_urlencoded = True
+        client = testing.TestClient(app)
+
+        client.app.req_options.auto_parse_form_urlencoded = False
+        simulate_request_post_query_params(client=client, path='/', query_string='q=42')
+
+        req = resource.captured_req
+        assert req.get_param('q') is None
+
+
+class TestPostQueryParamsDefaultBehavior(object):
+    def test_dont_auto_parse_by_default(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+        client.simulate_request(path='/', body='q=42', headers=headers)
+
+        req = resource.captured_req
+        assert req.get_param('q') is None

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -128,3 +128,115 @@ class TestDefaultRouting(object):
         response = client.simulate_request(path='/books/123')
         assert resource.called
         assert response.status == falcon.HTTP_200
+
+
+class TestDefaultRoutingWithBuilderClient(object):
+
+    def test_single_default_pattern(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_sink(sink) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/')
+        assert response.status == falcon.HTTP_503
+
+    def test_single_simple_pattern(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_sink(sink, r'/foo') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/foo/bar')
+        assert response.status == falcon.HTTP_503
+
+    def test_single_compiled_pattern(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_sink(sink, re.compile(r'/foo')) \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/foo/bar')
+        assert response.status == falcon.HTTP_503
+
+        response = client.simulate_request(path='/auth')
+        assert response.status == falcon.HTTP_404
+
+    def test_named_groups(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_sink(sink, r'/user/(?P<id>\d+)') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/user/309')
+        assert response.status == falcon.HTTP_503
+        assert sink.kwargs['id'] == '309'
+
+        response = client.simulate_request(path='/user/sally')
+        assert response.status == falcon.HTTP_404
+
+    def test_multiple_patterns(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_sink(sink, r'/foo') \
+            .add_sink(sink_too, r'/foo') \
+            .add_sink(sink, r'/katza') \
+            .build()  # Last duplicate wins
+
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/foo/bar')
+        assert response.status == falcon.HTTP_781
+
+        response = client.simulate_request(path='/katza')
+        assert response.status == falcon.HTTP_503
+
+    def test_with_route(self, sink, resource):
+        app = falcon.APIBuilder() \
+            .add_get_route('/books', resource.on_get) \
+            .add_sink(sink, '/proxy') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/proxy/books')
+        assert not resource.called
+        assert response.status == falcon.HTTP_503
+
+        response = client.simulate_request(path='/books')
+        assert resource.called
+        assert response.status == falcon.HTTP_200
+
+    def test_route_precedence(self, sink, resource):
+        # NOTE(kgriffs): In case of collision, the route takes precedence.
+        app = falcon.APIBuilder() \
+            .add_get_route('/books', resource.on_get) \
+            .add_sink(sink, '/books') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/books')
+        assert resource.called
+        assert response.status == falcon.HTTP_200
+
+    def test_route_precedence_with_id(self, sink, resource):
+        # NOTE(kgriffs): In case of collision, the route takes precedence.
+        app = falcon.APIBuilder() \
+            .add_get_route('/books/{id}', resource.on_get) \
+            .add_sink(sink, '/books') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/books')
+        assert not resource.called
+        assert response.status == falcon.HTTP_503
+
+    def test_route_precedence_with_both_id(self, sink, resource):
+        # NOTE(kgriffs): In case of collision, the route takes precedence.
+        app = falcon.APIBuilder() \
+            .add_get_route('/books/{id}', resource.on_get) \
+            .add_sink(sink, r'/books/\d+') \
+            .build()
+        client = testing.TestClient(app)
+
+        response = client.simulate_request(path='/books/123')
+        assert resource.called
+        assert response.status == falcon.HTTP_200

--- a/tests/test_static_builder.py
+++ b/tests/test_static_builder.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+
+import io
+import os
+
+import pytest
+
+import falcon
+from falcon.request import Request
+from falcon.response import Response
+from falcon.routing import StaticRoute
+import falcon.testing as testing
+
+
+@pytest.mark.parametrize('uri', [
+    # Root
+    '/static',
+    '/static/',
+    '/static/.',
+
+    # Attempt to jump out of the directory
+    '/static/..',
+    '/static/../.',
+    '/static/.././etc/passwd',
+    '/static/../etc/passwd',
+    '/static/css/../../secret',
+    '/static/css/../../etc/passwd',
+    '/static/./../etc/passwd',
+
+    # The file system probably won't process escapes, but better safe than sorry
+    '/static/css/../.\\056/etc/passwd',
+    '/static/./\\056./etc/passwd',
+    '/static/\\056\\056/etc/passwd',
+
+    # Double slash
+    '/static//test.css',
+    '/static//COM10',
+    '/static/path//test.css',
+    '/static/path///test.css',
+    '/static/path////test.css',
+    '/static/path/foo//test.css',
+
+    # Control characters (0x00–0x1f and 0x80–0x9f)
+    '/static/.\x00ssh/authorized_keys',
+    '/static/.\x1fssh/authorized_keys',
+    '/static/.\x80ssh/authorized_keys',
+    '/static/.\x9fssh/authorized_keys',
+
+    # Reserved characters (~, ?, <, >, :, *, |, ', and ")
+    '/static/~/.ssh/authorized_keys',
+    '/static/.ssh/authorized_key?',
+    '/static/.ssh/authorized_key>foo',
+    '/static/.ssh/authorized_key|foo',
+    '/static/.ssh/authorized_key<foo',
+    '/static/something:something',
+    '/static/thing*.sql',
+    '/static/\'thing\'.sql',
+    '/static/"thing".sql',
+
+    # Trailing periods and spaces
+    '/static/something.',
+    '/static/something..',
+    '/static/something ',
+    '/static/ something ',
+    '/static/ something ',
+    '/static/something\t',
+    '/static/\tsomething',
+
+    # Too long
+    '/static/' + ('t' * StaticRoute._MAX_NON_PREFIXED_LEN) + 'x',
+
+])
+def test_bad_path(uri, monkeypatch):
+    monkeypatch.setattr(io, 'open', lambda path, mode: path)
+
+    sr = StaticRoute('/static', '/var/www/statics')
+
+    req = Request(testing.create_environ(
+        host='test.com',
+        path=uri,
+        app='statics'
+    ))
+
+    resp = Response()
+
+    with pytest.raises(falcon.HTTPNotFound):
+        sr(req, resp)
+
+
+@pytest.mark.parametrize('prefix, directory', [
+    ('static', '/var/www/statics'),
+    ('/static', './var/www/statics'),
+    ('/static', 'statics'),
+    ('/static', '../statics'),
+])
+def test_invalid_args(prefix, directory):
+    with pytest.raises(ValueError):
+        StaticRoute(prefix, directory)
+
+    with pytest.raises(ValueError):
+        falcon.APIBuilder() \
+            .add_static_route(prefix, directory) \
+            .build()
+
+
+@pytest.mark.parametrize('default', [
+    'not-existing-file',
+    # directories
+    '.',
+    '/tmp',
+])
+def test_invalid_args_fallback_filename(default):
+    prefix, directory = '/static', '/var/www/statics'
+    with pytest.raises(ValueError, match='fallback_filename'):
+        StaticRoute(prefix, directory, fallback_filename=default)
+
+    with pytest.raises(ValueError, match='fallback_filename'):
+        falcon.APIBuilder() \
+            .add_static_route(prefix, directory, fallback_filename=default) \
+            .build()
+
+
+@pytest.mark.parametrize('uri_prefix, uri_path, expected_path, mtype', [
+    ('/static/', '/css/test.css', '/css/test.css', 'text/css'),
+    ('/static', '/css/test.css', '/css/test.css', 'text/css'),
+    (
+        '/static',
+        '/' + ('t' * StaticRoute._MAX_NON_PREFIXED_LEN),
+        '/' + ('t' * StaticRoute._MAX_NON_PREFIXED_LEN),
+        'application/octet-stream',
+    ),
+    ('/static', '/.test.css', '/.test.css', 'text/css'),
+    ('/some/download/', '/report.pdf', '/report.pdf', 'application/pdf'),
+    ('/some/download/', '/Fancy Report.pdf', '/Fancy Report.pdf', 'application/pdf'),
+    ('/some/download', '/report.zip', '/report.zip', 'application/zip'),
+    ('/some/download', '/foo/../report.zip', '/report.zip', 'application/zip'),
+    ('/some/download', '/foo/../bar/../report.zip', '/report.zip', 'application/zip'),
+    ('/some/download', '/foo/bar/../../report.zip', '/report.zip', 'application/zip'),
+])
+def test_good_path(uri_prefix, uri_path, expected_path, mtype, monkeypatch):
+    monkeypatch.setattr(io, 'open', lambda path, mode: path)
+
+    sr = StaticRoute(uri_prefix, '/var/www/statics')
+
+    req_path = uri_prefix[:-1] if uri_prefix.endswith('/') else uri_prefix
+    req_path += uri_path
+
+    req = Request(testing.create_environ(
+        host='test.com',
+        path=req_path,
+        app='statics'
+    ))
+
+    resp = Response()
+
+    sr(req, resp)
+
+    assert resp.content_type == mtype
+    assert resp.stream == '/var/www/statics' + expected_path
+
+
+def test_lifo(monkeypatch):
+    app = falcon.APIBuilder() \
+        .add_static_route('/downloads', '/opt/somesite/downloads') \
+        .add_static_route('/downloads/archive', '/opt/somesite/x') \
+        .build()
+    client = testing.TestClient(app)
+
+    monkeypatch.setattr(io, 'open', lambda path, mode: [path.encode('utf-8')])
+
+    response = client.simulate_request(path='/downloads/thing.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.text == '/opt/somesite/downloads/thing.zip'
+
+    response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.text == '/opt/somesite/x/thingtoo.zip'
+
+
+def test_lifo_negative(monkeypatch):
+    app = falcon.APIBuilder() \
+        .add_static_route('/downloads/archive', '/opt/somesite/x') \
+        .add_static_route('/downloads', '/opt/somesite/downloads') \
+        .build()
+    client = testing.TestClient(app)
+
+    monkeypatch.setattr(io, 'open', lambda path, mode: [path.encode('utf-8')])
+
+    response = client.simulate_request(path='/downloads/thing.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.text == '/opt/somesite/downloads/thing.zip'
+
+    response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.text == '/opt/somesite/downloads/archive/thingtoo.zip'
+
+
+def test_downloadable(monkeypatch):
+    app = falcon.APIBuilder() \
+        .add_static_route('/downloads', '/opt/somesite/downloads', downloadable=True) \
+        .add_static_route('/assets/', '/opt/somesite/assets') \
+        .build()
+    client = testing.TestClient(app)
+
+    monkeypatch.setattr(io, 'open', lambda path, mode: [path.encode('utf-8')])
+
+    response = client.simulate_request(path='/downloads/thing.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.headers['Content-Disposition'] == 'attachment; filename="thing.zip"'
+
+    response = client.simulate_request(path='/downloads/Some Report.zip')
+    assert response.status == falcon.HTTP_200
+    assert response.headers['Content-Disposition'] == 'attachment; filename="Some Report.zip"'
+
+    response = client.simulate_request(path='/assets/css/main.css')
+    assert response.status == falcon.HTTP_200
+    assert 'Content-Disposition' not in response.headers
+
+
+def test_downloadable_not_found():
+    app = falcon.APIBuilder() \
+        .add_static_route('/downloads', '/opt/somesite/downloads', downloadable=True) \
+        .build()
+    client = testing.TestClient(app)
+
+    response = client.simulate_request(path='/downloads/thing.zip')
+    assert response.status == falcon.HTTP_404
+
+
+@pytest.mark.parametrize('uri, default, expected, content_type', [
+    ('', 'default', 'default', 'application/octet-stream'),
+    ('other', 'default.html', 'default.html', 'text/html'),
+    ('index2', 'index', 'index2', 'application/octet-stream'),
+    ('absolute', '/foo/bar/index', '/foo/bar/index', 'application/octet-stream'),
+    ('docs/notes/test.txt', 'index.html', 'index.html', 'text/html'),
+    ('index.html_files/test.txt', 'index.html', 'index.html_files/test.txt', 'text/plain'),
+])
+@pytest.mark.parametrize('downloadable', [True, False])
+def test_fallback_filename(uri, default, expected, content_type, downloadable,
+                           monkeypatch):
+
+    def mockOpen(path, mode):
+        if default in path:
+            return path
+        raise IOError()
+
+    monkeypatch.setattr(io, 'open', mockOpen)
+    monkeypatch.setattr('os.path.isfile', lambda file: default in file)
+
+    sr = StaticRoute('/static', '/var/www/statics', downloadable=downloadable,
+                     fallback_filename=default)
+
+    req_path = '/static/' + uri
+
+    req = Request(testing.create_environ(
+        host='test.com',
+        path=req_path,
+        app='statics'
+    ))
+    resp = Response()
+    sr(req, resp)
+
+    assert sr.match(req.path)
+    assert resp.stream == os.path.join('/var/www/statics', expected)
+    assert resp.content_type == content_type
+
+    if downloadable:
+        assert os.path.basename(expected) in resp.downloadable_as
+    else:
+        assert resp.downloadable_as is None
+
+
+@pytest.mark.parametrize('strip_slash', [True, False])
+@pytest.mark.parametrize('path, fallback, static_exp, assert_axp', [
+    ('/index', 'index.html', 'index', 'index'),
+    ('', 'index.html', 'index.html', None),
+    ('/', 'index.html', 'index.html', None),
+    ('/other', 'index.html', 'index.html', None),
+    ('/other', 'index.raise', None, None)
+])
+def test_e2e_fallback_filename(monkeypatch, strip_slash, path, fallback,
+                               static_exp, assert_axp):
+
+    def mockOpen(path, mode):
+        if 'index' in path and 'raise' not in path:
+            return [path.encode('utf-8')]
+        raise IOError()
+
+    monkeypatch.setattr(io, 'open', mockOpen)
+    monkeypatch.setattr('os.path.isfile', lambda file: 'index' in file)
+
+    app = falcon.APIBuilder() \
+        .add_static_route(
+            '/static', '/opt/somesite/static',
+            fallback_filename=fallback) \
+        .add_static_route('/assets/', '/opt/somesite/assets') \
+        .build()
+    client = testing.TestClient(app)
+
+    client.app.req_options.strip_url_path_trailing_slash = strip_slash
+
+    def test(prefix, directory, expected):
+        response = client.simulate_request(path=prefix + path)
+        if expected is None:
+            assert response.status == falcon.HTTP_404
+        else:
+            assert response.status == falcon.HTTP_200
+            assert response.text == directory + expected
+
+    test('/static', '/opt/somesite/static/', static_exp)
+    test('/assets', '/opt/somesite/assets/', assert_axp)
+
+
+@pytest.mark.parametrize('default, path, expected', [
+    (None, '/static', False),
+    (None, '/static/', True),
+    (None, '/staticfoo', False),
+    (None, '/static/foo', True),
+    ('index2', '/static', True),
+    ('index2', '/static/', True),
+    ('index2', '/staticfoo', False),
+    ('index2', '/static/foo', True),
+])
+def test_match(default, path, expected, monkeypatch):
+    monkeypatch.setattr('os.path.isfile', lambda file: True)
+    sr = StaticRoute('/static', '/var/www/statics', fallback_filename=default)
+
+    assert sr.match(path) == expected
+
+
+def test_filesystem_traversal_fuse(monkeypatch):
+
+    def suspicious_normpath(path):
+        return 'assets/../../../../' + path
+
+    monkeypatch.setattr('os.path.normpath', suspicious_normpath)
+
+    app = falcon.APIBuilder() \
+        .add_static_route('/static', '/etc/nginx/includes/static-data') \
+        .build()
+    client = testing.TestClient(app)
+
+    response = client.simulate_request(path='/static/shadow')
+    assert response.status == falcon.HTTP_404

--- a/tests/test_uri_templates_builder.py
+++ b/tests/test_uri_templates_builder.py
@@ -1,0 +1,546 @@
+"""Application tests for URI templates using simulate_get().
+
+These tests differ from those in test_default_router in that they are
+a collection of sanity-checks that exercise the full framework code
+path via simulate_get(), vs. probing the router directly.
+"""
+
+from datetime import datetime
+import uuid
+
+import pytest
+import six
+
+import falcon
+from falcon import testing
+
+_TEST_UUID = uuid.uuid4()
+_TEST_UUID_2 = uuid.uuid4()
+_TEST_UUID_STR = str(_TEST_UUID)
+_TEST_UUID_STR_2 = str(_TEST_UUID_2)
+_TEST_UUID_STR_SANS_HYPHENS = _TEST_UUID_STR.replace('-', '')
+
+
+class IDResource(object):
+    def __init__(self):
+        self.id = None
+        self.name = None
+        self.called = False
+
+    def on_get(self, req, resp, id):
+        self.id = id
+        self.called = True
+        self.req = req
+
+
+class NameResource(object):
+    def __init__(self):
+        self.id = None
+        self.name = None
+        self.called = False
+
+    def on_get(self, req, resp, id, name):
+        self.id = id
+        self.name = name
+        self.called = True
+
+
+class NameAndDigitResource(object):
+    def __init__(self):
+        self.id = None
+        self.name51 = None
+        self.called = False
+
+    def on_get(self, req, resp, id, name51):
+        self.id = id
+        self.name51 = name51
+        self.called = True
+
+
+class FileResource(object):
+    def __init__(self):
+        self.file_id = None
+        self.called = False
+
+    def on_get(self, req, resp, file_id):
+        self.file_id = file_id
+        self.called = True
+
+
+class FileDetailsResource(object):
+    def __init__(self):
+        self.file_id = None
+        self.ext = None
+        self.called = False
+
+    def on_get(self, req, resp, file_id, ext):
+        self.file_id = file_id
+        self.ext = ext
+        self.called = True
+
+
+class ResourceWithSuffixRoutes(object):
+    def __init__(self):
+        self.get_called = False
+        self.post_called = False
+        self.put_called = False
+
+    def on_get(self, req, resp, collection_id, item_id):
+        self.collection_id = collection_id
+        self.item_id = item_id
+        self.get_called = True
+
+    def on_post(self, req, resp, collection_id, item_id):
+        self.collection_id = collection_id
+        self.item_id = item_id
+        self.post_called = True
+
+    def on_put(self, req, resp, collection_id, item_id):
+        self.collection_id = collection_id
+        self.item_id = item_id
+        self.put_called = True
+
+    def on_get_collection(self, req, resp, collection_id):
+        self.collection_id = collection_id
+        self.get_called = True
+
+    def on_post_collection(self, req, resp, collection_id):
+        self.collection_id = collection_id
+        self.post_called = True
+
+    def on_put_collection(self, req, resp, collection_id):
+        self.collection_id = collection_id
+        self.put_called = True
+
+
+@pytest.fixture
+def resource():
+    return testing.SimpleTestResource()
+
+
+def test_root_path(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+    client.simulate_get('/')
+    assert resource.called
+
+
+def test_no_vars(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/hello/world', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+    client.simulate_get('/hello/world')
+    assert resource.called
+
+
+@pytest.mark.skipif(six.PY3, reason='Test only applies to Python 2')
+def test_unicode_literal_routes(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route(u'/hello/world', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+    client.simulate_get('/hello/world')
+    assert resource.called
+
+
+def test_special_chars(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/hello/world.json', resource.on_get) \
+        .add_get_route('/hello(world)', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    client.simulate_get('/hello/world_json')
+    assert not resource.called
+
+    client.simulate_get('/helloworld')
+    assert not resource.called
+
+    client.simulate_get('/hello/world.json')
+    assert resource.called
+
+    client.simulate_get('/hello(world)')
+    assert resource.called
+
+
+@pytest.mark.parametrize('field_name', [
+    'id',
+    'id123',
+    'widget_id',
+])
+def test_single(resource, field_name):
+    template = '/widgets/{{{}}}'.format(field_name)
+
+    app = falcon.APIBuilder() \
+        .add_get_route(template, resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    client.simulate_get('/widgets/123')
+    assert resource.called
+    assert resource.captured_kwargs[field_name] == '123'
+
+
+@pytest.mark.parametrize('uri_template,', [
+    '/{id:int}',
+    '/{id:int(3)}',
+    '/{id:int(min=123)}',
+    '/{id:int(min=123, max=123)}',
+])
+def test_int_converter(uri_template):
+    resource1 = IDResource()
+
+    app = falcon.APIBuilder() \
+        .add_get_route(uri_template, resource1.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/123')
+
+    assert result.status_code == 200
+    assert resource1.called
+    assert resource1.id == 123
+    assert resource1.req.path == '/123'
+
+
+@pytest.mark.parametrize('uri_template,', [
+    '/{id:int(2)}',
+    '/{id:int(min=124)}',
+    '/{id:int(num_digits=3, max=100)}',
+])
+def test_int_converter_rejections(uri_template):
+    resource1 = IDResource()
+
+    app = falcon.APIBuilder() \
+        .add_get_route(uri_template, resource1.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/123')
+
+    assert result.status_code == 404
+    assert not resource1.called
+
+
+@pytest.mark.parametrize('uri_template, path, dt_expected', [
+    (
+        '/{start_year:int}-to-{timestamp:dt}',
+        '/1961-to-1969-07-21T02:56:00Z',
+        datetime(1969, 7, 21, 2, 56, 0)
+    ),
+    (
+        '/{start_year:int}-to-{timestamp:dt("%Y-%m-%d")}',
+        '/1961-to-1969-07-21',
+        datetime(1969, 7, 21)
+    ),
+    (
+        '/{start_year:int}/{timestamp:dt("%Y-%m-%d %H:%M")}',
+        '/1961/1969-07-21 14:30',
+        datetime(1969, 7, 21, 14, 30)
+    ),
+    (
+        '/{start_year:int}-to-{timestamp:dt("%Y-%m")}',
+        '/1961-to-1969-07-21',
+        None
+    ),
+])
+def test_datetime_converter(resource, uri_template, path, dt_expected):
+    app = falcon.APIBuilder() \
+        .add_get_route(uri_template, resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get(path)
+
+    if dt_expected is None:
+        assert result.status_code == 404
+        assert not resource.called
+    else:
+        assert result.status_code == 200
+        assert resource.called
+        assert resource.captured_kwargs['start_year'] == 1961
+        assert resource.captured_kwargs['timestamp'] == dt_expected
+
+
+@pytest.mark.parametrize('uri_template, path, expected', [
+    (
+        '/widgets/{widget_id:uuid}',
+        '/widgets/' + _TEST_UUID_STR,
+        {'widget_id': _TEST_UUID}
+    ),
+    (
+        '/widgets/{widget_id:uuid}/orders',
+        '/widgets/' + _TEST_UUID_STR_SANS_HYPHENS + '/orders',
+        {'widget_id': _TEST_UUID}
+    ),
+    (
+        '/versions/diff/{left:uuid()}...{right:uuid()}',
+        '/versions/diff/{}...{}'.format(_TEST_UUID_STR, _TEST_UUID_STR_2),
+        {'left': _TEST_UUID, 'right': _TEST_UUID_2, }
+    ),
+    (
+        '/versions/diff/{left:uuid}...{right:uuid()}',
+        '/versions/diff/{}...{}'.format(_TEST_UUID_STR, _TEST_UUID_STR_2),
+        {'left': _TEST_UUID, 'right': _TEST_UUID_2, }
+    ),
+    (
+        '/versions/diff/{left:uuid()}...{right:uuid}',
+        '/versions/diff/{}...{}'.format(_TEST_UUID_STR, _TEST_UUID_STR_2),
+        {'left': _TEST_UUID, 'right': _TEST_UUID_2, }
+    ),
+    (
+        '/widgets/{widget_id:uuid}/orders',
+        '/widgets/' + _TEST_UUID_STR_SANS_HYPHENS[:-1] + '/orders',
+        None
+    ),
+])
+def test_uuid_converter(resource, uri_template, path, expected):
+    app = falcon.APIBuilder() \
+        .add_get_route(uri_template, resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get(path)
+
+    if expected is None:
+        assert result.status_code == 404
+        assert not resource.called
+    else:
+        assert result.status_code == 200
+        assert resource.called
+        assert resource.captured_kwargs == expected
+
+
+def test_uuid_converter_complex_segment(resource):
+    app = falcon.APIBuilder() \
+        .add_get_route('/pages/{first:uuid}...{last:uuid}', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    first_uuid = uuid.uuid4()
+    last_uuid = uuid.uuid4()
+
+    result = client.simulate_get('/pages/{}...{}'.format(
+        first_uuid,
+        last_uuid
+    ))
+
+    assert result.status_code == 200
+    assert resource.called
+    assert resource.captured_kwargs['first'] == first_uuid
+    assert resource.captured_kwargs['last'] == last_uuid
+
+
+@pytest.mark.parametrize('uri_template, path, expected', [
+    (
+        '/{food:spam}',
+        '/something',
+        {'food': 'spam!'}
+    ),
+    (
+        '/{food:spam(")")}:{food_too:spam("()")}',
+        '/bacon:eggs',
+        {'food': 'spam!', 'food_too': 'spam!'}
+    ),
+    (
+        '/({food:spam()}){food_too:spam("()")}',
+        '/(bacon)eggs',
+        {'food': 'spam!', 'food_too': 'spam!'}
+    ),
+])
+def test_converter_custom(resource, uri_template, path, expected):
+
+    class SpamConverter(object):
+        def __init__(self, useless_text=None):
+            pass
+
+        def convert(self, fragment):
+            return 'spam!'
+
+    router = falcon.routing.DefaultRouter()
+    router.options.converters['spam'] = SpamConverter
+
+    app = falcon.APIBuilder() \
+        .set_router(router) \
+        .add_get_route(uri_template, resource.on_get) \
+        .add_post_route(uri_template, resource.on_post) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get(path)
+
+    assert result.status_code == 200
+    assert resource.called
+    assert resource.captured_kwargs == expected
+
+
+def test_single_trailing_slash():
+    resource1 = IDResource()
+    resource2 = IDResource()
+    resource3 = IDResource()
+    resource4 = IDResource()
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/1/{id}/', resource1.on_get) \
+        .add_get_route('/2/{id}/', resource2.on_get) \
+        .add_get_route('/3/{id}/', resource3.on_get) \
+        .add_get_route('/4/{id}', resource4.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    result = client.simulate_get('/1/123')
+    assert result.status == falcon.HTTP_200
+    assert resource1.called
+    assert resource1.id == '123'
+    assert resource1.req.path == '/1/123'
+
+    result = client.simulate_get('/2/123/')
+    assert result.status == falcon.HTTP_404
+    assert not resource2.called
+    assert resource2.id is None
+
+    client.app.req_options.strip_url_path_trailing_slash = True
+    result = client.simulate_get('/3/123/')
+    assert result.status == falcon.HTTP_200
+    assert resource3.called
+    assert resource3.id == '123'
+    assert resource3.req.path == '/3/123'
+
+    client.app.req_options.strip_url_path_trailing_slash = False
+    result = client.simulate_get('/4/123/')
+    assert result.status == falcon.HTTP_404
+    assert not resource4.called
+    assert resource4.id is None
+
+
+def test_multiple():
+    resource = NameResource()
+
+    app = falcon.APIBuilder() \
+        .add_get_route('/messages/{id}/names/{name}', resource.on_get) \
+        .build()
+    client = testing.TestClient(app)
+
+    test_id = 'bfb54d43-219b-4336-a623-6172f920592e'
+    test_name = '758e3922-dd6d-4007-a589-50fba0789365'
+    path = '/messages/' + test_id + '/names/' + test_name
+    client.simulate_get(path)
+
+    assert resource.called
+    assert resource.id == test_id
+    assert resource.name == test_name
+
+
+@pytest.mark.parametrize('uri_template', [
+    '//',
+    '//begin',
+    '/end//',
+    '/in//side',
+])
+def test_empty_path_component(resource, uri_template):
+    with pytest.raises(ValueError):
+        falcon.APIBuilder() \
+            .add_get_route(uri_template, resource.on_get) \
+            .add_post_route(uri_template, resource.on_post) \
+            .build()
+
+
+@pytest.mark.parametrize('uri_template', [
+    '',
+    'no',
+    'no/leading_slash',
+])
+def test_relative_path(resource, uri_template):
+    with pytest.raises(ValueError):
+        falcon.APIBuilder() \
+            .add_get_route(uri_template, resource.on_get) \
+            .add_post_route(uri_template, resource.on_post) \
+            .build()
+
+
+@pytest.mark.parametrize('reverse', [True, False])
+def test_same_level_complex_var(reverse):
+    file_resource = FileResource()
+    details_resource = FileDetailsResource()
+
+    routes = [
+        ('/files/{file_id}', file_resource),
+        ('/files/{file_id}.{ext}', details_resource)
+    ]
+    if reverse:
+        routes.reverse()
+
+    app_builder = falcon.APIBuilder()
+
+    for uri_template, resource in routes:
+        app_builder.add_get_route(uri_template, resource.on_get)
+
+    client = testing.TestClient(app_builder.build())
+
+    file_id_1 = 'bc6b201d-b449-4290-a061-8eeb9f7b1450'
+    file_id_2 = '33b7f34c-6ee6-40e6-89a3-742a69b59de0'
+    ext = 'a4581b95-bc36-4c08-a3c2-23ba266abdf2'
+    path_1 = '/files/' + file_id_1
+    path_2 = '/files/' + file_id_2 + '.' + ext
+
+    client.simulate_get(path_1)
+    assert file_resource.called
+    assert file_resource.file_id == file_id_1
+
+    client.simulate_get(path_2)
+    assert details_resource.called
+    assert details_resource.file_id == file_id_2
+    assert details_resource.ext == ext
+
+
+def test_adding_suffix_routes():
+    resource_with_suffix_routes = ResourceWithSuffixRoutes()
+    app = falcon.APIBuilder() \
+        .add_get_route(
+            '/collections/{collection_id}/items/{item_id}',
+            resource_with_suffix_routes.on_get) \
+        .add_get_route(
+            '/collections/{collection_id}/items',
+            resource_with_suffix_routes.on_get_collection,
+            suffix='collection') \
+        .add_post_route(
+            '/collections/{collection_id}/items/{item_id}',
+            resource_with_suffix_routes.on_post) \
+        .add_post_route(
+            '/collections/{collection_id}/items',
+            resource_with_suffix_routes.on_post_collection,
+            suffix='collection') \
+        .add_put_route(
+            '/collections/{collection_id}/items/{item_id}',
+            resource_with_suffix_routes.on_put) \
+        .add_put_route(
+            '/collections/{collection_id}/items',
+            resource_with_suffix_routes.on_put_collection,
+            suffix='collection') \
+        .build()
+    client = testing.TestClient(app)
+
+    # GET
+    client.simulate_get('/collections/123/items/456')
+    assert resource_with_suffix_routes.collection_id == '123'
+    assert resource_with_suffix_routes.item_id == '456'
+    assert resource_with_suffix_routes.get_called
+    client.simulate_get('/collections/foo/items')
+    assert resource_with_suffix_routes.collection_id == 'foo'
+    # POST
+    client.simulate_post('/collections/foo234/items/foo456')
+    assert resource_with_suffix_routes.collection_id == 'foo234'
+    assert resource_with_suffix_routes.item_id == 'foo456'
+    assert resource_with_suffix_routes.post_called
+    client.simulate_post('/collections/foo123/items')
+    assert resource_with_suffix_routes.collection_id == 'foo123'
+    # PUT
+    client.simulate_put('/collections/foo345/items/foo567')
+    assert resource_with_suffix_routes.collection_id == 'foo345'
+    assert resource_with_suffix_routes.item_id == 'foo567'
+    assert resource_with_suffix_routes.put_called
+    client.simulate_put('/collections/foo321/items')
+    assert resource_with_suffix_routes.collection_id == 'foo321'

--- a/tests/test_utils_builder.py
+++ b/tests/test_utils_builder.py
@@ -1,0 +1,682 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+import functools
+import random
+
+import pytest
+import six
+
+import falcon
+from falcon import testing
+from falcon import util
+from falcon.util import json, uri
+
+
+def _arbitrary_uris(count, length):
+    return (
+        u''.join(
+            [random.choice(uri._ALL_ALLOWED)
+             for _ in range(length)]
+        ) for __ in range(count)
+    )
+
+
+class TestFalconUtils(object):
+
+    def setup_method(self, method):
+        # NOTE(cabrera): for DRYness - used in uri.[de|en]code tests
+        # below.
+        self.uris = _arbitrary_uris(count=100, length=32)
+
+    def test_deprecated_decorator(self):
+        msg = 'Please stop using this thing. It is going away.'
+
+        @util.deprecated(msg)
+        def old_thing():
+            pass
+
+        with pytest.warns(UserWarning) as rec:
+            old_thing()
+
+        warn = rec.pop()
+        assert msg in str(warn.message)
+
+    def test_http_now(self):
+        expected = datetime.utcnow()
+        actual = falcon.http_date_to_dt(falcon.http_now())
+
+        delta = actual - expected
+        delta_sec = abs(delta.days * 86400 + delta.seconds)
+
+        assert delta_sec <= 1
+
+    def test_dt_to_http(self):
+        assert falcon.dt_to_http(datetime(2013, 4, 4)) == 'Thu, 04 Apr 2013 00:00:00 GMT'
+
+        assert falcon.dt_to_http(
+            datetime(2013, 4, 4, 10, 28, 54)
+        ) == 'Thu, 04 Apr 2013 10:28:54 GMT'
+
+    def test_http_date_to_dt(self):
+        assert falcon.http_date_to_dt('Thu, 04 Apr 2013 00:00:00 GMT') == datetime(2013, 4, 4)
+
+        assert falcon.http_date_to_dt(
+            'Thu, 04 Apr 2013 10:28:54 GMT'
+        ) == datetime(2013, 4, 4, 10, 28, 54)
+
+        with pytest.raises(ValueError):
+            falcon.http_date_to_dt('Thu, 04-Apr-2013 10:28:54 GMT')
+
+        assert falcon.http_date_to_dt(
+            'Thu, 04-Apr-2013 10:28:54 GMT', obs_date=True
+        ) == datetime(2013, 4, 4, 10, 28, 54)
+
+        with pytest.raises(ValueError):
+            falcon.http_date_to_dt('Sun Nov  6 08:49:37 1994')
+
+        with pytest.raises(ValueError):
+            falcon.http_date_to_dt('Nov  6 08:49:37 1994', obs_date=True)
+
+        assert falcon.http_date_to_dt(
+            'Sun Nov  6 08:49:37 1994', obs_date=True
+        ) == datetime(1994, 11, 6, 8, 49, 37)
+
+        assert falcon.http_date_to_dt(
+            'Sunday, 06-Nov-94 08:49:37 GMT', obs_date=True
+        ) == datetime(1994, 11, 6, 8, 49, 37)
+
+    def test_pack_query_params_none(self):
+        assert falcon.to_query_str({}) == ''
+
+    def test_pack_query_params_one(self):
+        assert falcon.to_query_str({'limit': 10}) == '?limit=10'
+
+        assert falcon.to_query_str(
+            {'things': [1, 2, 3]}) == '?things=1,2,3'
+
+        assert falcon.to_query_str({'things': ['a']}) == '?things=a'
+
+        assert falcon.to_query_str(
+            {'things': ['a', 'b']}) == '?things=a,b'
+
+        expected = ('?things=a&things=b&things=&things=None'
+                    '&things=true&things=false&things=0')
+
+        actual = falcon.to_query_str(
+            {'things': ['a', 'b', '', None, True, False, 0]},
+            comma_delimited_lists=False
+        )
+
+        assert actual == expected
+
+    def test_pack_query_params_several(self):
+        garbage_in = {
+            'limit': 17,
+            'echo': True,
+            'doit': False,
+            'x': 'val',
+            'y': 0.2
+        }
+
+        query_str = falcon.to_query_str(garbage_in)
+        fields = query_str[1:].split('&')
+
+        garbage_out = {}
+        for field in fields:
+            k, v = field.split('=')
+            garbage_out[k] = v
+
+        expected = {
+            'echo': 'true',
+            'limit': '17',
+            'x': 'val',
+            'y': '0.2',
+            'doit': 'false'}
+
+        assert expected == garbage_out
+
+    def test_uri_encode(self):
+        url = 'http://example.com/v1/fizbit/messages?limit=3&echo=true'
+        assert uri.encode(url) == url
+
+        url = 'http://example.com/v1/fiz bit/messages'
+        expected = 'http://example.com/v1/fiz%20bit/messages'
+        assert uri.encode(url) == expected
+
+        url = u'http://example.com/v1/fizbit/messages?limit=3&e\u00e7ho=true'
+        expected = ('http://example.com/v1/fizbit/messages'
+                    '?limit=3&e%C3%A7ho=true')
+        assert uri.encode(url) == expected
+
+    def test_uri_encode_double(self):
+        url = 'http://example.com/v1/fiz bit/messages'
+        expected = 'http://example.com/v1/fiz%20bit/messages'
+        assert uri.encode(uri.encode(url)) == expected
+
+        url = u'http://example.com/v1/fizbit/messages?limit=3&e\u00e7ho=true'
+        expected = ('http://example.com/v1/fizbit/messages'
+                    '?limit=3&e%C3%A7ho=true')
+        assert uri.encode(uri.encode(url)) == expected
+
+        url = 'http://example.com/v1/fiz%bit/mess%ages/%'
+        expected = 'http://example.com/v1/fiz%25bit/mess%25ages/%25'
+        assert uri.encode(uri.encode(url)) == expected
+
+        url = 'http://example.com/%%'
+        expected = 'http://example.com/%25%25'
+        assert uri.encode(uri.encode(url)) == expected
+
+        # NOTE(kgriffs): Specific example cited in GH issue
+        url = 'http://something?redirect_uri=http%3A%2F%2Fsite'
+        assert uri.encode(url) == url
+
+        hex_digits = 'abcdefABCDEF0123456789'
+        for c1 in hex_digits:
+            for c2 in hex_digits:
+                url = 'http://example.com/%' + c1 + c2
+                encoded = uri.encode(uri.encode(url))
+                assert encoded == url
+
+    def test_uri_encode_value(self):
+        assert uri.encode_value('abcd') == 'abcd'
+        assert uri.encode_value(u'abcd') == u'abcd'
+        assert uri.encode_value(u'ab cd') == u'ab%20cd'
+        assert uri.encode_value(u'\u00e7') == '%C3%A7'
+        assert uri.encode_value(u'\u00e7\u20ac') == '%C3%A7%E2%82%AC'
+        assert uri.encode_value('ab/cd') == 'ab%2Fcd'
+        assert uri.encode_value('ab+cd=42,9') == 'ab%2Bcd%3D42%2C9'
+
+    def test_uri_decode(self):
+        assert uri.decode('abcd') == 'abcd'
+        assert uri.decode(u'abcd') == u'abcd'
+        assert uri.decode(u'ab%20cd') == u'ab cd'
+
+        assert uri.decode('This thing is %C3%A7') == u'This thing is \u00e7'
+
+        assert uri.decode('This thing is %C3%A7%E2%82%AC') == u'This thing is \u00e7\u20ac'
+
+        assert uri.decode('ab%2Fcd') == 'ab/cd'
+
+        assert uri.decode(
+            'http://example.com?x=ab%2Bcd%3D42%2C9'
+        ) == 'http://example.com?x=ab+cd=42,9'
+
+    def test_prop_uri_encode_models_stdlib_quote(self):
+        equiv_quote = functools.partial(
+            six.moves.urllib.parse.quote, safe=uri._ALL_ALLOWED
+        )
+        for case in self.uris:
+            expect = equiv_quote(case)
+            actual = uri.encode(case)
+            assert expect == actual
+
+    def test_prop_uri_encode_value_models_stdlib_quote_safe_tilde(self):
+        equiv_quote = functools.partial(
+            six.moves.urllib.parse.quote, safe='~'
+        )
+        for case in self.uris:
+            expect = equiv_quote(case)
+            actual = uri.encode_value(case)
+            assert expect == actual
+
+    def test_prop_uri_decode_models_stdlib_unquote_plus(self):
+        stdlib_unquote = six.moves.urllib.parse.unquote_plus
+        for case in self.uris:
+            case = uri.encode_value(case)
+
+            expect = stdlib_unquote(case)
+            actual = uri.decode(case)
+            assert expect == actual
+
+    def test_unquote_string(self):
+        assert uri.unquote_string('v') == 'v'
+        assert uri.unquote_string('not-quoted') == 'not-quoted'
+        assert uri.unquote_string('partial-quoted"') == 'partial-quoted"'
+        assert uri.unquote_string('"partial-quoted') == '"partial-quoted'
+        assert uri.unquote_string('"partial-quoted"') == 'partial-quoted'
+
+    def test_parse_query_string(self):
+        query_strinq = (
+            'a=http%3A%2F%2Ffalconframework.org%3Ftest%3D1'
+            '&b=%7B%22test1%22%3A%20%22data1%22%'
+            '2C%20%22test2%22%3A%20%22data2%22%7D'
+            '&c=1,2,3'
+            '&d=test'
+            '&e=a,,%26%3D%2C'
+            '&f=a&f=a%3Db'
+            '&%C3%A9=a%3Db'
+        )
+        decoded_url = 'http://falconframework.org?test=1'
+        decoded_json = '{"test1": "data1", "test2": "data2"}'
+
+        result = uri.parse_query_string(query_strinq)
+        assert result['a'] == decoded_url
+        assert result['b'] == decoded_json
+        assert result['c'] == ['1', '2', '3']
+        assert result['d'] == 'test'
+        assert result['e'] == ['a', '&=,']
+        assert result['f'] == ['a', 'a=b']
+        assert result[u'é'] == 'a=b'
+
+        result = uri.parse_query_string(query_strinq, True)
+        assert result['a'] == decoded_url
+        assert result['b'] == decoded_json
+        assert result['c'] == ['1', '2', '3']
+        assert result['d'] == 'test'
+        assert result['e'] == ['a', '', '&=,']
+        assert result['f'] == ['a', 'a=b']
+        assert result[u'é'] == 'a=b'
+
+    def test_parse_host(self):
+        assert uri.parse_host('::1') == ('::1', None)
+        assert uri.parse_host('2001:ODB8:AC10:FE01::') == ('2001:ODB8:AC10:FE01::', None)
+        assert uri.parse_host(
+            '2001:ODB8:AC10:FE01::', default_port=80
+        ) == ('2001:ODB8:AC10:FE01::', 80)
+
+        ipv6_addr = '2001:4801:1221:101:1c10::f5:116'
+
+        assert uri.parse_host(ipv6_addr) == (ipv6_addr, None)
+        assert uri.parse_host('[' + ipv6_addr + ']') == (ipv6_addr, None)
+        assert uri.parse_host('[' + ipv6_addr + ']:28080') == (ipv6_addr, 28080)
+        assert uri.parse_host('[' + ipv6_addr + ']:8080') == (ipv6_addr, 8080)
+        assert uri.parse_host('[' + ipv6_addr + ']:123') == (ipv6_addr, 123)
+        assert uri.parse_host('[' + ipv6_addr + ']:42') == (ipv6_addr, 42)
+
+        assert uri.parse_host('173.203.44.122') == ('173.203.44.122', None)
+        assert uri.parse_host('173.203.44.122', default_port=80) == ('173.203.44.122', 80)
+        assert uri.parse_host('173.203.44.122:27070') == ('173.203.44.122', 27070)
+        assert uri.parse_host('173.203.44.122:123') == ('173.203.44.122', 123)
+        assert uri.parse_host('173.203.44.122:42') == ('173.203.44.122', 42)
+
+        assert uri.parse_host('example.com') == ('example.com', None)
+        assert uri.parse_host('example.com', default_port=443) == ('example.com', 443)
+        assert uri.parse_host('falcon.example.com') == ('falcon.example.com', None)
+        assert uri.parse_host('falcon.example.com:9876') == ('falcon.example.com', 9876)
+        assert uri.parse_host('falcon.example.com:42') == ('falcon.example.com', 42)
+
+    def test_get_http_status(self):
+        assert falcon.get_http_status(404) == falcon.HTTP_404
+        assert falcon.get_http_status(404.3) == falcon.HTTP_404
+        assert falcon.get_http_status('404.3') == falcon.HTTP_404
+        assert falcon.get_http_status(404.9) == falcon.HTTP_404
+        assert falcon.get_http_status('404') == falcon.HTTP_404
+        assert falcon.get_http_status(123) == '123 Unknown'
+        with pytest.raises(ValueError):
+            falcon.get_http_status('not_a_number')
+        with pytest.raises(ValueError):
+            falcon.get_http_status(0)
+        with pytest.raises(ValueError):
+            falcon.get_http_status(0)
+        with pytest.raises(ValueError):
+            falcon.get_http_status(99)
+        with pytest.raises(ValueError):
+            falcon.get_http_status(-404.3)
+        with pytest.raises(ValueError):
+            falcon.get_http_status('-404')
+        with pytest.raises(ValueError):
+            falcon.get_http_status('-404.3')
+        assert falcon.get_http_status(123, 'Go Away') == '123 Go Away'
+
+
+@pytest.mark.parametrize(
+    'protocol,method',
+    zip(
+        ['https'] * len(falcon.HTTP_METHODS) + ['http'] * len(falcon.HTTP_METHODS),
+        falcon.HTTP_METHODS * 2
+    )
+)
+def test_simulate_request_protocol(protocol, method):
+    sink_called = [False]
+
+    def sink(req, resp):
+        sink_called[0] = True
+        assert req.protocol == protocol
+
+    app = falcon.APIBuilder() \
+        .add_sink(sink, '/test') \
+        .build()
+    client = testing.TestClient(app)
+
+    try:
+        simulate = client.getattr('simulate_' + method.lower())
+        simulate('/test', protocol=protocol)
+        assert sink_called[0]
+    except AttributeError:
+        # NOTE(kgriffs): simulate_* helpers do not exist for all methods
+        pass
+
+
+@pytest.mark.parametrize('simulate', [
+    testing.simulate_get,
+    testing.simulate_head,
+    testing.simulate_post,
+    testing.simulate_put,
+    testing.simulate_options,
+    testing.simulate_patch,
+    testing.simulate_delete,
+])
+def test_simulate_free_functions(simulate):
+    sink_called = [False]
+
+    def sink(req, resp):
+        sink_called[0] = True
+
+    app = falcon.APIBuilder() \
+        .add_sink(sink, '/test') \
+        .build()
+
+    simulate(app, '/test')
+    assert sink_called[0]
+
+
+class TestFalconTestingUtils(object):
+    """Verify some branches not covered elsewhere."""
+
+    def test_path_escape_chars_in_create_environ(self):
+        env = testing.create_environ('/hello%20world%21')
+        assert env['PATH_INFO'] == '/hello world!'
+
+    def test_no_prefix_allowed_for_query_strings_in_create_environ(self):
+        with pytest.raises(ValueError):
+            testing.create_environ(query_string='?foo=bar')
+
+    @pytest.mark.skipif(six.PY3, reason='Test does not apply to Py3K')
+    def test_unicode_path_in_create_environ(self):
+        env = testing.create_environ(u'/fancy/unícode')
+        assert env['PATH_INFO'] == '/fancy/un\xc3\xadcode'
+
+        env = testing.create_environ(u'/simple')
+        assert env['PATH_INFO'] == '/simple'
+
+    def test_none_header_value_in_create_environ(self):
+        env = testing.create_environ('/', headers={'X-Foo': None})
+        assert env['HTTP_X_FOO'] == ''
+
+    def test_decode_empty_result(self):
+        app = falcon.APIBuilder().build()
+        client = testing.TestClient(app)
+        response = client.simulate_request(path='/')
+        assert response.text == ''
+
+    def test_httpnow_alias_for_backwards_compat(self):
+        assert testing.httpnow is util.http_now
+
+    def test_default_headers(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        headers = {
+            'Authorization': 'Bearer 123',
+        }
+
+        client = testing.TestClient(app, headers=headers)
+
+        client.simulate_get()
+        assert resource.captured_req.auth == headers['Authorization']
+
+        client.simulate_get(headers=None)
+        assert resource.captured_req.auth == headers['Authorization']
+
+    def test_default_headers_with_override(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        override_before = 'something-something'
+        override_after = 'something-something'[::-1]
+
+        headers = {
+            'Authorization': 'Bearer XYZ',
+            'Accept': 'application/vnd.siren+json',
+            'X-Override-Me': override_before,
+        }
+
+        client = testing.TestClient(app, headers=headers)
+        client.simulate_get(headers={'X-Override-Me': override_after})
+
+        assert resource.captured_req.auth == headers['Authorization']
+        assert resource.captured_req.accept == headers['Accept']
+        assert resource.captured_req.get_header('X-Override-Me') == override_after
+
+    def test_status(self):
+        resource = testing.SimpleTestResource(status=falcon.HTTP_702)
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.status == falcon.HTTP_702
+
+    def test_wsgi_iterable_not_closeable(self):
+        result = testing.Result([], falcon.HTTP_200, [])
+        assert not result.content
+        assert result.json is None
+
+    def test_path_must_start_with_slash(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        client = testing.TestClient(app)
+        with pytest.raises(ValueError):
+            client.simulate_get('foo')
+
+    def test_cached_text_in_result(self):
+        resource = testing.SimpleTestResource(body='test')
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .add_post_route('/', resource.on_post) \
+            .build()
+        client = testing.TestClient(app)
+
+        result = client.simulate_get()
+        assert result.text == result.text
+
+    def test_simple_resource_body_json_xor(self):
+        with pytest.raises(ValueError):
+            testing.SimpleTestResource(body='', json={})
+
+    def test_query_string(self):
+        class SomeResource(object):
+            def on_get(self, req, resp):
+                doc = {}
+
+                doc['oid'] = req.get_param_as_int('oid')
+                doc['detailed'] = req.get_param_as_bool('detailed')
+                doc['things'] = req.get_param_as_list('things', int)
+                doc['query_string'] = req.query_string
+
+                resp.body = json.dumps(doc)
+        resouce = SomeResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resouce.on_get) \
+            .build()
+        app.req_options.auto_parse_qs_csv = True
+        client = testing.TestClient(app)
+
+        result = client.simulate_get(query_string='oid=42&detailed=no&things=1')
+        assert result.json['oid'] == 42
+        assert not result.json['detailed']
+        assert result.json['things'] == [1]
+
+        params = {'oid': 42, 'detailed': False}
+        result = client.simulate_get(params=params)
+        assert result.json['oid'] == params['oid']
+        assert not result.json['detailed']
+        assert result.json['things'] is None
+
+        params = {'oid': 1978, 'detailed': 'yes', 'things': [1, 2, 3]}
+        result = client.simulate_get(params=params)
+        assert result.json['oid'] == params['oid']
+        assert result.json['detailed']
+        assert result.json['things'] == params['things']
+
+        expected_qs = 'things=1,2,3'
+        result = client.simulate_get(params={'things': [1, 2, 3]})
+        assert result.json['query_string'] == expected_qs
+
+        expected_qs = 'things=1&things=2&things=3'
+        result = client.simulate_get(params={'things': [1, 2, 3]},
+                                     params_csv=False)
+        assert result.json['query_string'] == expected_qs
+
+    def test_query_string_no_question(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+        with pytest.raises(ValueError):
+            client.simulate_get(query_string='?x=1')
+
+    def test_query_string_in_path(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+        with pytest.raises(ValueError):
+            client.simulate_get(path='/thing?x=1')
+
+    @pytest.mark.parametrize('document', [
+        # NOTE(vytas): using an exact binary fraction here to avoid special
+        # code branch for approximate equality as it is not the focus here
+        16.0625,
+        123456789,
+        True,
+        '',
+        u'I am a \u1d0a\ua731\u1d0f\u0274 string.',
+        [1, 3, 3, 7],
+        {u'message': u'\xa1Hello Unicode! \U0001F638'},
+        {
+            'count': 4,
+            'items': [
+                {'number': 'one'},
+                {'number': 'two'},
+                {'number': 'three'},
+                {'number': 'four'},
+            ],
+            'next': None,
+        },
+    ])
+    def test_simulate_json_body(self, document):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_post_route('/', resource.on_post) \
+            .build()
+
+        json_types = ('application/json', 'application/json; charset=UTF-8')
+        client = testing.TestClient(app)
+        client.simulate_post('/', json=document)
+        captured_body = resource.captured_req.stream.read().decode('utf-8')
+        assert json.loads(captured_body) == document
+        assert resource.captured_req.content_type in json_types
+
+        headers = {
+            'Content-Type': 'x-falcon/peregrine',
+            'X-Falcon-Type': 'peregrine',
+        }
+        body = 'If provided, `json` parameter overrides `body`.'
+        client.simulate_post('/', headers=headers, body=body, json=document)
+        assert resource.captured_req.media == document
+        assert resource.captured_req.content_type in json_types
+        assert resource.captured_req.get_header('X-Falcon-Type') == 'peregrine'
+
+    @pytest.mark.parametrize('remote_addr', [
+        None,
+        '127.0.0.1',
+        '8.8.8.8',
+        '104.24.101.85',
+        '2606:4700:30::6818:6455',
+    ])
+    def test_simulate_remote_addr(self, remote_addr):
+        class ShowMyIPResource(object):
+            def on_get(self, req, resp):
+                resp.body = req.remote_addr
+                resp.content_type = falcon.MEDIA_TEXT
+
+        resource = ShowMyIPResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+        resp = client.simulate_get('/', remote_addr=remote_addr)
+        assert resp.status_code == 200
+
+        if remote_addr is None:
+            assert resp.text == '127.0.0.1'
+        else:
+            assert resp.text == remote_addr
+
+    def test_simulate_hostname(self):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+        client.simulate_get('/', protocol='https',
+                            host='falcon.readthedocs.io')
+        assert resource.captured_req.uri == 'https://falcon.readthedocs.io/'
+
+    @pytest.mark.parametrize('extras,expected_headers', [
+        (
+            {},
+            (('user-agent', 'curl/7.24.0 (x86_64-apple-darwin12.0)'),),
+        ),
+        (
+            {'HTTP_USER_AGENT': 'URL/Emacs', 'HTTP_X_FALCON': 'peregrine'},
+            (('user-agent', 'URL/Emacs'), ('x-falcon', 'peregrine')),
+        ),
+    ])
+    def test_simulate_with_environ_extras(self, extras, expected_headers):
+        resource = testing.SimpleTestResource()
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+
+        client = testing.TestClient(app)
+        client.simulate_get('/', extras=extras)
+
+        for header, value in expected_headers:
+            assert resource.captured_req.get_header(header) == value
+
+    def test_override_method_with_extras(self):
+        resource = testing.SimpleTestResource(body='test')
+        app = falcon.APIBuilder() \
+            .add_get_route('/', resource.on_get) \
+            .build()
+        client = testing.TestClient(app)
+
+        with pytest.raises(ValueError):
+            client.simulate_get('/', extras={'REQUEST_METHOD': 'PATCH'})
+
+        resp = client.simulate_get('/', extras={'REQUEST_METHOD': 'GET'})
+        assert resp.status_code == 200
+        assert resp.text == 'test'
+
+
+class TestNoApiClass(testing.TestCase):
+    def test_something(self):
+        self.assertTrue(isinstance(self.app, falcon.API))
+
+
+class TestSetupApi(testing.TestCase):
+    def setUp(self):
+        super(TestSetupApi, self).setUp()
+        self.api = falcon.APIBuilder().build()
+
+    def test_something(self):
+        self.assertTrue(isinstance(self.api, falcon.API))

--- a/tests/test_wsgi_builder.py
+++ b/tests/test_wsgi_builder.py
@@ -1,0 +1,145 @@
+import multiprocessing
+import os
+import time
+from wsgiref.simple_server import make_server
+
+import pytest
+import requests
+
+import falcon
+from falcon.request_helpers import BoundedStream
+import falcon.testing as testing
+
+_SERVER_HOST = 'localhost'
+_SERVER_PORT = 9800 + os.getpid() % 100  # Facilitates parallel test execution
+_SERVER_BASE_URL = 'http://{}:{}/'.format(_SERVER_HOST, _SERVER_PORT)
+_SIZE_1_KB = 1024
+
+
+@pytest.mark.usefixtures('_setup_wsgi_server')
+class TestWSGIServer(object):
+
+    def test_get(self):
+        resp = requests.get(_SERVER_BASE_URL)
+        assert resp.status_code == 200
+        assert resp.text == '127.0.0.1'
+
+    def test_put(self):
+        body = '{}'
+        resp = requests.put(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 200
+        assert resp.text == '{}'
+
+    def test_head_405(self):
+        body = '{}'
+        resp = requests.head(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 405
+
+    def test_post(self):
+        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        resp = requests.post(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 200
+        assert resp.text == body
+
+    def test_post_invalid_content_length(self):
+        headers = {'Content-Length': 'invalid'}
+        resp = requests.post(_SERVER_BASE_URL, headers=headers)
+        assert resp.status_code == 200
+        assert resp.text == ''
+
+    def test_post_read_bounded_stream(self):
+        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        resp = requests.post(_SERVER_BASE_URL + 'bucket', data=body)
+        assert resp.status_code == 200
+        assert resp.text == body
+
+    def test_post_read_bounded_stream_no_body(self):
+        resp = requests.post(_SERVER_BASE_URL + 'bucket')
+        assert not resp.text
+
+
+def _run_server(stop_event):
+    class Things(object):
+        def on_get(self, req, resp):
+            resp.body = req.remote_addr
+
+        def on_post(self, req, resp):
+            resp.body = req.stream.read(_SIZE_1_KB)
+
+        def on_put(self, req, resp):
+            # NOTE(kgriffs): Test that reading past the end does
+            # not hang.
+            req_body = (req.stream.read(1)
+                        for i in range(req.content_length + 1))
+
+            resp.body = b''.join(req_body)
+
+    class Bucket(object):
+        def on_post(self, req, resp):
+            # NOTE(kgriffs): The framework automatically detects
+            # wsgiref's input object type and wraps it; we'll probably
+            # do away with this at some point, but for now we
+            # verify the functionality,
+            assert isinstance(req.stream, BoundedStream)
+
+            # NOTE(kgriffs): Ensure we are reusing the same object for
+            # the sake of efficiency and to ensure a shared state of the
+            # stream. (only in the case that we have decided to
+            # automatically wrap the WSGI input object, i.e. when
+            # running under wsgiref or similar).
+            assert req.stream is req.bounded_stream
+
+            # NOTE(kgriffs): This would normally block when
+            # Content-Length is 0 and the WSGI input object.
+            # BoundedStream fixes that. This is just a sanity check to
+            # make sure req.bounded_stream is what we think it is;
+            # BoundedStream itself has its own unit tests in
+            # test_request_body.py
+            resp.body = req.bounded_stream.read()
+
+            # NOTE(kgriffs): No need to also test the same read() for
+            # req.stream, since we already asserted they are the same
+            # objects.
+
+    things_resource = Things()
+    bucket_resource = Bucket()
+
+    application = falcon.APIBuilder() \
+        .add_get_route('/', things_resource.on_get) \
+        .add_put_route('/', things_resource.on_put) \
+        .add_post_route('/', things_resource.on_post) \
+        .add_post_route('/bucket', bucket_resource.on_post) \
+        .build()
+
+    server = make_server(_SERVER_HOST, _SERVER_PORT, application)
+
+    while not stop_event.is_set():
+        server.handle_request()
+
+
+@pytest.fixture
+def _setup_wsgi_server():
+    stop_event = multiprocessing.Event()
+    process = multiprocessing.Process(
+        target=_run_server,
+        args=(stop_event,)
+    )
+
+    process.start()
+
+    # NOTE(kgriffs): Let the server start up
+    time.sleep(0.2)
+
+    yield
+
+    stop_event.set()
+
+    # NOTE(kgriffs): Pump the request handler loop in case execution
+    # made it to the next server.handle_request() before we sent the
+    # event.
+    try:
+        requests.get(_SERVER_BASE_URL)
+    except Exception:
+        pass  # Process already exited
+
+    process.join()

--- a/tests/test_wsgi_errors.py
+++ b/tests/test_wsgi_errors.py
@@ -18,6 +18,16 @@ def client():
     return testing.TestClient(app)
 
 
+@pytest.fixture
+def builder_client():
+    tehlogger = LoggerResource()
+    app = falcon.APIBuilder() \
+        .add_get_route('/logger', tehlogger.on_get) \
+        .add_head_route('/logger', tehlogger.on_head) \
+        .build()
+    return testing.TestClient(app)
+
+
 class LoggerResource:
 
     def on_get(self, req, resp):
@@ -42,6 +52,10 @@ class TestWSGIError(object):
             # with undefined encoding, so do the encoding manually.
             self.wsgierrors = self.wsgierrors_buffer
 
+    @pytest.mark.parametrize('client', [
+        'client',
+        'builder_client'
+    ], indirect=True)
     def test_responder_logged_bytestring(self, client):
         client.simulate_request(path='/logger',
                                 wsgierrors=self.wsgierrors,
@@ -53,6 +67,10 @@ class TestWSGIError(object):
         assert b'?amount=10' in log
 
     @pytest.mark.skipif(six.PY3, reason='Test only applies to Python 2')
+    @pytest.mark.parametrize('client', [
+        'client',
+        'builder_client'
+    ], indirect=True)
     def test_responder_logged_unicode(self, client):
         client.simulate_request(path='/logger',
                                 wsgierrors=self.wsgierrors,

--- a/tests/test_wsgi_interface.py
+++ b/tests/test_wsgi_interface.py
@@ -1,8 +1,20 @@
 import re
 import sys
 
+import pytest
+
 import falcon
 import falcon.testing as testing
+
+
+@pytest.fixture
+def app():
+    return falcon.API()
+
+
+@pytest.fixture
+def builder_app():
+    return falcon.APIBuilder().build()
 
 
 class TestWSGIInterface(object):
@@ -20,12 +32,15 @@ class TestWSGIInterface(object):
 
         assert mock.exc_info == exc_info
 
-    def test_pep3333(self):
-        api = falcon.API()
+    @pytest.mark.parametrize('app', [
+        'app',
+        'builder_app'
+    ], indirect=True)
+    def test_pep3333(self, app):
         mock = testing.StartResponseMock()
 
         # Simulate a web request (normally done though a WSGI server)
-        response = api(testing.create_environ(), mock)
+        response = app(testing.create_environ(), mock)
 
         # Verify that the response is iterable
         assert _is_iterable(response)


### PR DESCRIPTION
This work wraps the current API object with a builder class.  This affords a few benefits over using the raw API class.

1. We are separating the concerns of building an `API` and using and `API`.  The current `API` class has both setters and doers.  Ideally we would avoid such hybrids.  This builder does not affect the `API` class (for backwards compatibility) but we could at some point deprecate the setters on the `API` object.
2. To better support a builder pattern, the setters in the new `APIBuilder` class all `return self` which means it can be used in a chained way. For example:
```
 app = APIBuilder() \
     .add_get_route('/', foo_resource.get_foos) \
     .add_put_route('/update_bar', update_bar) \
     .build()
```
3. Functions in resources no longer need to be named after HTTP methods and prefixed with the `on_` prefix.  This means that a resource can now have functions named `updated_username`, or `create_user` and have those methods be agnostic of the HTTP method that is directed to them.
4. The builder frees up the tight-REST resource constraint of Falcon, where a resource must be a class with at most one function per HTTP method.
  4.1 A route can now just be a top level python function which takes a `request` and a `response`.
  4.2 A resource can have multiple methods which are using the same HTTP method as long as they are
      using a different uri template. 

For this change I have maintained 100% test coverage by:
1. Adding new tests in `tests/test_api_builder.py` to cover any code paths of the builder.
2. Adding a doubled test in every other test where we instantiate an `API` but using the `APIBuilder` instead.  This should shore up any confidence issues in this new `APIBuilder` providing the same underlying `API` as would have been constructed by calling the `API` directly.