### PR TITLE
Fix for falcon unable to identify JSON

### DIFF
--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -19,14 +19,13 @@ class Handlers(UserDict):
 
     def _resolve_media_type(self, media_type, all_media_types):
         resolved = None
-        prim_sanitised_media = media_type.strip(")'(")
 
         try:
             # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
             # parse the media type, but cannot find a suitable type.
             resolved = mimeparse.best_match(
                 all_media_types,
-                prim_sanitised_media
+                media_type
             )
         except ValueError:
             pass
@@ -42,13 +41,13 @@ class Handlers(UserDict):
             return self.data[media_type]
         except KeyError:
             pass
-
+        sanitised_media = media_type.strip(")',(")
         # PERF(jmvrbanac): Fallback to the slower method
-        resolved = self._resolve_media_type(media_type, self.data.keys())
+        resolved = self._resolve_media_type(sanitised_media, self.data.keys())
 
         if not resolved:
             raise errors.HTTPUnsupportedMediaType(
-                '{0} is an unsupported media type.'.format(media_type)
+                '{0} is an unsupported media type.'.format(sanitised_media)
             )
 
         return self.data[resolved]

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -20,12 +20,14 @@ class Handlers(UserDict):
     def _resolve_media_type(self, media_type, all_media_types):
         resolved = None
 
+        prim_sanitised_media = media_type.strip(")'(")
+
         try:
             # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
             # parse the media type, but cannot find a suitable type.
             resolved = mimeparse.best_match(
                 all_media_types,
-                media_type
+                prim_sanitised_media
             )
         except ValueError:
             pass

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -19,7 +19,6 @@ class Handlers(UserDict):
 
     def _resolve_media_type(self, media_type, all_media_types):
         resolved = None
-
         prim_sanitised_media = media_type.strip(")'(")
 
         try:

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -24,6 +24,7 @@ def create_client(handlers=None):
     ('*/*'),
     ('application/json'),
     ('application/json; charset=utf-8'),
+    ("('application/json; charset=utf-8'),")
 ])
 def test_json(media_type):
     client = create_client()


### PR DESCRIPTION
In certain cases clients will send ('application/json; charset=UTF-8',)
causing mimeparse to except, and falcon to wrongly reject the request.

This attempts to fix this by stripping invalid characters, needs review.