### PR TITLE
perf(Response): Remove unnecessary coercion to str

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Changes to Supported Platforms
 Breaking Changes
 ----------------
 
+- Header-related methods of the ``falcon.Response`` class no longer coerce
+  the passed header name to a string via ``str()``.
+
 New & Improved
 --------------
 

--- a/docs/changes/3.0.0.rst
+++ b/docs/changes/3.0.0.rst
@@ -16,6 +16,9 @@ Changes to Supported Platforms
 Breaking Changes
 ----------------
 
+- Header-related methods of the :class:`~.Response` class no longer coerce
+  the passed header name to a string via ``str()``.
+
 New & Improved
 --------------
 

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -376,7 +376,6 @@ class Response:
         if not is_ascii_encodable(value):
             raise ValueError('"value" is not ascii encodable')
 
-        name = str(name)
         value = str(value)
 
         if self._cookies is None:
@@ -512,7 +511,6 @@ class Response:
         # is not a str, so do the conversion here. It's actually
         # faster to not do an isinstance check. str() will encode
         # to US-ASCII.
-        name = str(name)
         value = str(value)
 
         # NOTE(kgriffs): normalize name by lowercasing it
@@ -581,7 +579,6 @@ class Response:
         # is not a str, so do the conversion here. It's actually
         # faster to not do an isinstance check. str() will encode
         # to US-ASCII.
-        name = str(name)
         value = str(value)
 
         # NOTE(kgriffs): normalize name by lowercasing it
@@ -642,11 +639,9 @@ class Response:
             # is not a str, so do the conversion here. It's actually
             # faster to not do an isinstance check. str() will encode
             # to US-ASCII.
-            name = str(name)
             value = str(value)
 
             name = name.lower()
-
             if name == 'set-cookie':
                 raise HeaderNotSupported('This method cannot be used to set cookies')
 
@@ -755,12 +750,6 @@ class Response:
 
         if anchor is not None:
             value += '; anchor="' + uri_encode(anchor) + '"'
-
-        # NOTE(kgriffs): uwsgi fails with a TypeError if any header
-        # is not a str, so do the conversion here. It's actually
-        # faster to not do an isinstance check. str() will encode
-        # to US-ASCII.
-        value = str(value)
 
         _headers = self._headers
         if 'link' in _headers:


### PR DESCRIPTION
Now that we no longer support Python 2, there is no reason to coerce
variables to a str in certain cases that are cleaned up by this patch.

BREAKING CHANGE: Although in practice this patch should not break any
    apps, it is technically a breaking change in the case that an
    app was passing a non-string value for the header name.