### PR TITLE
refactor(Response): Restore the stream_len alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ matrix:
           env: TOXENV=py37_smoke_cython
         - python: 2.7
           env: TOXENV=docs
-        # TODO(kgriffs): Re-enable once we have mitigated the stream_len
-        #   breaking change in hug.
+        # TODO(kgriffs): Re-enable once Hug is compatible with Falcon 2.0
         # - python: 3.6
         #   env: TOXENV=hug
         - python: 3.7

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -38,10 +38,11 @@ CookieError = compat.http_cookies.CookieError
 
 GMT_TIMEZONE = TimezoneGMT()
 
-_STREAM_LEN_REMOVED_MSG = (
-    'The deprecated stream_len property was removed in Falcon 2.0. '
-    'Please use Response.set_stream() or Response.content_length instead.'
-)
+# TODO(kgriffs): Uncomment when 3.0 development opens
+# _STREAM_LEN_REMOVED_MSG = (
+#     'The deprecated stream_len property was removed in Falcon 3.0. '
+#     'Please use Response.set_stream() or Response.content_length instead.'
+# )
 
 
 class Response(object):
@@ -111,6 +112,8 @@ class Response(object):
                 If the stream is set to an iterable object that requires
                 resource cleanup, it can implement a close() method to do so.
                 The close() method will be called upon completion of the request.
+
+        stream_len (int): Deprecated alias for :attr:`content_length`.
 
         context (dict): Dictionary to hold any data about the response which is
             specific to your app. Falcon itself will not interact with this
@@ -249,17 +252,19 @@ class Response(object):
         # just be thrown away.
         self._data = None
 
-    @property
-    def stream_len(self):
-        # NOTE(kgriffs): Provide some additional information by raising the
-        #   error explicitly.
-        raise AttributeError(_STREAM_LEN_REMOVED_MSG)
+    # TODO(kgriffs): Uncomment when 3.0 development opens
+    # @property
+    # def stream_len(self):
+    #     # NOTE(kgriffs): Provide some additional information by raising the
+    #     #   error explicitly.
+    #     raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
-    @stream_len.setter
-    def stream_len(self, value):
-        # NOTE(kgriffs): We explicitly disallow setting the deprecated attribute
-        #   so that apps relying on it do not fail silently.
-        raise AttributeError(_STREAM_LEN_REMOVED_MSG)
+    # TODO(kgriffs): Uncomment when 3.0 development opens
+    # @stream_len.setter
+    # def stream_len(self, value):
+    #     # NOTE(kgriffs): We explicitly disallow setting the deprecated attribute
+    #     #   so that apps relying on it do not fail silently.
+    #     raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.status)
@@ -826,6 +831,9 @@ class Response(object):
 
         """,
     )
+
+    # TODO(kgriffs): Remove deprecated alias once development opens for 3.0
+    stream_len = content_length
 
     content_range = header_property(
         'Content-Range',

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -212,7 +212,8 @@ class ContentLengthHeaderResource(object):
         self._body = body
 
     def on_get(self, req, resp):
-        resp.content_length = self._content_length
+        # NOTE(kgriffs): Use stream_len for now to cover the deprecated alias
+        resp.stream_len = self._content_length
         resp.body = self._body
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -51,11 +51,12 @@ def test_response_attempt_to_set_read_only_headers():
     assert headers['x-things3'] == 'thing-3a, thing-3b'
 
 
-def test_response_removed_stream_len():
-    resp = falcon.Response()
+# TODO(kgriffs): Uncomment when 3.0 development opens
+# def test_response_removed_stream_len():
+#     resp = falcon.Response()
 
-    with pytest.raises(AttributeError):
-        resp.stream_len = 128
+#     with pytest.raises(AttributeError):
+#         resp.stream_len = 128
 
-    with pytest.raises(AttributeError):
-        resp.stream_len
+#     with pytest.raises(AttributeError):
+#         resp.stream_len


### PR DESCRIPTION
Restore the stream_len alias since it was only deprecated as of 2.0, not 1.4, and we should allow at least one release cycle before removing deprecated parts of the interface.