### PR TITLE
Ensure response status and headers are assigned after `start_response` was called

### DIFF
--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -82,19 +82,19 @@ class Result(object):
             if the response is not valid JSON.
     """
 
-    def __init__(self, iterable, status, headers):
+    def __init__(self, iterable, response_meta):
         self._text = None
 
         self._content = b''.join(iterable)
         if hasattr(iterable, 'close'):
             iterable.close()
 
-        self._status = status
-        self._status_code = int(status[:3])
-        self._headers = CaseInsensitiveDict(headers)
+        self._status = response_meta.status
+        self._status_code = int(self._status[:3])
+        self._headers = CaseInsensitiveDict(response_meta.headers)
 
         cookies = http_cookies.SimpleCookie()
-        for name, value in headers:
+        for name, value in self._headers.items():
             if name.lower() == 'set-cookie':
                 cookies.load(value)
 
@@ -349,7 +349,7 @@ def simulate_request(app, method='GET', path='/', query_string=None,
 
     iterable = validator(env, srmock)
 
-    result = Result(iterable, srmock.status, srmock.headers)
+    result = Result(iterable, srmock)
 
     return result
 

--- a/requirements/tests
+++ b/requirements/tests
@@ -12,3 +12,6 @@ ujson
 # Python 3 Only Handlers
 python-rapidjson; python_version >= '3'
 orjson; python_version >= '3' and python_version != '3.4' and platform_python_implementation != 'PyPy'
+
+# Python 2 Only
+mock; python_version < '3.3'

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,14 @@ setup(
     install_requires=REQUIRES,
     cmdclass=cmdclass,
     ext_modules=ext_modules,
-    tests_require=['testtools', 'requests', 'pyyaml', 'pytest', 'pytest-runner'],
+    tests_require=[
+        'testtools',
+        'requests',
+        'pyyaml',
+        'pytest',
+        'pytest-runner',
+        'mock; python_version < "3.3"'
+    ],
     entry_points={
         'console_scripts': [
             'falcon-bench = falcon.cmd.bench:main',

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,17 @@
+from falcon import status_codes
+from falcon.testing import TestClient
+
+
+def another_dummy_wsgi_app(environ, start_response):
+    start_response(status_codes.HTTP_OK, [('Content-Type', 'text/plain')])
+
+    yield b'It works!'
+
+
+def test_testing_client_handles_generator_wsgi_apps_properly():
+    client = TestClient(another_dummy_wsgi_app)
+
+    response = client.simulate_get('/nevermind')
+
+    assert response.status == status_codes.HTTP_OK
+    assert response.text == 'It works!'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,11 @@ from falcon import testing
 from falcon import util
 from falcon.util import compat, json, misc, structures, uri
 
+if compat.PY3:
+    from unittest import mock
+else:
+    import mock
+
 
 def _arbitrary_uris(count, length):
     return (
@@ -509,7 +514,7 @@ class TestFalconTestingUtils(object):
         assert result.status == falcon.HTTP_702
 
     def test_wsgi_iterable_not_closeable(self):
-        result = testing.Result([], falcon.HTTP_200, [])
+        result = testing.Result([], mock.sentinel.response_meta)
         assert not result.content
         assert result.json is None
 


### PR DESCRIPTION
Closes #1479 