### PR TITLE
fix(custom-http-methods): Making sure we clean up the env var input string

### DIFF
--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -317,24 +317,26 @@ be used by custom routing engines.
 Custom HTTP Methods
 -------------------
 
-Some applications need to support non-standard HTTP methods, such as FOO or BAR, 
-in addition to the standard HTTP methods like GET and PUT. To support custom
-HTTP methods, use one of the following methods:
+While not advised, some applications need to support non-standard HTTP methods,
+such as FOO or BAR, in addition to the standard HTTP methods like GET and PUT.
+To support custom HTTP methods, use one of the following methods:
 
-- define the FALCON_CUSTOM_HTTP_METHODS environment variable as a comma-delimited
-  list of custom methods, and make sure that environment variable is active in 
-  your API app's environment. For example::
+- Ideally, if you don't use hooks in your application, you can easily add the
+  custom methods in your application setup by overriding the value of
+  ``falcon.constants.COMBINED_METHODS``. For example::
+
+    import falcon.constants
+    falcon.constants.COMBINED_METHODS += ['FOO', 'BAR']
+
+- Due to the nature of hooks, if you do use them, you'll need to define the
+  FALCON_CUSTOM_HTTP_METHODS environment variable as a comma-delimited list
+  of custom methods. For example::
 
     $ export FALCON_CUSTOM_HTTP_METHODS=FOO,BAR
 
-- in your app setup, override the value of ``falcon.constants.COMBINED_METHODS``
-  to include your custom methods. For example::
 
-    import falcon.constants
-    falcon.constants += ['FOO', 'BAR']
-
-Once you have notified the framework that it should support these custom methods,
-you can define request methods like any other HTTP method, such as::
+Once you have used the appropriate method, your custom methods should be active.
+You then can define request methods like any other HTTP method, such as::
 
     def on_foo(self, req, resp):
         ...

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -26,8 +26,8 @@ WEBDAV_METHODS = [
 # if FALCON_CUSTOM_HTTP_METHODS is defined, treat it as a comma-
 # delimited string of additional supported methods in this env.
 FALCON_CUSTOM_HTTP_METHODS = [
-    method for method in
-    (os.environ.get('FALCON_CUSTOM_HTTP_METHODS') or '').split(',')
+    method.strip().upper()
+    for method in os.environ.get('FALCON_CUSTOM_HTTP_METHODS', '').split(',')
     if method != ''
 ]
 

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -28,7 +28,7 @@ WEBDAV_METHODS = [
 FALCON_CUSTOM_HTTP_METHODS = [
     method.strip().upper()
     for method in os.environ.get('FALCON_CUSTOM_HTTP_METHODS', '').split(',')
-    if method != ''
+    if method.strip() != ''
 ]
 
 COMBINED_METHODS = HTTP_METHODS + WEBDAV_METHODS + FALCON_CUSTOM_HTTP_METHODS

--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -16,7 +16,7 @@
 
 import re
 
-from falcon import COMBINED_METHODS, responders
+from falcon import constants, responders
 
 
 class SuffixedMethodNotFoundError(Exception):
@@ -108,7 +108,7 @@ def map_http_methods(resource, suffix=None):
 
     method_map = {}
 
-    for method in COMBINED_METHODS:
+    for method in constants.COMBINED_METHODS:
         try:
             responder_name = 'on_' + method.lower()
             if suffix:
@@ -149,6 +149,6 @@ def set_default_responders(method_map):
 
     na_responder = responders.create_method_not_allowed(allowed_methods)
 
-    for method in COMBINED_METHODS:
+    for method in constants.COMBINED_METHODS:
         if method not in allowed_methods:
             method_map[method] = na_responder

--- a/tests/test_http_custom_method_routing.py
+++ b/tests/test_http_custom_method_routing.py
@@ -1,3 +1,6 @@
+import importlib
+import os
+
 import pytest
 
 import falcon
@@ -8,16 +11,26 @@ from falcon.routing.util import map_http_methods
 FALCON_CUSTOM_HTTP_METHODS = ['FOO', 'BAR']
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def resource_things():
     return ThingsResource()
 
 
 @pytest.fixture
-def client():
+def cleanup_constants():
+    yield
+    falcon.constants.COMBINED_METHODS = list(
+        set(falcon.constants.COMBINED_METHODS) - set(FALCON_CUSTOM_HTTP_METHODS)
+    )
+
+
+@pytest.fixture
+def custom_http_client(cleanup_constants, resource_things):
+    falcon.constants.COMBINED_METHODS += FALCON_CUSTOM_HTTP_METHODS
+
     app = falcon.API()
-    app.add_route('/things', ThingsResource())
-    return testing.TestClient(app)
+    app.add_route('/things', resource_things)
+    yield testing.TestClient(app)
 
 
 class ThingsResource:
@@ -34,35 +47,51 @@ class ThingsResource:
         resp.status = falcon.HTTP_204
 
 
-def setup_module(module):
-    falcon.constants.COMBINED_METHODS += FALCON_CUSTOM_HTTP_METHODS
-
-
-def teardown_module(module):
-    for method in FALCON_CUSTOM_HTTP_METHODS:
-        index = falcon.constants.COMBINED_METHODS.index(method)
-        falcon.constants.COMBINED_METHODS.pop(index)
-
-
-def test_map_http_methods(resource_things, monkeypatch):
+def test_map_http_methods(custom_http_client, resource_things):
     method_map = map_http_methods(resource_things)
+
     assert 'FOO' in method_map
     assert 'BAR' not in method_map
 
 
-class TestHttpMethodRouting:
+@pytest.mark.parametrize('env_str,expected', [
+    ('foo', ['FOO']),
+    ('FOO', ['FOO']),
+    ('FOO,', ['FOO']),
+    ('FOO,BAR', ['FOO', 'BAR']),
+    ('FOO, BAR', ['FOO', 'BAR']),
+    (' foo , BAR ', ['FOO', 'BAR']),
+])
+def test_environment_override(cleanup_constants, resource_things, env_str,
+                              expected):
+    # Make sure we don't have anything in there
+    for method in expected:
+        assert method not in falcon.constants.COMBINED_METHODS
 
-    def test_foo(self, client, resource_things):
-        """FOO is a supported method, so returns HTTP_204"""
-        client.app.add_route('/things', resource_things)
-        response = client.simulate_request(path='/things', method='FOO')
-        assert 'FOO' in falcon.constants.COMBINED_METHODS
-        assert response.status == falcon.HTTP_204
-        assert resource_things.called
+    os.environ['FALCON_CUSTOM_HTTP_METHODS'] = env_str
 
-    def test_bar(self, client, resource_things):
-        """BAR is not supported by ResourceThing"""
-        client.app.add_route('/things', resource_things)
-        response = client.simulate_request(path='/things', method='BAR')
-        assert 'BAR' in falcon.constants.COMBINED_METHODS
-        assert response.status == falcon.HTTP_405
+    # Reload module to pick up environment variable methods
+    importlib.reload(falcon.constants)
+
+    # Now it should be there
+    for method in expected:
+        assert method in falcon.constants.COMBINED_METHODS
+
+
+def test_foo(custom_http_client, resource_things):
+    """FOO is a supported method, so returns HTTP_204"""
+    custom_http_client.app.add_route('/things', resource_things)
+    response = custom_http_client.simulate_request(path='/things', method='FOO')
+
+    assert 'FOO' in falcon.constants.COMBINED_METHODS
+    assert response.status == falcon.HTTP_204
+    assert resource_things.called
+
+
+def test_bar(custom_http_client, resource_things):
+    """BAR is not supported by ResourceThing"""
+    custom_http_client.app.add_route('/things', resource_things)
+    response = custom_http_client.simulate_request(path='/things', method='BAR')
+
+    assert 'BAR' in falcon.constants.COMBINED_METHODS
+    assert response.status == falcon.HTTP_405


### PR DESCRIPTION
Making sure we're strip and uppercase the custom methods specified from the environmental variable. Also, rewording docs a touch, and expanding the tests.