### PR TITLE
refactor(Response): Remove deprecated `stream_len` property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ Breaking Changes
 
 - Header-related methods of the ``falcon.Response`` class no longer coerce
   the passed header name to a string via ``str()``.
+- The deprecated ``stream_len`` property was removed from the ``Response``
+  class. Please use ``Response.set_stream()`` or ``Response.content_length``
+  instead.
 
 New & Improved
 --------------
@@ -96,9 +99,6 @@ Breaking Changes
   ``True``.
 - ``independent_middleware`` kwarg on ``falcon.API`` now defaults to ``True``
   instead of ``False``.
-- The deprecated ``stream_len`` property was removed from the ``Response``
-  class. Please use ``Response.set_stream()`` or ``Response.content_length``
-  instead.
 - ``Request.context_type`` was changed from dict to a bare class implementing
   the mapping interface.
 - ``Response.context_type`` was changed from dict to a bare class implementing

--- a/docs/changes/3.0.0.rst
+++ b/docs/changes/3.0.0.rst
@@ -20,6 +20,9 @@ Breaking Changes
 
 - Header-related methods of the :class:`~.Response` class no longer coerce
   the passed header name to a string via ``str()``.
+- The deprecated ``stream_len`` property was removed from the ``Response``
+  class. Please use ``Response.set_stream()`` or ``Response.content_length``
+  instead.
 
 New & Improved
 --------------

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -35,11 +35,10 @@ from falcon.util.uri import encode_value as uri_encode_value
 
 GMT_TIMEZONE = TimezoneGMT()
 
-# TODO(kgriffs): Uncomment when 3.0 development opens
-# _STREAM_LEN_REMOVED_MSG = (
-#     'The deprecated stream_len property was removed in Falcon 3.0. '
-#     'Please use Response.set_stream() or Response.content_length instead.'
-# )
+_STREAM_LEN_REMOVED_MSG = (
+    'The deprecated stream_len property was removed in Falcon 3.0. '
+    'Please use Response.set_stream() or Response.content_length instead.'
+)
 
 
 class Response:
@@ -99,8 +98,6 @@ class Response:
                 If the stream is set to an iterable object that requires
                 resource cleanup, it can implement a close() method to do so.
                 The close() method will be called upon completion of the request.
-
-        stream_len (int): Deprecated alias for :attr:`content_length`.
 
         context (dict): Dictionary to hold any data about the response which is
             specific to your app. Falcon itself will not interact with this
@@ -239,19 +236,17 @@ class Response:
         # just be thrown away.
         self._data = None
 
-    # TODO(kgriffs): Uncomment when 3.0 development opens
-    # @property
-    # def stream_len(self):
-    #     # NOTE(kgriffs): Provide some additional information by raising the
-    #     #   error explicitly.
-    #     raise AttributeError(_STREAM_LEN_REMOVED_MSG)
+    @property
+    def stream_len(self):
+        # NOTE(kgriffs): Provide some additional information by raising the
+        #   error explicitly.
+        raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
-    # TODO(kgriffs): Uncomment when 3.0 development opens
-    # @stream_len.setter
-    # def stream_len(self, value):
-    #     # NOTE(kgriffs): We explicitly disallow setting the deprecated attribute
-    #     #   so that apps relying on it do not fail silently.
-    #     raise AttributeError(_STREAM_LEN_REMOVED_MSG)
+    @stream_len.setter
+    def stream_len(self, value):
+        # NOTE(kgriffs): We explicitly disallow setting the deprecated attribute
+        #   so that apps relying on it do not fail silently.
+        raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.status)
@@ -798,9 +793,6 @@ class Response:
 
         """,
     )
-
-    # TODO(kgriffs): Remove deprecated alias once development opens for 3.0
-    stream_len = content_length
 
     content_range = header_property(
         'Content-Range',

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -212,8 +212,7 @@ class ContentLengthHeaderResource:
         self._data = data
 
     def on_get(self, req, resp):
-        # NOTE(kgriffs): Use stream_len for now to cover the deprecated alias
-        resp.stream_len = self._content_length
+        resp.content_length = self._content_length
 
         if self._body:
             resp.body = self._body

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -51,12 +51,11 @@ def test_response_attempt_to_set_read_only_headers():
     assert headers['x-things3'] == 'thing-3a, thing-3b'
 
 
-# TODO(kgriffs): Uncomment when 3.0 development opens
-# def test_response_removed_stream_len():
-#     resp = falcon.Response()
+def test_response_removed_stream_len():
+    resp = falcon.Response()
 
-#     with pytest.raises(AttributeError):
-#         resp.stream_len = 128
+    with pytest.raises(AttributeError):
+        resp.stream_len = 128
 
-#     with pytest.raises(AttributeError):
-#         resp.stream_len
+    with pytest.raises(AttributeError):
+        resp.stream_len


### PR DESCRIPTION
This appears to be the only existing functionality marked as deprecated hanging out in the code base. (Part of #1029.)