### PR TITLE
chore(Sphinx): explicitly specify autodoc directives for hook functions and redirect exceptions

### DIFF
--- a/docs/api/hooks.rst
+++ b/docs/api/hooks.rst
@@ -90,6 +90,6 @@ requests.
     are intended to hold request and response data specific to your app as it
     passes through the framework.
 
-.. automodule:: falcon
-    :members: before, after
-    :undoc-members:
+.. autofunction:: falcon.before
+
+.. autofunction:: falcon.after

--- a/docs/api/redirects.rst
+++ b/docs/api/redirects.rst
@@ -12,6 +12,12 @@ raising an instance or subclass of :py:class:`~.HTTPError`
 Redirects
 ---------
 
-.. automodule:: falcon
-    :members: HTTPMovedPermanently, HTTPFound, HTTPSeeOther,
-        HTTPTemporaryRedirect, HTTPPermanentRedirect
+.. autoexception:: falcon.HTTPMovedPermanently
+
+.. autoexception:: falcon.HTTPFound
+
+.. autoexception:: falcon.HTTPSeeOther
+
+.. autoexception:: falcon.HTTPTemporaryRedirect
+
+.. autoexception:: falcon.HTTPPermanentRedirect


### PR DESCRIPTION
Do so to stop Sphinx 2.1+ from complaining about duplicate object description of `falcon`.
