### PR TITLE
[WIP - DO NOT MERGE] feat: ASGI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib64
 parts
 sdist
 var
+pip-wheel-metadata
 
 # Installer logs
 pip-log.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,20 +27,18 @@ Please note that all contributors and maintainers of this project are subject to
 
 Before submitting a pull request, please ensure you have added or updated tests as appropriate, and that all existing tests still pass with your changes. Please also ensure that your coding style follows PEP 8.
 
-You can check all this by running the following from within the Falcon project directory (requires Python 3.7 to be installed on your system):
+You can check all this by running the following from within the Falcon project directory (requires Python 3.7 and 3.5 to be installed on your system):
 
 ```bash
 $ tools/mintest.sh
 
 ```
 
-You may also use Python 3.5 or 3.6 if you don't have 3.7 installed on your system. Substitute "py35" or "py36" as appropriate. For example:
-
+If you are useing pyenv, you will need to make sure both 3.7 and 3.5 are available in the current shell, e.g.:
 
 ```bash
-$ pip install -U tox coverage
-$ rm -f .coverage.*
-$ tox -e pep8 && tox -e py35 && tools/testing/combine_coverage.sh
+$ pyenv shell 3.7.3 3.5.7
+```
 
 #### Reviews
 

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -11,5 +11,5 @@ Reference
         simulate_request, simulate_get, simulate_head, simulate_post,
         simulate_put, simulate_options, simulate_patch, simulate_delete,
         TestClient, TestCase, SimpleTestResource, StartResponseMock,
-        capture_responder_args, rand_string, create_environ, redirected,
-        closed_wsgi_iterable
+        capture_responder_args, rand_string, create_environ, create_req,
+        create_asgi_req, redirected, closed_wsgi_iterable

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Primary package for Falcon, the minimalist WSGI library.
+"""Primary package for Falcon, the minimalist web API framework.
 
-Falcon is a minimalist WSGI library for building speedy web APIs and app
+Falcon is a minimalist web API framework for building speedy web APIs and app
 backends. The `falcon` package can be used to directly access most of
 the framework's classes, functions, and variables::
 
@@ -23,6 +23,8 @@ the framework's classes, functions, and variables::
     app = falcon.API()
 
 """
+
+import sys as _sys
 
 # Hoist classes and functions into the falcon namespace
 from falcon.version import __version__  # NOQA
@@ -44,3 +46,5 @@ from falcon.util import *  # NOQA
 from falcon.hooks import before, after  # NOQA
 from falcon.request import Request, RequestOptions, Forwarded  # NOQA
 from falcon.response import Response, ResponseOptions  # NOQA
+
+PY35 = _sys.version_info.minor == 5

--- a/falcon/api.py
+++ b/falcon/api.py
@@ -42,6 +42,8 @@ _TYPELESS_STATUS_CODES = frozenset([
 ])
 
 
+# TODO(kgriffs): Rename to "App" and alias to "API" for backwards-
+#   compatibility (also grep the docs/samples and update as needed.)
 class API:
     """This class is the main entry point into a Falcon-based app.
 
@@ -55,9 +57,11 @@ class API:
             number of constants for common media types, such as
             ``falcon.MEDIA_MSGPACK``, ``falcon.MEDIA_YAML``,
             ``falcon.MEDIA_XML``, etc.
-        middleware(object or list): Either a single object or a list
-            of objects (instantiated classes) that implement the
-            following middleware component interface::
+        middleware: Either a single middleware component object or an iterable
+            of objects (instantiated classes) that implement the following
+            middleware component interface. Note that it is only necessary
+            to implement the methods for the events you would like to
+            handle; Falcon simply skips over any missing middleware methods::
 
                 class ExampleComponent:
                     def process_request(self, req, resp):
@@ -151,24 +155,25 @@ class API:
 
     _STREAM_BLOCK_SIZE = 8 * 1024  # 8 KiB
 
+    _STATIC_ROUTE_TYPE = routing.StaticRoute
+
     __slots__ = ('_request_type', '_response_type',
-                 '_error_handlers', '_media_type', '_router', '_sinks',
+                 '_error_handlers', '_router', '_sinks',
                  '_serialize_error', 'req_options', 'resp_options',
                  '_middleware', '_independent_middleware', '_router_search',
-                 '_static_routes')
+                 '_static_routes', '_unprepared_middleware')
 
     def __init__(self, media_type=DEFAULT_MEDIA_TYPE,
                  request_type=Request, response_type=Response,
                  middleware=None, router=None,
                  independent_middleware=True):
         self._sinks = []
-        self._media_type = media_type
         self._static_routes = []
 
         # set middleware
-        self._middleware = helpers.prepare_middleware(
-            middleware, independent_middleware=independent_middleware)
+        self._unprepared_middleware = []
         self._independent_middleware = independent_middleware
+        self.add_middleware(middleware)
 
         self._router = router or routing.DefaultRouter()
         self._router_search = self._router.find
@@ -188,6 +193,32 @@ class API:
         # NOTE(kgriffs): Add default error handlers
         self.add_error_handler(falcon.HTTPError, self._http_error_handler)
         self.add_error_handler(falcon.HTTPStatus, self._http_status_handler)
+
+    def add_middleware(self, middleware):
+        """Add one or more additional middleware components.
+
+        Arguments:
+            middleware: Either a single middleware component or an iterable
+                of components to add. The component(s) will be invoked, in
+                order, as if they had been appended to the original middleware
+                list passed to the class initializer.
+        """
+
+        # NOTE(kgriffs): Since this is called by the initializer, there is
+        #   the chance that middleware may be None.
+        if middleware:
+            try:
+                self._unprepared_middleware += middleware
+            except TypeError:  # middleware is not iterable; assume it is just one bare component
+                self._unprepared_middleware.append(middleware)
+
+        # NOTE(kgriffs): Even if middleware is None or an empty list, we still
+        #   need to make sure self._middleware is initialized if this is the
+        #   first call to add_middleware().
+        self._middleware = self._prepare_middleware(
+            self._unprepared_middleware,
+            independent_middleware=self._independent_middleware
+        )
 
     def __call__(self, env, start_response):  # noqa: C901
         """WSGI `app` method.
@@ -217,83 +248,77 @@ class API:
         req_succeeded = False
 
         try:
-            try:
-                # NOTE(ealogar): The execution of request middleware
-                # should be before routing. This will allow request mw
-                # to modify the path.
-                # NOTE: if flag set to use independent middleware, execute
-                # request middleware independently. Otherwise, only queue
-                # response middleware after request middleware succeeds.
-                if self._independent_middleware:
-                    for process_request in mw_req_stack:
+            # NOTE(ealogar): The execution of request middleware
+            # should be before routing. This will allow request mw
+            # to modify the path.
+            # NOTE: if flag set to use independent middleware, execute
+            # request middleware independently. Otherwise, only queue
+            # response middleware after request middleware succeeds.
+            if self._independent_middleware:
+                for process_request in mw_req_stack:
+                    process_request(req, resp)
+                    if resp.complete:
+                        break
+            else:
+                for process_request, process_response in mw_req_stack:
+                    if process_request and not resp.complete:
                         process_request(req, resp)
+                    if process_response:
+                        dependent_mw_resp_stack.insert(0, process_response)
+
+            if not resp.complete:
+                # NOTE(warsaw): Moved this to inside the try except
+                # because it is possible when using object-based
+                # traversal for _get_responder() to fail.  An example is
+                # a case where an object does not have the requested
+                # next-hop child resource. In that case, the object
+                # being asked to dispatch to its child will raise an
+                # HTTP exception signalling the problem, e.g. a 404.
+                responder, params, resource, req.uri_template = self._get_responder(req)
+        except Exception as ex:
+            if not self._handle_exception(req, resp, ex, params):
+                raise
+        else:
+            try:
+                # NOTE(kgriffs): If the request did not match any
+                # route, a default responder is returned and the
+                # resource is None. In that case, we skip the
+                # resource middleware methods. Resource will also be
+                # None when a middleware method already set
+                # resp.complete to True.
+                if resource:
+                    # Call process_resource middleware methods.
+                    for process_resource in mw_rsrc_stack:
+                        process_resource(req, resp, resource, params)
                         if resp.complete:
                             break
-                else:
-                    for process_request, process_response in mw_req_stack:
-                        if process_request and not resp.complete:
-                            process_request(req, resp)
-                        if process_response:
-                            dependent_mw_resp_stack.insert(0, process_response)
 
                 if not resp.complete:
-                    # NOTE(warsaw): Moved this to inside the try except
-                    # because it is possible when using object-based
-                    # traversal for _get_responder() to fail.  An example is
-                    # a case where an object does not have the requested
-                    # next-hop child resource. In that case, the object
-                    # being asked to dispatch to its child will raise an
-                    # HTTP exception signalling the problem, e.g. a 404.
-                    responder, params, resource, req.uri_template = self._get_responder(req)
+                    responder(req, resp, **params)
+
+                req_succeeded = True
             except Exception as ex:
                 if not self._handle_exception(req, resp, ex, params):
                     raise
-            else:
-                try:
-                    # NOTE(kgriffs): If the request did not match any
-                    # route, a default responder is returned and the
-                    # resource is None. In that case, we skip the
-                    # resource middleware methods. Resource will also be
-                    # None when a middleware method already set
-                    # resp.complete to True.
-                    if resource:
-                        # Call process_resource middleware methods.
-                        for process_resource in mw_rsrc_stack:
-                            process_resource(req, resp, resource, params)
-                            if resp.complete:
-                                break
 
-                    if not resp.complete:
-                        responder(req, resp, **params)
+        # Call process_response middleware methods.
+        for process_response in mw_resp_stack or dependent_mw_resp_stack:
+            try:
+                process_response(req, resp, resource, req_succeeded)
+            except Exception as ex:
+                if not self._handle_exception(req, resp, ex, params):
+                    raise
 
-                    req_succeeded = True
-                except Exception as ex:
-                    if not self._handle_exception(req, resp, ex, params):
-                        raise
-        finally:
-            # NOTE(kgriffs): It may not be useful to still execute
-            # response middleware methods in the case of an unhandled
-            # exception, but this is done for the sake of backwards
-            # compatibility, since it was incidentally the behavior in
-            # the 1.0 release before this section of the code was
-            # reworked.
-
-            # Call process_response middleware methods.
-            for process_response in mw_resp_stack or dependent_mw_resp_stack:
-                try:
-                    process_response(req, resp, resource, req_succeeded)
-                except Exception as ex:
-                    if not self._handle_exception(req, resp, ex, params):
-                        raise
-
-                    req_succeeded = False
+                req_succeeded = False
 
         #
         # Set status and headers
         #
 
         resp_status = resp.status
-        media_type = self._media_type
+        default_media_type = self.resp_options.default_media_type
+
+        body, length = self._get_body(resp, env.get('wsgi.file_wrapper'))
 
         if req.method == 'HEAD' or resp_status in _BODILESS_STATUS_CODES:
             body = []
@@ -307,11 +332,20 @@ class API:
             # presence of the Content-Length header is not similarly
             # enforced.
             if resp_status in _TYPELESS_STATUS_CODES:
-                media_type = None
+                default_media_type = None
+            elif (
+                length is not None and
+                req.method == 'HEAD'and
+                resp_status not in _BODILESS_STATUS_CODES and
+                'content-length' not in resp._headers
+            ):
+                # NOTE(kgriffs): We really should be returning a Content-Length
+                #   in this case according to my reading of the RFCs. By
+                #   optionally using len(data) we let a resource simulate HEAD
+                #   by turning around and calling it's own on_get().
+                resp._headers['content-length'] = str(length)
 
         else:
-            body, length = self._get_body(resp, env.get('wsgi.file_wrapper'))
-
             # PERF(kgriffs): Böse mußt sein. Operate directly on resp._headers
             #   to reduce overhead since this is a hot/critical code path.
             # NOTE(kgriffs): We always set content-length to match the
@@ -322,7 +356,7 @@ class API:
             if length is not None:
                 resp._headers['content-length'] = str(length)
 
-        headers = resp._wsgi_headers(media_type)
+        headers = resp._wsgi_headers(default_media_type)
 
         # Return the response per the WSGI spec.
         start_response(resp_status, headers)
@@ -414,6 +448,10 @@ class API:
             For security reasons, the directory and the fallback_filename (if provided)
             should be read only for the account running the application.
 
+        Note:
+            For ASGI apps, file reads are made non-blocking by scheduling
+            them on the default executor.
+
         Static routes are matched in LIFO order. Therefore, if the same
         prefix is used for two routes, the second one will override the
         first. This also means that more specific routes should be added
@@ -448,8 +486,8 @@ class API:
 
         self._static_routes.insert(
             0,
-            routing.StaticRoute(prefix, directory, downloadable=downloadable,
-                                fallback_filename=fallback_filename)
+            self._STATIC_ROUTE_TYPE(prefix, directory, downloadable=downloadable,
+                                    fallback_filename=fallback_filename)
         )
 
     def add_sink(self, sink, prefix=r'/'):
@@ -646,11 +684,19 @@ class API:
     # Helpers that require self
     # ------------------------------------------------------------------------
 
-    def _get_responder(self, req):
+    def _prepare_middleware(self, middleware=None, independent_middleware=False):
+        return helpers.prepare_middleware(
+            middleware=middleware,
+            independent_middleware=independent_middleware
+        )
+
+    def _get_responder(self, req, asgi=False):
         """Search routes for a matching responder.
 
         Args:
-            req: The request object.
+            req (Request): The request object.
+            asgi (bool): ``True`` if using an ASGI app, ``False`` otherwise
+                (default ``False``).
 
         Returns:
             tuple: A 4-member tuple consisting of a responder callable,
@@ -694,7 +740,10 @@ class API:
             try:
                 responder = method_map[method]
             except KeyError:
-                responder = falcon.responders.bad_request
+                if asgi:
+                    responder = falcon.responders.bad_request_async
+                else:
+                    responder = falcon.responders.bad_request
         else:
             params = {}
 
@@ -712,7 +761,10 @@ class API:
                         responder = sr
                         break
                 else:
-                    responder = falcon.responders.path_not_found
+                    if asgi:
+                        responder = falcon.responders.path_not_found_async
+                    else:
+                        responder = falcon.responders.path_not_found
 
         return (responder, params, resource, uri_template)
 

--- a/falcon/api_helpers.py
+++ b/falcon/api_helpers.py
@@ -14,19 +14,27 @@
 
 """Utilities for the API class."""
 
+from inspect import iscoroutinefunction
+
 from falcon import util
+from falcon.errors import CompatibilityError
 
 
-def prepare_middleware(middleware=None, independent_middleware=False):
-    """Check middleware interface and prepare it to iterate.
+def prepare_middleware(middleware, independent_middleware=False, asgi=False):
+    """Check middleware interfaces and prepare the methods for request handling.
 
-    Args:
-        middleware: list (or object) of input middleware
-        independent_middleware: bool whether should prepare request and
-            response middleware independently
+    Arguments:
+        middleware (iterable): An iterable of middleware objects.
+
+    Keyword Args:
+        independent_middleware (bool): ``True`` if the request and
+            response middleware methods should be treated independently
+            (default ``False``)
+        asgi (bool): ``True`` if an ASGI app, ``False`` otherwise
+            (default ``False``)
 
     Returns:
-        list: A tuple of prepared middleware tuples
+        tuple: A tuple of prepared middleware method tuples
     """
 
     # PERF(kgriffs): do getattr calls once, in advance, so we don't
@@ -35,22 +43,59 @@ def prepare_middleware(middleware=None, independent_middleware=False):
     resource_mw = []
     response_mw = []
 
-    if middleware is None:
-        middleware = []
-    else:
-        if not isinstance(middleware, list):
-            middleware = [middleware]
-
     for component in middleware:
-        process_request = util.get_bound_method(component,
-                                                'process_request')
-        process_resource = util.get_bound_method(component,
-                                                 'process_resource')
-        process_response = util.get_bound_method(component,
-                                                 'process_response')
+        # NOTE(kgriffs): Middleware that uses parts of the Request and Response
+        #   interfaces that are the same between ASGI and WSGI (most of it is,
+        #   and we should probably define this via ABC) can just implement
+        #   the method names without the *_async postfix. If a middleware
+        #   component wants to provide an alternative implementation that
+        #   does some work that requires async def, or something specific about
+        #   the ASGI Request/Response classes, the component can implement the
+        #   *_async method in that case.
+        #
+        #   Middleware that is WSGI-only or ASGI-only can simply implement all
+        #   methods without the *_async postfix. Regardless, components should
+        #   clearly document their compatibility with WSGI vs. ASGI.
+
+        if asgi:
+            process_request = (
+                util.get_bound_method(component, 'process_request_async') or
+                util.get_bound_method(component, 'process_request')
+            )
+
+            process_resource = (
+                util.get_bound_method(component, 'process_resource_async') or
+                util.get_bound_method(component, 'process_resource')
+            )
+
+            process_response = (
+                util.get_bound_method(component, 'process_response_async') or
+                util.get_bound_method(component, 'process_response')
+            )
+
+            for m in (process_request, process_resource, process_response):
+                if m:
+                    m.__func__._coroutine = iscoroutinefunction(m)
+
+        else:
+            process_request = util.get_bound_method(component, 'process_request')
+            process_resource = util.get_bound_method(component, 'process_resource')
+            process_response = util.get_bound_method(component, 'process_response')
+
+            for m in (process_request, process_resource, process_response):
+                if m:
+                    if iscoroutinefunction(m):
+                        msg = (
+                            '{0} may not implement coroutine methods and '
+                            'remain compatible with WSGI apps without '
+                            'using the *_async postfix to explicitly identify '
+                            'the coroutine version of a given middleware '
+                            'method.'
+                        )
+                        raise CompatibilityError(msg.format(component))
 
         if not (process_request or process_resource or process_response):
-            msg = '{0} does not implement the middleware interface'
+            msg = '{0} must implement at least one middleware method'
             raise TypeError(msg.format(component))
 
         # NOTE: depending on whether we want to execute middleware

--- a/falcon/asgi/__init__.py
+++ b/falcon/asgi/__init__.py
@@ -1,0 +1,38 @@
+# Copyright 2019 by Kurt Griffiths.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASGI package for Falcon, the minimalist web API framework.
+
+The `falcon.asgi` package can be used to directly access most of
+the framework's ASGI-related classes, functions, and variables::
+
+    import falcon.asgi
+
+    app = falcon.asgi.API()
+
+Some ASGI-related methods and classes are found in other modules
+(most notably falcon.testing) when (A) they are compatible with Python 3.5,
+and (B) their purpose is particularly cohesive with that of the module in
+question.
+"""
+
+from falcon import PY35
+if PY35:
+    raise ImportError('falcon.asgi requires Python 3.6+')
+
+from falcon.asgi.app import App  # NOQA
+from falcon.asgi.structures import SSEvent  # NOQA
+from falcon.asgi.request import Request  # NOQA
+from falcon.asgi.response import Response  # NOQA
+from falcon.asgi.stream import BoundedStream  # NOQA

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -1,0 +1,69 @@
+# Copyright 2019 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import re
+
+
+def header_property(header_name):
+    """Create a read-only header property.
+
+    Args:
+        wsgi_name (str): Case-sensitive name of the header as it would
+            appear in the WSGI environ ``dict`` (i.e., 'HTTP_*')
+
+    Returns:
+        A property instance than can be assigned to a class variable.
+
+    """
+
+    header_name = header_name.lower()
+
+    def fget(self):
+        try:
+            return self._asgi_headers[header_name] or None
+        except KeyError:
+            return None
+
+    return property(fget)
+
+
+def fixup_wsgi_references(prop):
+    fget = prop.fget
+    src = inspect.getsource(fget)
+
+    # NOTE(kgriffs): Fixup this special case so the following regex's
+    #   will match.
+    modified_src = src.replace('CONTENT_LENGTH', 'HTTP_CONTENT_LENGTH')
+
+    # self.env['HTTP_HOST']
+    modified_src = re.sub(
+        r'self\.env\[["\']HTTP_([^"\']+)["\']\]',
+        lambda m: 'self._asgi_headers["{}"]'.format(m.group(1).lower().replace('_', '-')),
+        modified_src
+    )
+
+    # self.env.get('HTTP_IF_MATCH')
+    modified_src = re.sub(
+        r'self\.env\.get\(["\']HTTP_([^"\']+)["\']',
+        lambda m: 'self._asgi_headers.get("{}"'.format(m.group(1).lower().replace('_', '-')),
+        modified_src
+    )
+
+    modified_src = re.sub('^    ', '', modified_src, flags=re.MULTILINE)
+
+    scope = inspect.currentframe().f_back.f_globals.copy()
+    exec(compile(modified_src, '<string>', 'exec'), scope)
+
+    return scope[fget.__name__]

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -1,0 +1,599 @@
+# Copyright 2019 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASGI application class."""
+
+import asyncio
+from inspect import isasyncgenfunction, iscoroutinefunction
+import traceback
+
+import falcon.api
+from falcon.api_helpers import prepare_middleware
+from falcon.asgi.request import Request
+from falcon.asgi.response import Response
+from falcon.asgi.structures import SSEvent
+from falcon.errors import UnsupportedScopeError
+from falcon.http_error import HTTPError
+from falcon.http_status import HTTPStatus
+import falcon.routing
+from falcon.util.misc import http_status_to_code, set_coroutine_flag
+
+
+__all__ = ['App']
+
+
+_EVT_RESP_EOF = {'type': 'http.response.body'}
+
+_BODILESS_STATUS_CODES = frozenset([
+    100,
+    101,
+    204,
+    304,
+])
+
+_TYPELESS_STATUS_CODES = frozenset([
+    204,
+    304,
+])
+
+
+# TODO(kgriffs): Rename the WSGI class to App with an API alias kept for
+#   backwards-compatibility.
+class App(falcon.api.API):
+
+    _STATIC_ROUTE_TYPE = falcon.routing.StaticRouteAsync
+
+    __slots__ = ['_lifespan_handlers']
+
+    def __init__(self, *args, request_type=Request, response_type=Response, **kwargs):
+        super().__init__(*args, request_type=request_type, response_type=response_type, **kwargs)
+        self._lifespan_handlers = []
+
+    async def __call__(self, scope, receive, send):  # noqa: C901
+        try:
+            asgi_info = scope['asgi']
+
+            # NOTE(kgriffs): We only check this here because
+            #   uvicorn does not explicitly set the 'asgi' key, which
+            #   would normally mean we should assume '2.0', but uvicorn
+            #   actually *does* support 3.0. But in that case, we will
+            #   end up in the except clause, below, and not raise an
+            #   error.
+            # PERF(kgriffs): This should usually be present, so use a
+            #   try..except
+            try:
+                version = asgi_info['version']
+            except KeyError:
+                # NOTE(kgriffs): According to the ASGI spec, "2.0" is
+                #   the default version.
+                version = '2.0'
+
+            if not version.startswith('3.'):
+                raise UnsupportedScopeError(
+                    f'Falcon requires ASGI version 3.x. Detected: {asgi_info}'
+                )
+
+        except KeyError:
+            asgi_info = scope['asgi'] = {'version': '2.0'}
+
+        # NOTE(kgriffs): The ASGI spec requires the 'type' key to be present.
+        scope_type = scope['type']
+        if scope_type != 'http':
+            if scope_type == 'lifespan':
+                try:
+                    spec_version = asgi_info['spec_version']
+                except KeyError:
+                    spec_version = '1.0'
+
+                if not spec_version.startswith('1.') and not spec_version.startswith('2.'):
+                    raise UnsupportedScopeError(
+                        f'Only versions 1.x and 2.x of the ASGI "lifespan" scope are supported.'
+                    )
+
+                await self._call_lifespan_handlers(spec_version, scope, receive, send)
+                return
+
+            # NOTE(kgriffs): According to the ASGI spec: "Applications should
+            #   actively reject any protocol that they do not understand with
+            #   an Exception (of any type)."
+            raise UnsupportedScopeError(
+                f'The ASGI "{scope_type}" scope type is not supported.'
+            )
+
+        # PERF(kgriffs): This is slighter faster than using dict.get()
+        # TODO(kgriffs): Use this to determine what features are supported by
+        #   the servver (e.g., the headers key in the WebSocket Accept
+        #   response).
+        spec_version = asgi_info['spec_version'] if 'spec_version' in asgi_info else '2.0'
+
+        if not spec_version.startswith('2.'):
+            raise UnsupportedScopeError(
+                f'The ASGI http scope version {spec_version} is not supported.'
+            )
+
+        resp = self._response_type(options=self.resp_options)
+        req = self._request_type(scope, receive, options=self.req_options)
+        if self.req_options.auto_parse_form_urlencoded:
+            await req._parse_form_urlencoded()
+
+        resource = None
+        responder = None
+        params = {}
+
+        dependent_mw_resp_stack = []
+        mw_req_stack, mw_rsrc_stack, mw_resp_stack = self._middleware
+
+        req_succeeded = False
+
+        try:
+            # NOTE(ealogar): The execution of request middleware
+            # should be before routing. This will allow request mw
+            # to modify the path.
+            # NOTE: if flag set to use independent middleware, execute
+            # request middleware independently. Otherwise, only queue
+            # response middleware after request middleware succeeds.
+            if self._independent_middleware:
+                for process_request in mw_req_stack:
+                    # NOTE(kgriffs): We allow non-coroutine middleware
+                    #   since (1) middleware often does quick, non-blocking
+                    #   things and (2) it makes it easier to share/port
+                    #   middleware between WSGI and ASGI apps.
+                    if process_request._coroutine:
+                        await process_request(req, resp)
+                    else:
+                        process_request(req, resp)
+
+                    if resp.complete:
+                        break
+            else:
+                for process_request, process_response in mw_req_stack:
+                    if process_request and not resp.complete:
+                        if process_request._coroutine:
+                            await process_request(req, resp)
+                        else:
+                            process_request(req, resp)
+
+                    if process_response:
+                        dependent_mw_resp_stack.insert(0, process_response)
+
+            if not resp.complete:
+                # NOTE(warsaw): Moved this to inside the try except
+                # because it is possible when using object-based
+                # traversal for _get_responder() to fail.  An example is
+                # a case where an object does not have the requested
+                # next-hop child resource. In that case, the object
+                # being asked to dispatch to its child will raise an
+                # HTTP exception signalling the problem, e.g. a 404.
+                responder, params, resource, req.uri_template = self._get_responder(
+                    req,
+                    asgi=True
+                )
+
+        except Exception as ex:
+            if not await self._handle_exception(req, resp, ex, params):
+                raise
+
+        else:
+            try:
+                # NOTE(kgriffs): If the request did not match any
+                # route, a default responder is returned and the
+                # resource is None. In that case, we skip the
+                # resource middleware methods. Resource will also be
+                # None when a middleware method already set
+                # resp.complete to True.
+                if resource:
+                    # Call process_resource middleware methods.
+                    for process_resource in mw_rsrc_stack:
+                        if process_resource._coroutine:
+                            await process_resource(req, resp, resource, params)
+                        else:
+                            process_resource(req, resp, resource, params)
+
+                        if resp.complete:
+                            break
+
+                if not resp.complete:
+                    await responder(req, resp, **params)
+
+                req_succeeded = True
+
+            except Exception as ex:
+                if not await self._handle_exception(req, resp, ex, params):
+                    raise
+
+        # Call process_response middleware methods.
+        for process_response in mw_resp_stack or dependent_mw_resp_stack:
+            try:
+                if process_response._coroutine:
+                    await process_response(req, resp, resource, req_succeeded)
+                else:
+                    process_response(req, resp, resource, req_succeeded)
+
+            except Exception as ex:
+                if not await self._handle_exception(req, resp, ex, params):
+                    raise
+
+                req_succeeded = False
+
+        #
+        # Set status and headers
+        #
+
+        resp_status = http_status_to_code(resp.status)
+        default_media_type = self.resp_options.default_media_type
+
+        data = await resp.render_body()
+
+        if req.method == 'HEAD' or resp_status in _BODILESS_STATUS_CODES:
+            #
+            # PERF(vytas): move check for the less common and much faster path
+            # of resp_status being in {204, 304} here; NB: this builds on the
+            # assumption _TYPELESS_STATUS_CODES <= _BODILESS_STATUS_CODES.
+            #
+            # NOTE(kgriffs): Based on wsgiref.validate's interpretation of
+            # RFC 2616, as commented in that module's source code. The
+            # presence of the Content-Length header is not similarly
+            # enforced.
+            #
+            # NOTE(kgriffs): Assuming the same for ASGI until proven otherwise.
+            #
+            if resp_status in _TYPELESS_STATUS_CODES:
+                default_media_type = None
+            elif (
+                req.method == 'HEAD'and
+                resp_status not in _BODILESS_STATUS_CODES and
+                'content-length' not in resp._headers
+            ):
+                # NOTE(kgriffs): We really should be returning a Content-Length
+                #   in this case according to my reading of the RFCs. By
+                #   optionally using len(data) we let a resource simulate HEAD
+                #   by turning around and calling it's own on_get().
+                resp._headers['content-length'] = str(len(data)) if data else '0'
+
+            await send({
+                'type': 'http.response.start',
+                'status': resp_status,
+                'headers': resp._asgi_headers(default_media_type)
+            })
+
+            await send(_EVT_RESP_EOF)
+            self._schedule_callbacks(resp)
+            return
+
+        sse_emitter = resp.sse
+        if sse_emitter:
+            if isasyncgenfunction(sse_emitter):
+                raise TypeError(
+                    'Response.sse must be an async iterable. This can be obtained by '
+                    'simply executing the async generator function and then setting '
+                    'the result to Response.sse, e.g.: resp.sse = some_asyncgen_function()'
+                )
+
+            await send({
+                'type': 'http.response.start',
+                'status': resp_status,
+                'headers': resp._asgi_headers('text/event-stream')
+            })
+
+            self._schedule_callbacks(resp)
+
+            # TODO(kgriffs): Do we need to do anything special to handle when
+            #   a connection is closed?
+            async for event in sse_emitter:
+                if not event:
+                    event = SSEvent()
+
+                await send({
+                    'type': 'http.response.body',
+                    'body': event.serialize(),
+                    'more_body': True
+                })
+
+            await send({'type': 'http.response.body'})
+            return
+
+        if data is not None:
+            # PERF(kgriffs): Böse mußt sein. Operate directly on resp._headers
+            #   to reduce overhead since this is a hot/critical code path.
+            # NOTE(kgriffs): We always set content-length to match the
+            #   body bytes length, even if content-length is already set. The
+            #   reason being that web servers and LBs behave unpredictably
+            #   when the header doesn't match the body (sometimes choosing to
+            #   drop the HTTP connection prematurely, for example).
+            resp._headers['content-length'] = str(len(data))
+
+            await send({
+                'type': 'http.response.start',
+                'status': resp_status,
+                'headers': resp._asgi_headers(default_media_type)
+            })
+
+            await send({
+                'type': 'http.response.body',
+                'body': data
+            })
+
+            self._schedule_callbacks(resp)
+            return
+
+        stream = resp.stream
+        if not stream:
+            resp._headers['content-length'] = '0'
+
+        await send({
+            'type': 'http.response.start',
+            'status': resp_status,
+            'headers': resp._asgi_headers(default_media_type)
+        })
+
+        if stream:
+            # Detect whether this is one of the following:
+            #
+            #   (a) async file-like object (e.g., aiofiles)
+            #   (b) async generator
+            #   (c) async iterator
+            #
+
+            if hasattr(stream, 'read'):
+                while True:
+                    data = await stream.read(self._STREAM_BLOCK_SIZE)
+                    if data == b'':
+                        break
+                    else:
+                        await send({
+                            'type': 'http.response.body',
+
+                            # NOTE(kgriffs): Handle the case in which data == None
+                            'body': data or b'',
+
+                            'more_body': True
+                        })
+            else:
+                # NOTE(kgriffs): Works for both async generators and iterators
+                try:
+                    async for data in stream:
+                        await send({
+                            'type': 'http.response.body',
+                            'body': data,
+                            'more_body': True
+                        })
+                except TypeError:
+                    if isasyncgenfunction(stream):
+                        raise TypeError(
+                            'The object assigned to Response.stream appears to '
+                            'be an async generator function. A generator '
+                            'object is expected instead. This can be obtained '
+                            'simply by calling the generator function, e.g.: '
+                            'resp.stream = some_asyncgen_function()'
+                        )
+
+                    raise TypeError(
+                        'Response.stream must be a generator or implement an '
+                        '__aiter__ method.'
+                    )
+
+            if hasattr(stream, 'close'):
+                await stream.close()
+
+        await send(_EVT_RESP_EOF)
+        self._schedule_callbacks(resp)
+
+    def add_lifespan_handler(self, handler):
+        """Add a lifespan handler object.
+
+        A lifespan handler performs startup and/or shutdown activities for the
+        main event loop. An example of this would be creating a connection
+        pool and subsequently closing the connection pool to release the
+        connections.
+
+        Note:
+            In a multi-process environment, lifespan events will be
+            triggered independently for the individual event loop associated
+            with each process.
+
+        A lifespan handler is any class that implements the interface below.
+        Note that it is only necessary to implement the methods for the
+        events that you wish to handle; Falcon will simply skip over any
+        missing methods in the lifespan handler::
+
+            class ExampleHandler:
+                def process_startup(self, scope, event):
+                    \"\"\"Process the lifespan startup event.
+
+                    Invoked when the server is ready to startup and
+                    receive connections, but before it has started to
+                    do so.
+
+                    To halt startup processing and signal to the server that it
+                    should terminate, simply raise an exception and the
+                    framework will convert it to a "lifespan.startup.failed"
+                    event for the server.
+
+                    Arguments:
+                        scope (dict): The ASGI scope dictionary for the
+                            lifespan protocol. The lifespan scope exists
+                            for the duration of the event loop.
+                        event (dict): The ASGI event dictionary for the
+                            startup event.
+                    \"\"\"
+
+                def process_shutdown(self, scope, event):
+                    \"\"\"Process the lifespan shutdown event.
+
+                    Invoked when the server has stopped accepting
+                    connections and closed all active connections.
+
+                    To halt shutdown processing and signal to the server
+                    that it should immediately terminate, simply raise an
+                    exception and the framework will convert it to a
+                    "lifespan.shutdown.failed" event for the server.
+
+                    Arguments:
+                        scope (dict): The ASGI scope dictionary for the
+                            lifespan protocol. The lifespan scope exists
+                            for the duration of the event loop.
+                        event (dict): The ASGI event dictionary for the
+                            shutdown event.
+                    \"\"\"
+
+        Lifespan handlers are executed hierarchically in a stack, based on
+        the order in which they were added. For example, suppose three
+        handlers were added as follows::
+
+            some_app.add_lifespan_handler(h1)
+            some_app.add_lifespan_handler(h2)
+            some_app.add_lifespan_handler(h3)
+
+        In this case, the handlers' methods would be invoked by the
+        framework in this order::
+
+            h1.process_startup()
+
+            h2.process_startup()
+
+            h3.process_startup()
+            h3.process_shutdown()
+
+            h2.process_shutdown()
+
+            h1.process_shutdown()
+
+        Arguments:
+            handler (object): An instantiated lifespan handler object.
+        """
+
+        for m in ('process_startup', 'process_shutdown'):
+            if hasattr(handler, m):
+                break
+        else:
+            raise TypeError(f'{handler} must implement at least one lifespan event method')
+
+        self._lifespan_handlers.append(handler)
+
+    def add_error_handler(self, exception, handler=None):
+        if not handler:
+            try:
+                handler = exception.handle
+            except AttributeError:
+                # NOTE(kgriffs): Delegate to the parent method for error handling.
+                pass
+
+        if handler:
+            set_coroutine_flag(handler)
+
+        super().add_error_handler(exception, handler=handler)
+
+    def add_route(self, uri_template, resource, **kwargs):
+        # TODO: Check for an _auto_async_wrap kwarg or env var and if there and True,
+        #   go through the resource and wrap any non-couroutine objects. Then
+        #   set that flag in the test cases.
+
+        # NOTE(kgriffs): Inject an extra kwarg so that the compiled router
+        #   will know to validate the reponder methods to make sure they
+        #   are async coroutines.
+        kwargs['_asgi'] = True
+        super().add_route(uri_template, resource, **kwargs)
+
+    # ------------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------------
+
+    def _schedule_callbacks(self, resp):
+        callbacks = resp._registered_callbacks
+        if not callbacks:
+            return
+
+        loop = asyncio.get_event_loop()
+
+        for cb in callbacks:
+            if iscoroutinefunction(cb):
+                loop.create_task(cb())
+            else:
+                loop.run_in_executor(None, cb)
+
+    async def _call_lifespan_handlers(self, ver, scope, receive, send):
+        while True:
+            event = await receive()
+            if event['type'] == 'lifespan.startup':
+                for handler in self._lifespan_handlers:
+                    if hasattr(handler, 'process_startup'):
+                        try:
+                            await handler.process_startup(scope, event)
+                        except Exception:
+                            await send({
+                                'type': 'lifespan.startup.failed',
+                                'message': traceback.format_exc(),
+                            })
+                            return
+
+                await send({'type': 'lifespan.startup.complete'})
+
+            elif event['type'] == 'lifespan.shutdown':
+                for handler in reversed(self._lifespan_handlers):
+                    if hasattr(handler, 'process_shutdown'):
+                        try:
+                            await handler.process_shutdown(scope, event)
+                        except Exception:
+                            await send({
+                                'type': 'lifespan.shutdown.failed',
+                                'message': traceback.format_exc(),
+                            })
+                            return
+
+                await send({'type': 'lifespan.shutdown.complete'})
+                return
+
+    def _prepare_middleware(self, middleware=None, independent_middleware=False):
+        return prepare_middleware(
+            middleware=middleware,
+            independent_middleware=independent_middleware,
+            asgi=True
+        )
+
+    async def _handle_exception(self, req, resp, ex, params):
+        """Handle an exception raised from mw or a responder.
+
+        Args:
+            ex: Exception to handle
+            req: Current request object to pass to the handler
+                registered for the given exception type
+            resp: Current response object to pass to the handler
+                registered for the given exception type
+            params: Responder params to pass to the handler
+                registered for the given exception type
+
+        Returns:
+            bool: ``True`` if a handler was found and called for the
+            exception, ``False`` otherwise.
+        """
+
+        for err_type, err_handler in self._error_handlers:
+            if isinstance(ex, err_type):
+                try:
+                    if err_handler._coroutine:
+                        await err_handler(req, resp, ex, params)
+                    else:
+                        err_handler(req, resp, ex, params)
+                except HTTPStatus as status:
+                    self._compose_status_response(req, resp, status)
+                except HTTPError as error:
+                    self._compose_error_response(req, resp, error)
+
+                return True
+
+        # NOTE(kgriffs): No error handlers are defined for ex
+        # and it is not one of (HTTPStatus, HTTPError), since it
+        # would have matched one of the corresponding default
+        # handlers.
+        return False

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -1,0 +1,511 @@
+# Copyright 2019 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASGI Request class."""
+
+from falcon import errors
+from falcon import request_helpers as helpers  # NOQA: Required by fixed up WSGI Request attrs
+import falcon.asgi._request_helpers as asgi_helpers
+from falcon.asgi.stream import BoundedStream
+from falcon.constants import SINGLETON_HEADERS
+from falcon.forwarded import _parse_forwarded_header  # NOQA: Req. by fixed up WSGI Request attrs
+from falcon.forwarded import Forwarded  # NOQA
+import falcon.request
+from falcon.util.uri import parse_host, parse_query_string
+
+
+__all__ = ['Request']
+
+
+class Request(falcon.request.Request):
+    """
+
+            remote_addr(str): IP address of the closest known client or proxy to
+                the WSGI server, or '127.0.0.1' if unknown.
+
+                This property's value is equivalent to the last element of the
+                :py:attr:`~.access_route` property.
+
+            access_route(list): IP address of the original client (if known), as
+                well as any known addresses of proxies fronting the WSGI server.
+
+                The following request headers are checked, in order of
+                preference, to determine the addresses:
+
+                    - ``Forwarded``
+                    - ``X-Forwarded-For``
+                    - ``X-Real-IP``
+
+                In addition, the value of the 'client' field from the ASGI
+                connection scope will be appended to the end of the list if
+                not already included in one of the above headers. If the
+                'client' field is not available, it will default to
+                '127.0.0.1'.
+
+                Note:
+                    Per `RFC 7239`_, the access route may contain "unknown"
+                    and obfuscated identifiers, in addition to IPv4 and
+                    IPv6 addresses
+
+                    .. _RFC 7239: https://tools.ietf.org/html/rfc7239
+
+                Warning:
+                    Headers can be forged by any client or proxy. Use this
+                    property with caution and validate all values before
+                    using them. Do not rely on the access route to authorize
+                    requests!
+
+    """
+
+    __slots__ = [
+        '_asgi_headers',
+        '_asgi_server_cached'
+        '_receive',
+        '_stream',
+        'scope',
+    ]
+
+    async def read():
+        return b''
+
+    def __init__(self, scope, receive, options=None):
+
+        # =====================================================================
+        # Prepare headers
+        # =====================================================================
+
+        req_headers = {}
+        for header_name, header_value in scope['headers']:
+            # NOTE(kgriffs): According to ASGI 3.0, header names are always
+            #   lowercased, and both name and value are byte strings. Although
+            #   technically header names and values are restricted to US-ASCII
+            #   we decode using the default 'utf-8' because it is a little
+            #   faster than passing an encoding option.
+            header_name = header_name.decode()
+            header_value = header_value.decode()
+
+            # NOTE(kgriffs): There are no standard request headers that
+            #   allow multiple instances to appear in the request while also
+            #   disallowing list syntax.
+            if header_name not in req_headers or header_name in SINGLETON_HEADERS:
+                req_headers[header_name] = header_value
+            else:
+                req_headers[header_name] += ',' + header_value
+
+        self._asgi_headers = req_headers
+
+        # =====================================================================
+        #  Misc.
+        # =====================================================================
+
+        self._asgi_server_cached = None  # Lazy
+
+        self.scope = scope
+        self.options = options if options else falcon.request.RequestOptions()
+
+        self._wsgierrors = None
+        self.method = scope['method']
+
+        self.uri_template = None
+        self._media = None
+
+        # TODO(kgriffs): ASGI does not specify whether 'path' may be empty,
+        #   as was allowed for WSGI.
+        path = scope['path'] or '/'
+
+        if (self.options.strip_url_path_trailing_slash and
+                len(path) != 1 and path.endswith('/')):
+            self.path = path[:-1]
+        else:
+            self.path = path
+
+        query_string = scope['query_string'].decode()
+        self.query_string = query_string
+        if query_string:
+            self._params = parse_query_string(
+                query_string,
+                keep_blank=self.options.keep_blank_qs_values,
+                csv=self.options.auto_parse_qs_csv,
+            )
+
+        else:
+            self._params = {}
+
+        self._cached_access_route = None
+        self._cached_forwarded = None
+        self._cached_forwarded_prefix = None
+        self._cached_forwarded_uri = None
+        self._cached_headers = req_headers
+        self._cached_prefix = None
+        self._cached_relative_uri = None
+        self._cached_uri = None
+
+        if self.method == 'GET':
+            # PERF(kgriffs): Normally we expect no Content-Type header, so
+            #   use this pattern which is a little bit faster than dict.get()
+            if 'content-type' in req_headers:
+                self.content_type = req_headers['content-type']
+            else:
+                self.content_type = None
+        else:
+            # PERF(kgriffs): This is the most performant pattern when we expect
+            #   the key to be present most of the time.
+            try:
+                self.content_type = req_headers['content-type']
+            except KeyError:
+                self.content_type = None
+
+        # =====================================================================
+        # The request body stream is created lazily
+        # =====================================================================
+
+        # NOTE(kgriffs): The ASGI spec states that "you should not trigger
+        #   on a connection opening alone". I take this to mean that the app
+        #   should have the opportunity to respond with a 401, for example,
+        #   without having to first read any of the body. This is accomplished
+        #   in Falcon by only reading the first data event when the app attempts
+        #   to read from req.stream for the first time, and in uvicorn
+        #   (for example) by not confirming a 100 Continue request unless
+        #   the app calls receive() to read the request body.
+
+        self._stream = None
+        self._receive = receive
+
+        # =====================================================================
+        # Create a context object
+        # =====================================================================
+
+        self.context = self.context_type()
+
+    # ------------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------------
+
+    auth = asgi_helpers.header_property('Authorization')
+    expect = asgi_helpers.header_property('Expect')
+    if_range = asgi_helpers.header_property('If-Range')
+    referer = asgi_helpers.header_property('Referer')
+    user_agent = asgi_helpers.header_property('User-Agent')
+
+    accept = asgi_helpers.fixup_wsgi_references(falcon.request.Request.accept)
+    content_length = asgi_helpers.fixup_wsgi_references(falcon.request.Request.content_length)
+    forwarded = asgi_helpers.fixup_wsgi_references(falcon.request.Request.forwarded)
+    if_match = asgi_helpers.fixup_wsgi_references(falcon.request.Request.if_match)
+    if_none_match = asgi_helpers.fixup_wsgi_references(falcon.request.Request.if_none_match)
+    range = asgi_helpers.fixup_wsgi_references(falcon.request.Request.range)
+    range_unit = asgi_helpers.fixup_wsgi_references(falcon.request.Request.range_unit)
+
+    @property
+    def stream(self):
+        if not self._stream:
+            self._stream = BoundedStream(self._receive, self.content_length)
+
+        return self._stream
+
+    bounded_stream = stream
+
+    @property
+    def root_path(self):
+        # PERF(kgriffs): try...except is faster than get() assuming that
+        #   we normally expect the key to exist. Even though ASGI 3.0
+        #   allows servers to omit the key when the value is an
+        #   empty string, at least uvicorn still includes it explicitly in
+        #   that case.
+        try:
+            return self.scope['root_path']
+        except KeyError:
+            pass
+
+        return ''
+
+    app = root_path
+
+    @property
+    def scheme(self):
+        # PERF(kgriffs): Use try...except because we normally expect the
+        #   key to be present.
+        try:
+            return self.scope['scheme']
+        except KeyError:
+            pass
+
+        return 'http'
+
+    @property
+    def forwarded_scheme(self):
+        # PERF(kgriffs): Since the Forwarded header is still relatively
+        # new, we expect X-Forwarded-Proto to be more common, so
+        # try to avoid calling self.forwarded if we can, since it uses a
+        # try...catch that will usually result in a relatively expensive
+        # raised exception.
+        if 'forwarded' in self._asgi_headers:
+            first_hop = self.forwarded[0]
+            scheme = first_hop.scheme or self.scheme
+        else:
+            # PERF(kgriffs): This call should normally succeed, so
+            # just go for it without wasting time checking it
+            # first. Note also that the indexing operator is
+            # slightly faster than using get().
+            try:
+                scheme = self._asgi_headers['x-forwarded-proto'].lower()
+            except KeyError:
+                scheme = self.scheme
+
+        return scheme
+
+    @property
+    def prefix(self):
+        if self._cached_prefix is None:
+            self._cached_prefix = (
+                self.scheme + '://' +
+                self.netloc +
+                self.app
+            )
+
+        return self._cached_prefix
+
+    @property
+    def host(self):
+        try:
+            # NOTE(kgriffs): Prefer the host header; the web server
+            # isn't supposed to mess with it, so it should be what
+            # the client actually sent.
+            host_header = self._asgi_headers['host']
+            host, __ = parse_host(host_header)
+        except KeyError:
+            host, __ = self._asgi_server
+
+        return host
+
+    @property
+    def forwarded_host(self):
+        # PERF(kgriffs): Since the Forwarded header is still relatively
+        # new, we expect X-Forwarded-Host to be more common, so
+        # try to avoid calling self.forwarded if we can, since it uses a
+        # try...catch that will usually result in a relatively expensive
+        # raised exception.
+        if 'forwarded' in self._asgi_headers:
+            first_hop = self.forwarded[0]
+            host = first_hop.host or self.host
+        else:
+            # PERF(kgriffs): This call should normally succeed, assuming
+            # that the caller is expecting a forwarded header, so
+            # just go for it without wasting time checking it
+            # first.
+            try:
+                host = self._asgi_headers['x-forwarded-host']
+            except KeyError:
+                host = self.host
+
+        return host
+
+    @property
+    def access_route(self):
+        if self._cached_access_route is None:
+            # PERF(kgriffs): 'client' is optional according to the ASGI spec
+            #   but it will probably be present, hence the try...except.
+            try:
+                # NOTE(kgriffs): The ASGI spec states that this can be
+                #   any iterable. So we need to read and cache it in
+                #   case the iterable is forward-only. But that is
+                #   effectively what we are doing since we only ever
+                #   access this field when setting self._cached_access_route
+                client, __ = self.scope['client']
+            except KeyError:
+                # NOTE(kgriffs): Default to localhost so that app logic does
+                #   note have to special-case the handling of a missing
+                #   client field in the connection scope. This should be
+                #   a reasonable default, but we can change it later if
+                #   that turns out not to be the case.
+                client = '127.0.0.1'
+
+            headers = self._asgi_headers
+
+            if 'forwarded' in headers:
+                self._cached_access_route = []
+                for hop in self.forwarded:
+                    if hop.src is not None:
+                        host, __ = parse_host(hop.src)
+                        self._cached_access_route.append(host)
+            elif 'x-forwarded-for' in headers:
+                addresses = headers['x-forwarded-for'].split(',')
+                self._cached_access_route = [ip.strip() for ip in addresses]
+            elif 'x-real-ip' in headers:
+                self._cached_access_route = [headers['x-real-ip']]
+
+            if self._cached_access_route:
+                if self._cached_access_route[-1] != client:
+                    self._cached_access_route.append(client)
+            else:
+                self._cached_access_route = [client] if client else []
+
+        return self._cached_access_route
+
+    @property
+    def remote_addr(self):
+        route = self.access_route
+        return route[-1]
+
+    @property
+    def port(self):
+        try:
+            host_header = self._asgi_headers['host']
+            default_port = 80 if self.scheme == 'http' else 443
+            __, port = parse_host(host_header, default_port=default_port)
+        except KeyError:
+            __, port = self._asgi_server
+
+        return port
+
+    @property
+    def netloc(self):
+        # PERF(kgriffs): try..except is faster than get() when we
+        # expect the key to be present most of the time.
+        try:
+            netloc_value = self._asgi_headers['host']
+        except KeyError:
+            netloc_value, port = self._asgi_server
+
+            if self.scheme == 'https':
+                if port != 443:
+                    netloc_value = f'{netloc_value}:{port}'
+            else:
+                if port != 80:
+                    netloc_value = f'{netloc_value}:{port}'
+
+        return netloc_value
+
+    @property
+    async def media(self):
+        stream = self.stream
+
+        if self._media is not None or stream.eof:
+            return self._media
+
+        content_type = self.content_type
+
+        handler = self.options.media_handlers.find_by_media_type(
+            content_type, self.options.default_media_type
+        )
+
+        try:
+            self._media = await handler.deserialize_async(
+                stream, content_type, self.content_length
+            )
+        finally:
+            if not stream.eof:
+                await stream.exhaust()
+
+        return self._media
+
+    # ------------------------------------------------------------------------
+    # Public Methods
+    # ------------------------------------------------------------------------
+
+    def get_header(self, name, required=False, default=None):
+        """Retrieve the raw string value for the given header.
+
+        Args:
+            name (str): Header name, case-insensitive (e.g., 'Content-Type')
+
+        Keyword Args:
+            required (bool): Set to ``True`` to raise
+                ``HTTPBadRequest`` instead of returning gracefully when the
+                header is not found (default ``False``).
+            default (any): Value to return if the header
+                is not found (default ``None``).
+
+        Returns:
+            str: The value of the specified header if it exists, or
+            the default value if the header is not found and is not
+            required.
+
+        Raises:
+            HTTPBadRequest: The header was not found in the request, but
+                it was required.
+
+        """
+
+        asgi_name = name.lower()
+
+        # Use try..except to optimize for the header existing in most cases
+        try:
+            # Don't take the time to cache beforehand, using HTTP naming.
+            # This will be faster, assuming that most headers are looked
+            # up only once, and not all headers will be requested.
+            return self._asgi_headers[asgi_name]
+
+        except KeyError:
+            if not required:
+                return default
+
+            raise errors.HTTPMissingHeader(name)
+
+    # ASGI does not have anything equivalent to wsgi.errors
+    log_error = None
+
+    # ------------------------------------------------------------------------
+    # Private Helpers
+    # ------------------------------------------------------------------------
+
+    @property
+    def _asgi_server(self):
+        if not self._asgi_server_cached:
+            try:
+                # NOTE(kgriffs): Since the ASGI spec states that 'server'
+                #   can be any old iterable, we have to be careful to only
+                #   read it once and cache the result in case the
+                #   iterator is forward-only (not likely, but better
+                #   safe than sorry).
+                self._asgi_server_cached = tuple(self.scope['server'])
+            except (KeyError, TypeError):
+                # NOTE(kgriffs): Not found, or was None
+                default_port = 80 if self.scheme == 'http' else 443
+                self._asgi_server_cached = ('localhost', default_port)
+
+        return self._asgi_server_cached
+
+    async def _parse_form_urlencoded(self):
+        if (
+            self.content_type is not None and
+
+            # PERF(kgriffs): Technically, we should spend a few more
+            # cycles and parse the content type for real, but
+            # this heuristic will work virtually all the time.
+            'application/x-www-form-urlencoded' in self.content_type and
+
+            # NOTE(kgriffs): Within HTTP, a payload for a GET or HEAD
+            # request has no defined semantics, so we don't expect a
+            # body in those cases. We would normally not expect a body
+            # for OPTIONS either, but RFC 7231 does allow for it.
+            self.method not in ('GET', 'HEAD')
+        ):
+            body = await self.stream.read()
+
+            # NOTE(kgriffs): According to http://goo.gl/6rlcux the
+            # body should be US-ASCII. Enforcing this also helps
+            # catch malicious input.
+            try:
+                body = body.decode('ascii')
+            except UnicodeDecodeError:
+                body = None
+
+            if body:
+                extra_params = parse_query_string(
+                    body,
+                    keep_blank=self.options.keep_blank_qs_values,
+                    csv=self.options.auto_parse_qs_csv,
+                )
+
+                self._params.update(extra_params)

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -1,0 +1,256 @@
+# Copyright 2019 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASGI Response class."""
+
+from inspect import iscoroutine
+
+import falcon.response
+
+__all__ = ['Response']
+
+
+class Response(falcon.response.Response):
+    """
+
+    Attributes:
+        sse (coroutine): A Server-Sent Event (SSE) emitter, implemented as
+            an async coroutine function that returns an iterable
+            of :py:class:`falcon.asgi.SSEent` instances. Each event will be
+            serialized and sent to the client as HTML5 Server-Sent Events.
+
+        data (bytes): Byte string representing response content.
+
+            Use this attribute in lieu of `body` when your content is
+            already a byte string (of type ``bytes``).
+
+            Warning:
+                Always use the `body` attribute for text, or encode it
+                first to ``bytes`` when using the `data` attribute, to
+                ensure Unicode characters are properly encoded in the
+                HTTP response.
+
+            Note:
+                Unlike the WSGI Response class, the ASGI Response class
+                does not implement the side-effect of serializing
+                the media object (if one is set) when the `data`
+                attribute is read. Instead,
+                :py:meth:`falcon.asgi.Response.render_body` should
+                be used to get the correct content for the response.
+    """
+
+    # PERF(kgriffs): These will be shadowed when set on an instance; let's
+    #   us avoid having to implement __init__ and incur the overhead of
+    #   an additional function call.
+    _sse = None
+    _registered_callbacks = None
+    _media_rendered = None
+
+    @property
+    def sse(self):
+        return self._sse
+
+    @sse.setter
+    def sse(self, value):
+        self._sse = value
+
+    @property
+    def media(self):
+        return self._media
+
+    @media.setter
+    def media(self, value):
+        self._media = value
+        self._media_rendered = None
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = value
+
+    async def render_body(self):
+        """Get the raw content for the response body.
+
+        This coroutine can be awaited to get the raw body data that should
+        be returned in the HTTP response.
+
+        Returns:
+            bytes: The UTF-8 encoded value of the `body` attribute, if
+                set. Otherwise, the value of the `data` attribute if set, or
+                finally the serialized value of the `media` attribute. If
+                none of these attributes are set, ``None`` is returned.
+        """
+
+        body = self.body
+        if body is None:
+            data = self._data
+
+            if data is None and self._media is not None:
+                if self._media_rendered is None:
+                    if not self.content_type:
+                        self.content_type = self.options.default_media_type
+
+                    handler = self.options.media_handlers.find_by_media_type(
+                        self.content_type,
+                        self.options.default_media_type
+                    )
+
+                    self._media_rendered = await handler.serialize_async(
+                        self._media,
+                        self.content_type
+                    )
+
+                data = self._media_rendered
+        else:
+            try:
+                # NOTE(kgriffs): Normally we expect body to be a string
+                data = body.encode()
+            except AttributeError:
+                # NOTE(kgriffs): Assume it was a bytes object already
+                data = body
+
+        return data
+
+    def schedule(self, callback):
+        """Schedules a callback to run soon after sending the HTTP response.
+
+        This method can be used to execute a background job after the
+        response has been returned to the client.
+
+        If the callback is an async coroutine function, it will be scheduled
+        to run on the event loop as soon as possible. Alternatively, if a
+        synchronous callable is passed, it will be run on the event loop's
+        default ``Executor`` (which can be overridden via
+        :py:meth:`asyncio.AbstractEventLoop.set_default_executor`).
+
+        The callback will be invoked without arguments. Use
+        :py:meth`functools.partial` to pass arguments to the callback
+        as needed.
+
+        Note:
+            If an unhandled exception is raised while processing the request,
+            the callback will not be scheduled to run.
+
+        Note:
+            When an SSE emitter has been set on the response, the callback will
+            be scheduled before the first call to the emitter.
+
+        Warning:
+            Because coroutines run on the main request thread, care should
+            be taken to ensure they are non-blocking. Long-running operations
+            must use async libraries or delegate to an Executor pool to avoid
+            blocking the processing of subsequent requests.
+
+        Warning:
+            Synchronous callables run on the event loop's default ``Executor``,
+            which uses an instance of ``ThreadPoolExecutor`` unless
+            :py:meth:`asyncio.AbstractEventLoop.set_default_executor` is used
+            to change it to something else. Due to the GIL, CPU-bound jobs
+            will block request processing for the current process unless
+            the default ``Executor`` is changed to one that is process-based
+            instead of thread-based (e.g., an instance of
+            :py:class:`concurrent.futures.ProcessPoolExecutor`).
+
+        Args:
+            callback(object): An async coroutine function or a synchronous
+                callable. The callback will be called without arguments.
+        """
+
+        if iscoroutine(callback):
+            raise TypeError(
+                'The callback object appears to '
+                'be a coroutine, rather than a coroutine function. Please '
+                'pass the function itself, rather than the result obtained '
+                'by calling the function. '
+            )
+
+        if not self._registered_callbacks:
+            self._registered_callbacks = [callback]
+        else:
+            self._registered_callbacks.append(callback)
+
+    def set_stream(self, stream, content_length):
+        """Convenience method for setting both `stream` and `content_length`.
+
+        Although the `stream` and `content_length` properties may be set
+        directly, using this method ensures `content_length` is not
+        accidentally neglected when the length of the stream is known in
+        advance. Using this method is also slightly more performant
+        as compared to setting the properties individually.
+
+        Note:
+            If the stream length is unknown, you can set `stream`
+            directly, and ignore `content_length`. In this case, the
+            ASGI server may choose to use chunked encoding for HTTP/1.1
+
+        Args:
+            stream: A readable, awaitable file-like object or async iterable that
+                retuns byte strings. If the object implements a close() method, it
+                will be called after reading all of the data.
+            content_length (int): Length of the stream, used for the
+                Content-Length header in the response.
+        """
+
+        self.stream = stream
+
+        # PERF(kgriffs): Set directly rather than incur the overhead of
+        #   the self.content_length property.
+        self._headers['content-length'] = str(content_length)
+
+    # ------------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------------
+
+    def _asgi_headers(self, media_type=None):
+        """Convert headers into the format expected by ASGI servers.
+
+        Header names must be lowercased and both name and value must be
+        byte strings.
+
+        See also: https://asgi.readthedocs.io/en/latest/specs/www.html#response-start
+
+        Args:
+            media_type: Default media type to use for the Content-Type
+                header if the header was not set explicitly (default ``None``).
+
+        """
+
+        headers = self._headers
+        # PERF(vytas): uglier inline version of Response._set_media_type
+        if media_type is not None and 'content-type' not in headers:
+            headers['content-type'] = media_type
+
+        items = [(n.encode(), v.encode()) for n, v in headers.items()]
+
+        if self._extra_headers:
+            items += [(n.encode(), v.encode()) for n, v in self._extra_headers]
+
+        # NOTE(kgriffs): It is important to append these after self._extra_headers
+        #   in case the latter contains Set-Cookie headers that should be
+        #   overridden by a call to unset_cookie().
+        if self._cookies is not None:
+            # PERF(tbug):
+            # The below implementation is ~23% faster than
+            # the alternative:
+            #
+            #     self._cookies.output().split("\\r\\n")
+            #
+            # Even without the .split("\\r\\n"), the below
+            # is still ~17% faster, so don't use .output()
+            items += [(b'set-cookie', c.OutputString().encode())
+                      for c in self._cookies.values()]
+        return items

--- a/falcon/asgi/stream.py
+++ b/falcon/asgi/stream.py
@@ -1,0 +1,255 @@
+# Copyright 2019 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ASGI BoundedStream class."""
+
+
+__all__ = ['BoundedStream']
+
+
+class BoundedStream:
+    """File-like async object for reading ASGI streams.
+
+    Does not support synhcronous reading/iterating but is otherwise similar to io.IOBase.
+
+    If content length is unknown, will read until the ASGI server indicates
+    there is no more body available.
+
+    """
+
+    __slots__ = [
+        '_buffer',
+        '_bytes_remaining',
+        '_closed',
+        '_pos',
+        '_receive',
+    ]
+
+    def __init__(self, receive, content_length=None):
+        self._closed = False
+
+        self._receive = receive
+        self._buffer = b''
+
+        # NOTE(kgriffs): If length is unknown we just set remaining bytes
+        #   to a ridiculously high number so that we will keep reading
+        #   until we get an event with more_body == False. We do not
+        #   use sys.maxsize because 2**31 on 32-bit systems is not
+        #   a large enough number (someone may have an API that accepts
+        #   multi-GB payloads).
+        self._bytes_remaining = 2**63 if content_length is None else content_length
+
+        self._pos = 0
+
+    def __aiter__(self):
+        # NOTE(kgriffs): Technically we should be returning an async iterator
+        #   here instead of an async generator, but in practice the caller
+        #   should be happy as long as the returned object is iterable.
+        return self._iter_content()
+
+    # -------------------------------------------------------------------------
+    # These methods are included to improve compatibility with Python's
+    #   standard "file-like" IO interface.
+    # -------------------------------------------------------------------------
+
+    # NOTE(kgriffs): According to the Python docs, NotImplementedError is not
+    #   meant to be used to mean "not supported"; rather, the method should
+    #   just be left undefined; hence we do not implement readline(),
+    #   readlines(), __iter__(), __next__(), flush(), seek(),
+    #   truncate(), __del__().
+
+    def fileno(self):
+        """Raises an instance of OSError since a file descriptor is not used."""
+        raise OSError('This IO object does not use a file descriptor')
+
+    def isatty(self):
+        """Always returns ``False``."""
+        return False
+
+    def readable(self):
+        """Always returns ``True``."""
+        return True
+
+    def seekable(self):
+        """Always returns ``False``."""
+        return False
+
+    def writable(self):
+        """Always returns ``False``."""
+        return False
+
+    def tell(self):
+        """Returns the number of bytes read from the stream."""
+        return self._pos
+
+    @property
+    def closed(self):
+        return self._closed
+
+    # -------------------------------------------------------------------------
+
+    @property
+    def eof(self):
+        return not self._buffer and self._bytes_remaining == 0
+
+    async def close(self):
+        """Clear any buffered data and close the stream."""
+        if not self._closed:
+            self._buffer = b''
+            self._bytes_remaining = 0
+
+            self._closed = True
+
+    async def exhaust(self):
+        self._buffer = b''
+
+        while self._bytes_remaining > 0:
+            event = await self._receive()
+
+            if event['type'] == 'http.disconnect':
+                self._bytes_remaining = 0
+            else:
+                num_bytes = len(event['body'])
+                self._bytes_remaining -= num_bytes
+                self._pos += num_bytes
+
+                if not ('more_body' in event and event['more_body']):
+                    self._bytes_remaining = 0
+
+        # NOTE(kgriffs): Ensure that if we read more than expected, this
+        #   this value is normalized to zero.
+        self._bytes_remaining = 0
+
+    async def readall(self):
+        if self.eof:
+            return b''
+
+        if self._buffer:
+            next_chunk = self._buffer
+            self._buffer = b''
+            chunks = [next_chunk]
+        else:
+            chunks = []
+
+        while self._bytes_remaining > 0:
+            event = await self._receive()
+            if 'body' in event:
+                next_chunk = event['body']
+                next_chunk_len = len(next_chunk)
+
+                if next_chunk_len <= self._bytes_remaining:
+                    chunks.append(next_chunk)
+                    self._bytes_remaining -= next_chunk_len
+                else:
+                    # NOTE(kgriffs): Do not read more data than we are
+                    #   expecting. This *should* never happen if the
+                    #   server enforces the content-length header, but
+                    #   it is better to be safe than sorry.
+                    chunks.append(next_chunk[:self._bytes_remaining])
+                    self._bytes_remaining = 0
+
+            # NOTE(kgriffs): This also handles the case of receiving
+            #   the event: {'type': 'http.disconnect'}
+            if not ('more_body' in event and event['more_body']):
+                self._bytes_remaining = 0
+
+        data = chunks[0] if len(chunks) == 1 else b''.join(chunks)
+        self._pos += len(data)
+
+        return data
+
+    async def read(self, size=None):
+        if self.eof:
+            return b''
+
+        if size is None or size == -1:
+            return await self.readall()
+
+        if size <= 0:
+            return b''
+
+        if self._buffer:
+            num_bytes_available = len(self._buffer)
+            chunks = [self._buffer]
+        else:
+            num_bytes_available = 0
+            chunks = []
+
+        while self._bytes_remaining > 0 and num_bytes_available < size:
+            event = await self._receive()
+            if 'body' in event:
+                next_chunk = event['body']
+                next_chunk_len = len(next_chunk)
+
+                if next_chunk_len <= self._bytes_remaining:
+                    chunks.append(next_chunk)
+                    self._bytes_remaining -= next_chunk_len
+                    num_bytes_available += next_chunk_len
+                else:
+                    # NOTE(kgriffs): Do not read more data than we are
+                    #   expecting. This *should* never happen, but better
+                    #   safe than sorry.
+                    chunks.append(next_chunk[:self._bytes_remaining])
+                    self._bytes_remaining = 0
+                    num_bytes_available += self._bytes_remaining
+
+            # NOTE(kgriffs): This also handles the case of receiving
+            #   the event: {'type': 'http.disconnect'}
+            if not ('more_body' in event and event['more_body']):
+                self._bytes_remaining = 0
+
+        self._buffer = chunks[0] if len(chunks) == 1 else b''.join(chunks)
+
+        if num_bytes_available <= size:
+            data = self._buffer
+            self._buffer = b''
+        else:
+            data = self._buffer[:size]
+            self._buffer = self._buffer[size:]
+
+        self._pos += len(data)
+
+        return data
+
+    # NOTE: In docs, tell people to not mix reading different modes - make
+    #   sure you exhaust in the finally if you are reading something
+    #   in middleware, or a chance something else might read it. Don't want someone
+    #   to end up trying to read a half-read thing anyway!
+    async def _iter_content(self):
+        if self.eof:
+            yield b''
+            return
+
+        while self._bytes_remaining > 0:
+            event = await self._receive()
+            if 'body' in event:
+                next_chunk = event['body']
+                next_chunk_len = len(next_chunk)
+
+                if next_chunk_len <= self._bytes_remaining:
+                    self._bytes_remaining -= next_chunk_len
+                else:
+                    next_chunk = next_chunk[:self._bytes_remaining]
+                    self._bytes_remaining = 0
+
+                yield next_chunk
+
+            # NOTE(kgriffs): Per the ASGI spec, more_body is optional
+            #   and should be considered False if not present.
+            # NOTE(kgriffs): This also handles the case of receiving
+            #   the event: {'type': 'http.disconnect'}
+            # PERF(kgriffs): event.get() is more elegant, but uses a
+            #   few more CPU cycles.
+            if not ('more_body' in event and event['more_body']):
+                self._bytes_remaining = 0

--- a/falcon/asgi/structures.py
+++ b/falcon/asgi/structures.py
@@ -1,0 +1,93 @@
+from json import dumps as json_dumps
+
+
+__all__ = ['SSEvent']
+
+
+class SSEvent:
+    __slots__ = [
+        'data',
+        'text',
+        'json',
+        'event',
+        'event_id',
+        'retry',
+        'comment',
+    ]
+
+    def __init__(
+        self,
+        data=None,
+        text=None,
+        json=None,
+        event=None,
+        event_id=None,
+        retry=None,
+        comment=None
+    ):
+        # NOTE(kgriffs): Check up front since this makes it a lot easier
+        #   to debug the source of the problem in the app vs. waiting for
+        #   an error to be raised from the framework when it calls serialize()
+        #   after the fact.
+
+        if data and not isinstance(data, bytes):
+            raise TypeError('data must be a byte string')
+
+        if text and not isinstance(text, str):
+            raise TypeError('text must be a string')
+
+        if event and not isinstance(event, str):
+            raise TypeError('event name must be a string')
+
+        if event_id and not isinstance(event_id, str):
+            raise TypeError('event_id must be a string')
+
+        if comment and not isinstance(comment, str):
+            raise TypeError('comment must be a string')
+
+        self.data = data
+        self.text = text
+        self.json = json
+        self.event = event
+        self.event_id = event_id
+
+        # NOTE(kgriffs) The SSE spec states that retry must be an integer;
+        #   this is a quick way to check (and coerce, if necessary) without
+        #   spending cycles on an isinstance() call.
+        self.retry = int(retry) if retry else None
+
+        self.comment = comment
+
+    def serialize(self):
+        if self.comment is not None:
+            block = ': ' + self.comment + '\n'
+        else:
+            block = ''
+
+        if self.event is not None:
+            block += 'event: ' + self.event + '\n'
+
+        if self.event_id is not None:
+            # NOTE(kgriffs): f-strings are a tiny bit faster than str().
+            block += f'id: {self.event_id}\n'
+
+        if self.retry is not None:
+            block += f'retry: {self.retry}\n'
+
+        if self.data is not None:
+            # NOTE(kgriffs): While this decode() may seem unnecessary, it
+            #   does provide a check to ensure it is valid UTF-8. I'm also
+            #   assuming for the moment that most people will not use this
+            #   attribute, but rather the text and json ones instead. If that
+            #   is true, it makes sense to construct the entire string
+            #   first, then encode it all in one go at the end.
+            block += 'data: ' + self.data.decode() + '\n'
+        elif self.text is not None:
+            block += 'data: ' + self.text + '\n'
+        elif self.json is not None:
+            block += 'data: ' + json_dumps(self.json, ensure_ascii=False) + '\n'
+
+        if not block:
+            return b': ping\n\n'
+
+        return (block + '\n').encode()

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -83,3 +83,16 @@ MEDIA_PNG = 'image/png'
 MEDIA_GIF = 'image/gif'
 
 DEFAULT_MEDIA_TYPE = MEDIA_JSON
+
+# NOTE(kgriffs): We do not expect more than one of these in the request
+SINGLETON_HEADERS = frozenset([
+    'content-length',
+    'content-type',
+    'cookie',
+    'expect',
+    'from',
+    'host',
+    'max-forwards',
+    'referer',
+    'user-agent',
+])

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -47,6 +47,14 @@ class HeaderNotSupported(ValueError):
     """The specified header is not supported by this method."""
 
 
+class CompatibilityError(Exception):
+    """The given method or value is not compatibile."""
+
+
+class UnsupportedScopeError(RuntimeError):
+    """The ASGI scope type is not supported by Falcon."""
+
+
 class HTTPBadRequest(HTTPError):
     """400 Bad Request.
 

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -1,4 +1,5 @@
 import abc
+import io
 
 
 class BaseHandler(metaclass=abc.ABCMeta):
@@ -16,15 +17,54 @@ class BaseHandler(metaclass=abc.ABCMeta):
             bytes: The resulting serialized bytes from the input object.
         """
 
+    async def serialize_async(self, media, content_type):
+        """Serialize the media object on a :any:`falcon.Response`
+
+        This method is similar to serialize() except that it is
+        asynchronous. The default implementation simply calls
+        serialize(). If the media object may be awaitable, or is otherwise
+        something that should be read asynchronously, subclasses
+        must override the default implementation in order to handle
+        that case.
+
+        Args:
+            media (object): A serializable object.
+            content_type (str): Type of response content.
+
+        Returns:
+            bytes: The resulting serialized bytes from the input object.
+        """
+        return self.serialize(media, content_type)
+
     @abc.abstractmethod  # pragma: no cover
     def deserialize(self, stream, content_type, content_length):
         """Deserialize the :any:`falcon.Request` body.
 
         Args:
-            stream (object): Input data to deserialize.
+            stream (object): Readable file-like object to deserialize.
             content_type (str): Type of request content.
             content_length (int): Length of request content.
 
         Returns:
             object: A deserialized object.
         """
+
+    async def deserialize_async(self, stream, content_type, content_length):
+        """Deserialize the :any:`falcon.Request` body.
+
+        This method is similar to deserialize() except that it is
+        asynchronous. The default implementation adapts the synchronous
+        deserialize() method via io.BytesIO. For improved performance,
+        media handlers should override this method.
+
+        Args:
+            stream (object): Asynchronous file-like object to deserialize.
+            content_type (str): Type of request content.
+            content_length (int): Length of request content.
+
+        Returns:
+            object: A deserialized object.
+        """
+
+        data = await stream.read()
+        return self.deserialize(io.BytesIO(data), content_type, content_length)

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -35,7 +35,7 @@ class Handlers(UserDict):
     def find_by_media_type(self, media_type, default):
         # PERF(jmvrbanac): Check via a quick methods first for performance
         if media_type == '*/*' or not media_type:
-            return self.data[default]
+            media_type = default
 
         try:
             return self.data[media_type]

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -78,7 +78,26 @@ class JSONHandler(BaseHandler):
                 'Could not parse JSON body - {0}'.format(err)
             )
 
+    async def deserialize_async(self, stream, content_type, content_length):
+        data = await stream.read()
+
+        try:
+            return self.loads(data.decode('utf-8'))
+        except ValueError as err:
+            raise errors.HTTPBadRequest(
+                'Invalid JSON',
+                'Could not parse JSON body - {0}'.format(err)
+            )
+
     def serialize(self, media, content_type):
+        result = self.dumps(media)
+
+        if not isinstance(result, bytes):
+            return result.encode('utf-8')
+
+        return result
+
+    async def serialize_async(self, media, content_type):
         result = self.dumps(media)
 
         if not isinstance(result, bytes):

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -41,5 +41,21 @@ class MessagePackHandler(BaseHandler):
                 'Could not parse MessagePack body - {0}'.format(err)
             )
 
+    async def deserialize_async(self, stream, content_type, content_length):
+        data = await stream.read()
+
+        try:
+            # NOTE(jmvrbanac): Using unpackb since we would need to manage
+            # a buffer for Unpacker() which wouldn't gain us much.
+            return self.msgpack.unpackb(data, raw=False)
+        except ValueError as err:
+            raise errors.HTTPBadRequest(
+                'Invalid MessagePack',
+                'Could not parse MessagePack body - {0}'.format(err)
+            )
+
     def serialize(self, media, content_type):
+        return self.packer.pack(media)
+
+    async def serialize_async(self, media, content_type):
         return self.packer.pack(media)

--- a/falcon/media/validators/jsonschema.py
+++ b/falcon/media/validators/jsonschema.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from inspect import iscoroutinefunction
 
 import falcon
 
@@ -46,36 +47,81 @@ def validate(req_schema=None, resp_schema=None):
     """
 
     def decorator(func):
-        @wraps(func)
-        def wrapper(self, req, resp, *args, **kwargs):
-            if req_schema is not None:
-                try:
-                    jsonschema.validate(
-                        req.media, req_schema,
-                        format_checker=jsonschema.FormatChecker()
-                    )
-                except jsonschema.ValidationError as e:
-                    raise falcon.HTTPBadRequest(
-                        'Request data failed validation',
-                        description=e.message
-                    )
+        if iscoroutinefunction(func):
+            return _validate_async(func, req_schema, resp_schema)
 
-            result = func(self, req, resp, *args, **kwargs)
+        return _validate(func, req_schema, resp_schema)
 
-            if resp_schema is not None:
-                try:
-                    jsonschema.validate(
-                        resp.media, resp_schema,
-                        format_checker=jsonschema.FormatChecker()
-                    )
-                except jsonschema.ValidationError:
-                    raise falcon.HTTPInternalServerError(
-                        'Response data failed validation'
-                        # Do not return 'e.message' in the response to
-                        # prevent info about possible internal response
-                        # formatting bugs from leaking out to users.
-                    )
-
-            return result
-        return wrapper
     return decorator
+
+
+def _validate(func, req_schema=None, resp_schema=None):
+    @wraps(func)
+    def wrapper(self, req, resp, *args, **kwargs):
+        if req_schema is not None:
+            try:
+                jsonschema.validate(
+                    req.media, req_schema,
+                    format_checker=jsonschema.FormatChecker()
+                )
+            except jsonschema.ValidationError as e:
+                raise falcon.HTTPBadRequest(
+                    'Request data failed validation',
+                    description=e.message
+                )
+
+        result = func(self, req, resp, *args, **kwargs)
+
+        if resp_schema is not None:
+            try:
+                jsonschema.validate(
+                    resp.media, resp_schema,
+                    format_checker=jsonschema.FormatChecker()
+                )
+            except jsonschema.ValidationError:
+                raise falcon.HTTPInternalServerError(
+                    'Response data failed validation'
+                    # Do not return 'e.message' in the response to
+                    # prevent info about possible internal response
+                    # formatting bugs from leaking out to users.
+                )
+
+        return result
+
+    return wrapper
+
+
+def _validate_async(func, req_schema=None, resp_schema=None):
+    @wraps(func)
+    async def wrapper(self, req, resp, *args, **kwargs):
+        if req_schema is not None:
+            try:
+                jsonschema.validate(
+                    (await req.media), req_schema,
+                    format_checker=jsonschema.FormatChecker()
+                )
+            except jsonschema.ValidationError as e:
+                raise falcon.HTTPBadRequest(
+                    'Request data failed validation',
+                    description=e.message
+                )
+
+        result = await func(self, req, resp, *args, **kwargs)
+
+        if resp_schema is not None:
+            try:
+                jsonschema.validate(
+                    resp.media, resp_schema,
+                    format_checker=jsonschema.FormatChecker()
+                )
+            except jsonschema.ValidationError:
+                raise falcon.HTTPInternalServerError(
+                    'Response data failed validation'
+                    # Do not return 'e.message' in the response to
+                    # prevent info about possible internal response
+                    # formatting bugs from leaking out to users.
+                )
+
+        return result
+
+    return wrapper

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -182,12 +182,18 @@ class BoundedStream(io.IOBase):
 
     This class normalizes *wsgi.input* behavior between WSGI servers
     by implementing non-blocking behavior for the cases mentioned
-    above.
+    above. The caller is not allowed to read more than the number of
+    bytes specified by the Content-Length header in the request.
 
     Args:
         stream: Instance of ``socket._fileobject`` from
             ``environ['wsgi.input']``
         stream_len: Expected content length of the stream.
+
+    Attributes:
+        eof (bool): ``True`` if there is no more data to read from
+            the stream, otherwise ``False``.
+        is_exhausted (bool): Deprecated alias for `eof`.
 
     """
 
@@ -239,7 +245,7 @@ class BoundedStream(io.IOBase):
         """Always returns ``False``."""
         return False
 
-    def writeable(self):
+    def writable(self):
         """Always returns ``False``."""
         return False
 
@@ -305,9 +311,10 @@ class BoundedStream(io.IOBase):
                 break
 
     @property
-    def is_exhausted(self):
-        """If the stream is exhausted this attribute is ``True``."""
+    def eof(self):
         return self._bytes_remaining <= 0
+
+    is_exhausted = eof
 
 
 # NOTE(kgriffs): Alias for backwards-compat

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -187,6 +187,11 @@ class Response:
 
     @property
     def data(self):
+        # TODO(kgriffs): Remove the side-effect that accessing this
+        #   property causes (do something similar to what we did on the
+        #   ASGI side). This will be a breaking change, so caution is
+        #   advised.
+
         # NOTE(kgriffs): Test explicitly against None since the
         # app may have set it to an empty binary string.
         if self._data is not None:
@@ -234,6 +239,11 @@ class Response:
         # rather than serializing immediately. That way, if media() is called
         # multiple times we don't waste time serializing objects that will
         # just be thrown away.
+        #
+        # TODO(kgriffs): This makes precedence harder to reason about, since
+        #   it is no longer about what attributes have and have not been set,
+        #   but also what order they were set in. On the ASGI side this has
+        #   already been addressed.
         self._data = None
 
     @property

--- a/falcon/routing/__init__.py
+++ b/falcon/routing/__init__.py
@@ -20,7 +20,7 @@ routers.
 """
 
 from falcon.routing.compiled import CompiledRouter, CompiledRouterOptions  # NOQA
-from falcon.routing.static import StaticRoute  # NOQA
+from falcon.routing.static import StaticRoute, StaticRouteAsync  # NOQA
 from falcon.routing.util import map_http_methods  # NOQA
 from falcon.routing.util import set_default_responders  # NOQA
 from falcon.routing.util import compile_uri_template  # NOQA

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import partial
 import io
 import os
 import re
@@ -122,3 +124,24 @@ class StaticRoute:
 
         if self._downloadable:
             resp.downloadable_as = os.path.basename(file_path)
+
+
+class StaticRouteAsync(StaticRoute):
+    """Subclass of StaticRoute with modifications to support ASGI apps."""
+
+    async def __call__(self, req, resp):
+        super().__call__(req, resp)
+
+        # NOTE(kgriffs): Fixup resp.stream so that it is non-blocking
+        resp.stream = _AsyncFileReader(resp.stream)
+
+
+class _AsyncFileReader:
+    """Adapts a standard file I/O object so that reads are non-blocking."""
+
+    def __init__(self, file):
+        self._file = file
+        self._loop = asyncio.get_event_loop()
+
+    async def read(self, size=-1):
+        return await self._loop.run_in_executor(None, partial(self._file.read, size))

--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -130,12 +130,14 @@ def map_http_methods(resource, suffix=None):
     return method_map
 
 
-def set_default_responders(method_map):
+def set_default_responders(method_map, asgi=False):
     """Maps HTTP methods not explicitly defined on a resource to default responders.
 
     Args:
         method_map: A dict with HTTP methods mapped to responders explicitly
             defined in a resource.
+        asgi (bool): ``True`` if using an ASGI app, ``False`` otherwise
+            (default ``False``).
     """
 
     # Attach a resource for unsupported HTTP methods
@@ -143,11 +145,11 @@ def set_default_responders(method_map):
 
     if 'OPTIONS' not in method_map:
         # OPTIONS itself is intentionally excluded from the Allow header
-        opt_responder = responders.create_default_options(allowed_methods)
+        opt_responder = responders.create_default_options(allowed_methods, asgi=asgi)
         method_map['OPTIONS'] = opt_responder
         allowed_methods.append('OPTIONS')
 
-    na_responder = responders.create_method_not_allowed(allowed_methods)
+    na_responder = responders.create_method_not_allowed(allowed_methods, asgi=asgi)
 
     for method in constants.COMBINED_METHODS:
         if method not in allowed_methods:

--- a/falcon/testing/__init__.py
+++ b/falcon/testing/__init__.py
@@ -78,6 +78,6 @@ The testing framework supports both unittest and pytest::
 from falcon.testing.client import *  # NOQA
 from falcon.testing.helpers import *  # NOQA
 from falcon.testing.resource import capture_responder_args, set_resp_defaults  # NOQA
-from falcon.testing.resource import SimpleTestResource  # NOQA
+from falcon.testing.resource import SimpleTestResource, SimpleTestResourceAsync  # NOQA
 from falcon.testing.srmock import StartResponseMock  # NOQA
 from falcon.testing.test_case import TestCase  # NOQA

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -18,15 +18,24 @@ This package includes utilities for simulating HTTP requests against a
 WSGI callable, without having to stand up a WSGI server.
 """
 
+import asyncio
 from http import cookies as http_cookies
+import inspect
+import time
 import warnings
 import wsgiref.validate
+
 
 from falcon.constants import MEDIA_JSON
 from falcon.testing import helpers
 from falcon.testing.srmock import StartResponseMock
-from falcon.util import CaseInsensitiveDict, http_date_to_dt, to_query_str
-from falcon.util import json as util_json
+from falcon.util import (
+    CaseInsensitiveDict,
+    code_to_http_status,
+    http_date_to_dt,
+    json as util_json,
+    to_query_str,
+)
 
 
 warnings.filterwarnings(
@@ -42,7 +51,7 @@ warnings.filterwarnings(
 
 
 class Result:
-    """Encapsulates the result of a simulated WSGI request.
+    """Encapsulates the result of a simulated request.
 
     Args:
         iterable (iterable): An iterable that yields zero or more
@@ -79,9 +88,12 @@ class Result:
         json (JSON serializable): Deserialized JSON body. Will be ``None`` if
             the body has no content to deserialize. Otherwise, raises an error
             if the response is not valid JSON.
+        events (iterable): An iterable collection of events that were
+            emitted by the calling ASGI app. This attribute will
+            always be an empty iterable for WSGI apps.
     """
 
-    def __init__(self, iterable, status, headers):
+    def __init__(self, iterable, status, headers, events=None):
         self._text = None
 
         self._content = b''.join(iterable)
@@ -89,6 +101,7 @@ class Result:
         self._status = status
         self._status_code = int(status[:3])
         self._headers = CaseInsensitiveDict(headers)
+        self._events = events or []
 
         cookies = http_cookies.SimpleCookie()
         for name, value in headers:
@@ -147,6 +160,10 @@ class Result:
             return None
 
         return util_json.loads(self.text)
+
+    @property
+    def events(self):
+        return self._events
 
 
 class Cookie:
@@ -224,19 +241,25 @@ class Cookie:
         return bool(self._httponly)
 
 
+# NOTE(kgriffs): The default of asgi_disconnect_ttl was chosen to be
+#   relatively long (5 minutes) to help testers notice when something
+#   appears to be "hanging", which might indicates that the app is
+#   not handling the reception of events correctly.
 def simulate_request(app, method='GET', path='/', query_string=None,
                      headers=None, body=None, json=None, file_wrapper=None,
                      wsgierrors=None, params=None, params_csv=True,
                      protocol='http', host=helpers.DEFAULT_HOST,
-                     remote_addr=None, extras=None):
-    """Simulates a request to a WSGI application.
+                     remote_addr=None, extras=None, http_version='1.1',
+                     port=None, root_path=None, asgi_chunk_size=4096,
+                     asgi_disconnect_ttl=300):
 
-    Performs a request against a WSGI application. Uses
-    :any:`wsgiref.validate` to ensure the response is valid
-    WSGI.
+    """Simulates a request to a WSGI or ASGI application.
+
+    Performs a request against a WSGI or ASGI application. In the case of
+    WSGI, uses :any:`wsgiref.validate` to ensure the response is valid.
 
     Keyword Args:
-        app (callable): The WSGI application to call
+        app (callable): The WSGI or ASGI application to call
         method (str): An HTTP method to use in the request
             (default: 'GET')
         path (str): The URL path to request (default: '/').
@@ -245,8 +268,17 @@ def simulate_request(app, method='GET', path='/', query_string=None,
                 The path may contain a query string. However, neither
                 `query_string` nor `params` may be specified in this case.
 
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
         protocol: The protocol to use for the URL scheme
             (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -261,27 +293,48 @@ def simulate_request(app, method='GET', path='/', query_string=None,
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        body (str): A string to send as the body of the request. The value
-            will be encoded as UTF-8.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        body (str): The body of the request (default ''). The value will be
+            encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
+            may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
             overrides `body` and the Content-Type header in
             `headers`.
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
-            environ (default: ``None``). This can be used to test
+            WSGI environ (default: ``None``). This can be used to test
             high-performance file transmission when `resp.stream` is
             set to a file-like object.
         host(str): A string to use for the hostname part of the fully
             qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        wsgierrors (io): The stream to use as *wsgierrors*
-            (default ``sys.stderr``)
-        extras (dict): Additional CGI variables to add to the WSGI
-            ``environ`` dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
 
     Returns:
         :py:class:`~.Result`: The result of the request
@@ -302,15 +355,6 @@ def simulate_request(app, method='GET', path='/', query_string=None,
         raise ValueError("query_string should not start with '?'")
 
     extras = extras or {}
-    if 'REQUEST_METHOD' in extras and extras['REQUEST_METHOD'] != method:
-        # NOTE(vytas): Even given the duct tape nature of overriding
-        # arbitrary environ variables, changing the method can potentially
-        # be very confusing, particularly when using specialized
-        # simulate_get/post/patch etc methods.
-        raise ValueError(
-            'environ extras may not override the request method. Please '
-            'use the method parameter.'
-        )
 
     if query_string is None:
         query_string = to_query_str(
@@ -324,48 +368,160 @@ def simulate_request(app, method='GET', path='/', query_string=None,
         headers = headers or {}
         headers['Content-Type'] = MEDIA_JSON
 
-    env = helpers.create_environ(
-        method=method,
-        scheme=protocol,
-        path=path,
-        query_string=(query_string or ''),
-        headers=headers,
-        body=body,
-        file_wrapper=file_wrapper,
-        host=host,
-        remote_addr=remote_addr,
-        wsgierrors=wsgierrors,
-    )
-    if extras:
+    if http_version not in ('2', '1.1', '1.0'):
+        raise ValueError('Invalid http_version specified: ' + http_version)
+
+    if not _is_asgi_app(app):
+        env = helpers.create_environ(
+            method=method,
+            scheme=protocol,
+            path=path,
+            query_string=(query_string or ''),
+            headers=headers,
+            body=body,
+            file_wrapper=file_wrapper,
+            host=host,
+            remote_addr=remote_addr,
+            wsgierrors=wsgierrors,
+            http_version=http_version,
+            port=port,
+            root_path=root_path,
+        )
+
+        if 'REQUEST_METHOD' in extras and extras['REQUEST_METHOD'] != method:
+            # NOTE(vytas): Even given the duct tape nature of overriding
+            # arbitrary environ variables, changing the method can potentially
+            # be very confusing, particularly when using specialized
+            # simulate_get/post/patch etc methods.
+            raise ValueError(
+                'WSGI environ extras may not override the request method. '
+                'Please use the method parameter.'
+            )
+
         env.update(extras)
 
-    srmock = StartResponseMock()
-    validator = wsgiref.validate.validator(app)
+        srmock = StartResponseMock()
+        validator = wsgiref.validate.validator(app)
 
-    iterable = validator(env, srmock)
+        iterable = validator(env, srmock)
 
-    result = Result(helpers.closed_wsgi_iterable(iterable),
-                    srmock.status, srmock.headers)
+        return Result(helpers.closed_wsgi_iterable(iterable),
+                      srmock.status, srmock.headers)
 
-    return result
+    # ---------------------------------------------------------------------
+    # NOTE(kgriffs): 'lifespan' scope
+    # ---------------------------------------------------------------------
+
+    lifespan_scope = {
+        'type': 'lifespan',
+        'asgi': {
+            'version': '3.0',
+            'spec_version': '2.0',
+        },
+    }
+
+    shutting_down = asyncio.Condition()
+    lifespan_event_emitter = helpers.ASGILifespanEventEmitter(shutting_down)
+    lifespan_event_collector = helpers.ASGIResponseEventCollector()
+
+    # ---------------------------------------------------------------------
+    # NOTE(kgriffs): 'http' scope
+    # ---------------------------------------------------------------------
+
+    content_length = None
+
+    if body is not None:
+        if isinstance(body, str):
+            body = body.encode()
+
+        content_length = len(body)
+
+    http_scope = helpers.create_scope(
+        path=path,
+        query_string=query_string,
+        method=method,
+        headers=headers,
+        host=host,
+        scheme=protocol,
+        port=port,
+        http_version=http_version,
+        remote_addr=remote_addr,
+        root_path=root_path,
+        content_length=content_length,
+    )
+
+    if 'method' in extras and extras['method'] != method.upper():
+        raise ValueError(
+            'ASGI scope extras may not override the request method. '
+            'Please use the method parameter.'
+        )
+
+    http_scope.update(extras)
+
+    disconnect_at = time.time() + max(0, asgi_disconnect_ttl)
+    req_event_emitter = helpers.ASGIRequestEventEmitter(
+        (body or b''),
+        disconnect_at,
+        chunk_size=asgi_chunk_size
+    )
+
+    resp_event_collector = helpers.ASGIResponseEventCollector()
+
+    async def conductor():
+        # NOTE(kgriffs): We assume this is a Falcon WSGI app, which supports
+        #   the lifespan protocol and thus we do not need to catch
+        #   exceptions that would signify no lifespan protocol support.
+        t = asyncio.create_task(
+            app(lifespan_scope, lifespan_event_emitter, lifespan_event_collector)
+        )
+
+        await _wait_for_startup(lifespan_event_collector.events)
+
+        await app(http_scope, req_event_emitter, resp_event_collector)
+
+        # NOTE(kgriffs): Notify lifespan_event_emitter that it is OK
+        #   to proceed.
+        async with shutting_down:
+            shutting_down.notify()
+
+        await _wait_for_shutdown(lifespan_event_collector.events)
+        await t
+
+    helpers.invoke_coroutine_sync(conductor)
+
+    return Result(resp_event_collector.body_chunks,
+                  code_to_http_status(resp_event_collector.status),
+                  resp_event_collector.headers,
+                  events=resp_event_collector.events)
 
 
 def simulate_get(app, path, **kwargs):
-    """Simulates a GET request to a WSGI application.
+    """Simulates a GET request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'GET', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
-        path (str): The URL path to request.
+        app (callable): The application to call
+        path (str): The URL path to request
 
             Note:
                 The path may contain a query string. However, neither
                 `query_string` nor `params` may be specified in this case.
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -380,41 +536,72 @@ def simulate_get(app, path, **kwargs):
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
-            environ (default: ``None``). This can be used to test
+            WSGI environ (default: ``None``). This can be used to test
             high-performance file transmission when `resp.stream` is
             set to a file-like object.
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'GET', path, **kwargs)
 
 
 def simulate_head(app, path, **kwargs):
-    """Simulates a HEAD request to a WSGI application.
+    """Simulates a HEAD request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'HEAD', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
-        path (str): The URL path to request.
+        app (callable): The application to call
+        path (str): The URL path to request
 
             Note:
                 The path may contain a query string. However, neither
                 `query_string` nor `params` may be specified in this case.
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -429,32 +616,63 @@ def simulate_head(app, path, **kwargs):
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'HEAD', path, **kwargs)
 
 
 def simulate_post(app, path, **kwargs):
-    """Simulates a POST request to a WSGI application.
+    """Simulates a POST request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'POST', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
+        app (callable): The application to call
         path (str): The URL path to request
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -466,38 +684,78 @@ def simulate_post(app, path, **kwargs):
             of the parameter (e.g., 'thing=1&thing=2&thing=3').
             Otherwise, parameters will be encoded as comma-separated
             values (e.g., 'thing=1,2,3'). Defaults to ``True``.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        body (str): A string to send as the body of the request. The value
-            will be encoded as UTF-8.
+        query_string (str): A raw query string to include in the
+            request (default: ``None``). If specified, overrides
+            `params`.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        body (str): The body of the request (default ''). The value will be
+            encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
+            may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
             overrides `body` and the Content-Type header in
             `headers`.
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        file_wrapper (callable): Callable that returns an iterable,
+            to be used as the value for *wsgi.file_wrapper* in the
+            WSGI environ (default: ``None``). This can be used to test
+            high-performance file transmission when `resp.stream` is
+            set to a file-like object.
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'POST', path, **kwargs)
 
 
 def simulate_put(app, path, **kwargs):
-    """Simulates a PUT request to a WSGI application.
+    """Simulates a PUT request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'PUT', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
+        app (callable): The application to call
         path (str): The URL path to request
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -509,38 +767,79 @@ def simulate_put(app, path, **kwargs):
             of the parameter (e.g., 'thing=1&thing=2&thing=3').
             Otherwise, parameters will be encoded as comma-separated
             values (e.g., 'thing=1,2,3'). Defaults to ``True``.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        body (str): A string to send as the body of the request. The value
-            will be encoded as UTF-8.
+        query_string (str): A raw query string to include in the
+            request (default: ``None``). If specified, overrides
+            `params`.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        body (str): The body of the request (default ''). The value will be
+            encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
+            may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
             overrides `body` and the Content-Type header in
             `headers`.
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        file_wrapper (callable): Callable that returns an iterable,
+            to be used as the value for *wsgi.file_wrapper* in the
+            WSGI environ (default: ``None``). This can be used to test
+            high-performance file transmission when `resp.stream` is
+            set to a file-like object.
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
+
     """
     return simulate_request(app, 'PUT', path, **kwargs)
 
 
 def simulate_options(app, path, **kwargs):
-    """Simulates an OPTIONS request to a WSGI application.
+    """Simulates an OPTIONS request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'OPTIONS', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
+        app (callable): The application to call
         path (str): The URL path to request
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -552,32 +851,66 @@ def simulate_options(app, path, **kwargs):
             of the parameter (e.g., 'thing=1&thing=2&thing=3').
             Otherwise, parameters will be encoded as comma-separated
             values (e.g., 'thing=1,2,3'). Defaults to ``True``.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        query_string (str): A raw query string to include in the
+            request (default: ``None``). If specified, overrides
+            `params`.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'OPTIONS', path, **kwargs)
 
 
 def simulate_patch(app, path, **kwargs):
-    """Simulates a PATCH request to a WSGI application.
+    """Simulates a PATCH request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'PATCH', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
+        app (callable): The application to call
         path (str): The URL path to request
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -589,38 +922,73 @@ def simulate_patch(app, path, **kwargs):
             of the parameter (e.g., 'thing=1&thing=2&thing=3').
             Otherwise, parameters will be encoded as comma-separated
             values (e.g., 'thing=1,2,3'). Defaults to ``True``.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        body (str): A string to send as the body of the request. The value
-            will be encoded as UTF-8.
+        query_string (str): A raw query string to include in the
+            request (default: ``None``). If specified, overrides
+            `params`.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        body (str): The body of the request (default ''). The value will be
+            encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
+            may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
             overrides `body` and the Content-Type header in
             `headers`.
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'PATCH', path, **kwargs)
 
 
 def simulate_delete(app, path, **kwargs):
-    """Simulates a DELETE request to a WSGI application.
+    """Simulates a DELETE request to a WSGI or ASGI application.
 
     Equivalent to::
 
          simulate_request(app, 'DELETE', path, **kwargs)
 
     Args:
-        app (callable): The WSGI application to call
+        app (callable): The application to call
         path (str): The URL path to request
 
     Keyword Args:
+        root_path (str): The initial portion of the request URL's "path" that
+            corresponds to the application object, so that the application
+            knows its virtual "location". This defaults to the empty string,
+            indicating that the application corresponds to the "root" of the
+            server.
+        protocol: The protocol to use for the URL scheme
+            (default: 'http')
+        port (int): The TCP port to simulate. Defaults to
+            the standard port used by the given scheme (i.e., 80 for 'http'
+            and 443 for 'https'). A string may also be passed, as long as
+            it can be parsed as an int.
         params (dict): A dictionary of query string parameters,
             where each key is a parameter name, and each value is
             either a ``str`` or something that can be converted
@@ -632,22 +1000,52 @@ def simulate_delete(app, path, **kwargs):
             of the parameter (e.g., 'thing=1&thing=2&thing=3').
             Otherwise, parameters will be encoded as comma-separated
             values (e.g., 'thing=1,2,3'). Defaults to ``True``.
-        headers (dict): Additional headers to include in the request
-            (default: ``None``)
-        protocol: The protocol to use for the URL scheme
-            (default: 'http')
-        host(str): A string to use for the hostname part of the fully qualified
-            request URL (default: 'falconframework.org')
+        query_string (str): A raw query string to include in the
+            request (default: ``None``). If specified, overrides
+            `params`.
+        headers (dict): Extra headers as a dict-like (Mapping) object, or an
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of strings provides the name and value
+            for an HTTP header. If desired, multiple header values may be
+            combined into a single (*name*, *value*) pair by joining the values
+            with a comma when the header in question supports the list
+            format (see also RFC 7230 and RFC 7231). Header names are not
+            case-sensitive.
+        body (str): The body of the request (default ''). The value will be
+            encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
+            may be passed, in which case it will be used as-is.
+        json(JSON serializable): A JSON document to serialize as the
+            body of the request (default: ``None``). If specified,
+            overrides `body` and the Content-Type header in
+            `headers`.
+        host(str): A string to use for the hostname part of the fully
+            qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
-            request (default: '127.0.0.1')
-        extras (dict): Additional CGI variables to add to the WSGI ``environ``
-            dictionary for the request (default: ``None``)
+            request (default: '127.0.0.1'). For WSGI, this corresponds to
+            the 'REMOTE_ADDR' environ variable. For ASGI, this corresponds
+            to the IP address used for the 'client' field in the connection
+            scope.
+        http_version (str): The HTTP version to simulate. Must be either
+            '2', '1.1', or '1.0' (default '1.1'). If set to '1.0', the Host
+            header will not be added to the scope.
+        wsgierrors (io): The stream to use as *wsgierrors* in the WSGI
+            environ (default ``sys.stderr``)
+        asgi_chunk_size (int): The maximum number of bytes that will be
+            sent to the ASGI app in a single 'http.request' event (default
+            4096).
+        asgi_disconnect_ttl (int): The maxmimum number of seconds to wait
+            since the request was initiated, before emitting an
+            'http.disconnect' event when the app calls the
+            receive() function (default 300).
+        extras (dict): Additional values to add to the WSGI
+            ``environ`` dictionary or the ASGI scope for the request
+            (default: ``None``)
     """
     return simulate_request(app, 'DELETE', path, **kwargs)
 
 
 class TestClient:
-    """Simulates requests to a WSGI application.
+    """Simulates requests to a WSGI or ASGI application.
 
     This class provides a contextual wrapper for Falcon's `simulate_*`
     test functions. It lets you replace this::
@@ -666,14 +1064,17 @@ class TestClient:
         overriding of request preparation by child classes.
 
     Args:
-        app (callable): A WSGI application to target when simulating
+        app (callable): A WSGI or ASGI application to target when simulating
             requests
-
 
     Keyword Arguments:
         headers (dict): Default headers to set on every request (default
             ``None``). These defaults may be overridden by passing values
             for the same headers to one of the `simulate_*()` methods.
+
+    Attributes:
+        app: The app that this client instance was configured to use.
+
     """
 
     def __init__(self, app, headers=None):
@@ -749,3 +1150,49 @@ class TestClient:
             kwargs['headers'] = merged_headers
 
         return simulate_request(self.app, *args, **kwargs)
+
+
+# -----------------------------------------------------------------------------
+# Private
+# -----------------------------------------------------------------------------
+
+
+def _is_asgi_app(app):
+    app_args = inspect.getfullargspec(app).args
+    num_app_args = len(app_args)
+
+    # NOTE(kgriffs): Technically someone could name the "self"
+    #   arg something else, but we will make the simplifying
+    #   assumption that this is rare enough to not worry about.
+    if app_args[0] == 'self':
+        num_app_args -= 1
+
+    is_asgi = (num_app_args == 3)
+
+    return is_asgi
+
+
+async def _wait_for_startup(events):
+    while True:
+        # NOTE(kgriffs): Yield to the concurrent lifespan task
+        await asyncio.sleep(0.001)
+
+        if any(e['type'] == 'lifespan.startup.complete' for e in events):
+            break
+
+        for e in events:
+            if e['type'] == 'lifespan.startup.failed':
+                raise RuntimeError('ASGI app returned lifespan.startup.failed. ' + e['message'])
+
+
+async def _wait_for_shutdown(events):
+    while True:
+        # NOTE(kgriffs): Yield to the concurrent lifespan task
+        await asyncio.sleep(0.001)
+
+        if any(e['type'] == 'lifespan.shutdown.complete' for e in events):
+            break
+
+        for e in events:
+            if e['type'] == 'lifespan.shutdown.failed':
+                raise RuntimeError('ASGI app returned lifespan.shutdown.failed. ' + e['message'])

--- a/falcon/testing/resource.py
+++ b/falcon/testing/resource.py
@@ -35,14 +35,50 @@ def capture_responder_args(req, resp, resource, params):
     Adds the following attributes to the hooked responder's resource
     class:
 
-        * captured_req
-        * captured_resp
-        * captured_kwargs
+        * `captured_req`
+        * `captured_resp`
+        * `captured_kwargs`
+
+    In addition, if the capture-req-body-bytes header is present in the
+    request, the following attribute is added:
+
+        * `captured_req_body`
+
+    Including the capture-req-media header in the request (set to any
+    value) will add the following attribute:
+
+        * `capture-req-media`
     """
 
     resource.captured_req = req
     resource.captured_resp = resp
     resource.captured_kwargs = params
+
+    resource.captured_req_media = None
+    resource.captured_req_body = None
+
+    num_bytes = req.get_header('capture-req-body-bytes')
+    if num_bytes:
+        resource.captured_req_body = req.stream.read(int(num_bytes))
+    elif req.get_header('capture-req-media'):
+        resource.captured_req_media = req.media
+
+
+async def capture_responder_args_async(req, resp, resource, params):
+    """An asynchronous version of ``capture_responder_args()``."""
+
+    resource.captured_req = req
+    resource.captured_resp = resp
+    resource.captured_kwargs = params
+
+    resource.captured_req_media = None
+    resource.captured_req_body = None
+
+    num_bytes = req.get_header('capture-req-body-bytes')
+    if num_bytes:
+        resource.captured_req_body = await req.stream.read(int(num_bytes))
+    elif req.get_header('capture-req-media'):
+        resource.captured_req_media = await req.media
 
 
 def set_resp_defaults(req, resp, resource, params):
@@ -56,6 +92,11 @@ def set_resp_defaults(req, resp, resource, params):
 
     if resource._default_headers is not None:
         resp.set_headers(resource._default_headers)
+
+
+async def set_resp_defaults_async(req, resp, resource, params):
+    """Wraps capture_responder_args in a coroutine."""
+    set_resp_defaults(req, resp, resource, params)
 
 
 class SimpleTestResource:
@@ -125,4 +166,75 @@ class SimpleTestResource:
     @falcon.before(capture_responder_args)
     @falcon.before(set_resp_defaults)
     def on_post(self, req, resp, **kwargs):
+        pass
+
+
+class SimpleTestResourceAsync:
+    """Mock resource for functional testing of ASGI framework components.
+
+    This class implements a simple test resource that can be extended
+    as needed to test middleware, hooks, and the Falcon framework
+    itself. It is identical to SimpleTestResource, except that it implements
+    asynchronous responders for use with the ASGI interface.
+
+    Only noop ``on_get()`` and ``on_post()`` responders are implemented;
+    when overriding these, or adding additional responders in child
+    classes, they can be decorated with the
+    :py:meth:`falcon.testing.capture_responder_args` hook in
+    order to capture the *req*, *resp*, and *params* arguments that
+    are passed to the responder. Responders may also be decorated with
+    the :py:meth:`falcon.testing.set_resp_defaults` hook in order to
+    set *resp* properties to default *status*, *body*, and *header*
+    values.
+
+    Keyword Arguments:
+        status (str): Default status string to use in responses
+        body (str): Default body string to use in responses
+        json (JSON serializable): Default JSON document to use in responses.
+            Will be serialized to a string and encoded as UTF-8. Either
+            *json* or *body* may be specified, but not both.
+        headers (dict): Default set of additional headers to include in
+            responses
+
+    Attributes:
+        called (bool): Whether or not a req/resp was captured.
+        captured_req (falcon.Request): The last Request object passed
+            into any one of the responder methods.
+        captured_resp (falcon.Response): The last Response object passed
+            into any one of the responder methods.
+        captured_kwargs (dict): The last dictionary of kwargs, beyond
+            ``req`` and ``resp``, that were passed into any one of the
+            responder methods.
+    """
+
+    def __init__(self, status=None, body=None, json=None, headers=None):
+        self._default_status = status
+        self._default_headers = headers
+
+        if json is not None:
+            if body is not None:
+                msg = 'Either json or body may be specified, but not both'
+                raise ValueError(msg)
+
+            self._default_body = json_dumps(json, ensure_ascii=False)
+
+        else:
+            self._default_body = body
+
+        self.captured_req = None
+        self.captured_resp = None
+        self.captured_kwargs = None
+
+    @property
+    def called(self):
+        return self.captured_req is not None
+
+    @falcon.before(capture_responder_args_async)
+    @falcon.before(set_resp_defaults_async)
+    async def on_get(self, req, resp, **kwargs):
+        pass
+
+    @falcon.before(capture_responder_args_async)
+    @falcon.before(set_resp_defaults_async)
+    async def on_post(self, req, resp, **kwargs):
         pass

--- a/falcon/testing/test_case.py
+++ b/falcon/testing/test_case.py
@@ -45,10 +45,10 @@ class TestCase(unittest.TestCase, TestClient):
     :py:class:`unittest.TestCase` or :py:class:`testtools.TestCase`.
 
     Attributes:
-        app (object): A WSGI application to target when simulating
+        app (object): A WSGI or ASGI application to target when simulating
             requests (default: ``falcon.API()``). When testing your
             application, you will need to set this to your own instance
-            of ``falcon.API``. For example::
+            of ``falcon.API`` or ``falcon.asgi.App``. For example::
 
                 from falcon import testing
                 import myapp
@@ -75,11 +75,6 @@ class TestCase(unittest.TestCase, TestClient):
     def setUp(self):
         super(TestCase, self).setUp()
 
-        app = falcon.API()
-
         # NOTE(kgriffs): Don't use super() to avoid triggering
         # unittest.TestCase.__init__()
-        TestClient.__init__(self, app)
-
-        # Reset to simulate "restarting" the WSGI container
-        falcon.request._maybe_wrap_wsgi_stream = True
+        TestClient.__init__(self, falcon.API())

--- a/requirements/tests
+++ b/requirements/tests
@@ -4,6 +4,9 @@ pyyaml
 requests
 testtools
 
+# ASGI Specific
+uvicorn; python_version >= '3.6'
+
 # Handler Specific
 msgpack
 mujson

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     zip_safe=False,
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires='>=3.5',
     install_requires=REQUIRES,
     cmdclass=cmdclass,
     ext_modules=ext_modules,

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,0 +1,60 @@
+import pytest
+
+import falcon
+import falcon.testing
+
+if not falcon.PY35:
+    import falcon.asgi
+
+
+__all__ = [
+    'create_app',
+    'create_req',
+    'create_resp',
+    'to_coroutine',
+]
+
+
+def create_app(asgi, **app_kwargs):
+    if asgi:
+        if falcon.PY35:
+            pytest.skip('ASGI requires Python 3.6+')
+        else:
+            return falcon.asgi.App(**app_kwargs)
+
+    return falcon.API(**app_kwargs)
+
+
+def create_req(asgi, options=None, **environ_or_scope_kwargs):
+    if asgi:
+        if falcon.PY35:
+            pytest.skip('ASGI requires Python 3.6+')
+        else:
+            req = falcon.testing.create_asgi_req(
+                options=options,
+                **environ_or_scope_kwargs
+            )
+    else:
+        req = falcon.testing.create_req(
+            options=options,
+            **environ_or_scope_kwargs
+        )
+
+    return req
+
+
+def create_resp(asgi):
+    if asgi:
+        if falcon.PY35:
+            pytest.skip('ASGI requires Python 3.6+')
+        else:
+            return falcon.asgi.Response()
+
+    return falcon.Response()
+
+
+def to_coroutine(callable):
+    async def wrapper(*args, **kwargs):
+        return callable(*args, **kwargs)
+
+    return wrapper

--- a/tests/asgi/test_asgi.py
+++ b/tests/asgi/test_asgi.py
@@ -1,0 +1,206 @@
+import asyncio
+from collections import Counter
+from io import StringIO
+import logging
+import multiprocessing
+import os
+import time
+
+import pytest
+import requests
+import uvicorn
+
+import falcon
+import falcon.asgi
+import falcon.testing as testing
+
+_SERVER_HOST = '127.0.0.1'
+_SERVER_PORT = 9000 + os.getpid() % 100  # Facilitates parallel test execution
+_SERVER_BASE_URL = 'http://{}:{}/'.format(_SERVER_HOST, _SERVER_PORT)
+_SIZE_1_KB = 1024
+
+
+@pytest.mark.usefixtures('_setup_asgi_server')
+class TestASGIServer:
+
+    def test_get(self):
+        resp = requests.get(_SERVER_BASE_URL)
+        assert resp.status_code == 200
+        assert resp.text == '127.0.0.1'
+
+    def test_put(self):
+        body = '{}'
+        resp = requests.put(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 200
+        assert resp.text == '{}'
+
+    def test_head_405(self):
+        body = '{}'
+        resp = requests.head(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 405
+
+    def test_post_multiple(self):
+        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        resp = requests.post(_SERVER_BASE_URL, data=body)
+        assert resp.status_code == 200
+        assert resp.text == body
+        assert resp.headers['X-Counter'] == '0'
+
+        time.sleep(0.5)
+
+        resp = requests.post(_SERVER_BASE_URL, data=body)
+        assert resp.headers['X-Counter'] == '2002'
+
+    def test_post_invalid_content_length(self):
+        headers = {'Content-Length': 'invalid'}
+
+        # NOTE(kgriffs): Uvicorn will kill the request so it does not
+        #   even get to our app; the app logic is tested on the WSGI
+        #   side. We leave this here in case something changes in
+        #   the way uvicorn handles it or something and we want to
+        #   get a heads-up if the request is no longer blocked.
+        with pytest.raises(Exception):
+            requests.post(_SERVER_BASE_URL, headers=headers)
+
+    def test_post_read_bounded_stream(self):
+        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        resp = requests.post(_SERVER_BASE_URL + 'bucket', data=body)
+        assert resp.status_code == 200
+        assert resp.text == body
+
+    def test_post_read_bounded_stream_no_body(self):
+        resp = requests.post(_SERVER_BASE_URL + 'bucket')
+        assert not resp.text
+
+    def test_sse(self):
+        resp = requests.get(_SERVER_BASE_URL + 'events')
+        assert resp.status_code == 200
+
+        events = resp.text.split('\n\n')
+        assert len(events) > 2
+        for e in events[:-1]:
+            assert e == 'data: hello world'
+
+        assert not events[-1]
+
+
+def _run_server(succeeded):
+    output = StringIO()
+    logger = logging.getLogger('uvicorn')
+    logger.addHandler(logging.StreamHandler(output))
+
+    class Things:
+        def __init__(self):
+            self._counter = Counter()
+
+        async def on_get(self, req, resp):
+            await asyncio.sleep(0.01)
+            resp.body = req.remote_addr
+
+        async def on_post(self, req, resp):
+            resp.data = await req.stream.read(req.content_length or 0)
+            resp.set_header('X-Counter', str(self._counter['backround:things:on_post']))
+
+            async def background_job_async():
+                await asyncio.sleep(0.1)
+                self._counter['backround:things:on_post'] += 1
+
+            def background_job_sync():
+                time.sleep(0.1)
+                self._counter['backround:things:on_post'] += 1000
+
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_sync)
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_sync)
+
+        async def on_put(self, req, resp):
+            # NOTE(kgriffs): Test that reading past the end does
+            # not hang.
+
+            chunks = []
+            for i in range(req.content_length + 1):
+                # NOTE(kgriffs): In the ASGI interface, bounded_stream is an
+                #   alias for req.stream. We'll use the alias here just as
+                #   a sanity check.
+                chunk = await req.bounded_stream.read(1)
+                chunks.append(chunk)
+
+            # NOTE(kgriffs): body should really be set to a string, but
+            #   Falcon is lenient and will allow bytes as well (although
+            #   it is slightly less performant).
+            # TODO(kgriffs): Perhaps in Falcon 4.0 be more strict? We would
+            #   also have to change the WSGI behavior to match.
+            resp.body = b''.join(chunks)
+
+    class Bucket:
+        async def on_post(self, req, resp):
+            resp.body = await req.stream.read()
+
+    class Events:
+        async def on_get(self, req, resp):
+            async def emit():
+                start = time.time()
+                while time.time() - start < 1:
+                    yield falcon.asgi.SSEvent(text='hello world')
+                    await asyncio.sleep(0.2)
+
+            resp.sse = emit()
+
+    class LifespanHandler:
+        def __init__(self):
+            self.startup_succeeded = False
+            self.shutdown_succeeded = False
+
+        async def process_startup(self, scope, event):
+            assert scope['type'] == 'lifespan'
+            assert event['type'] == 'lifespan.startup'
+            self.startup_succeeded = True
+
+        async def process_shutdown(self, scope, event):
+            assert scope['type'] == 'lifespan'
+            assert event['type'] == 'lifespan.shutdown'
+            self.shutdown_succeeded = True
+
+    app = falcon.asgi.App()
+    app.add_route('/', Things())
+    app.add_route('/bucket', Bucket())
+    app.add_route('/events', Events())
+
+    lifespan_handler = LifespanHandler()
+    app.add_lifespan_handler(lifespan_handler)
+
+    uvicorn.run(app, host=_SERVER_HOST, port=_SERVER_PORT, loop='asyncio')
+
+    assert lifespan_handler.startup_succeeded
+    assert lifespan_handler.shutdown_succeeded
+
+    print(output.getvalue())
+
+    succeeded.value = 1
+
+
+@pytest.fixture
+def _setup_asgi_server():
+    succeeded = multiprocessing.Value('B', 0)
+    process = multiprocessing.Process(target=_run_server, args=(succeeded,), daemon=True)
+    process.start()
+
+    # NOTE(kgriffs): Let the server start up
+    time.sleep(0.2)
+    assert process.is_alive()
+
+    yield
+
+    # NOTE(kgriffs): Pump the request handler loop in case execution
+    # made it to the next server.handle_request() before we sent the
+    # event.
+    try:
+        requests.get(_SERVER_BASE_URL)
+    except Exception:
+        pass  # Process already exited
+
+    process.terminate()
+    process.join()
+
+    assert succeeded.value == 1

--- a/tests/asgi/test_hello_asgi.py
+++ b/tests/asgi/test_hello_asgi.py
@@ -1,0 +1,246 @@
+import io
+
+import pytest
+
+import falcon
+from falcon import testing
+import falcon.asgi
+
+
+@pytest.fixture
+def client():
+    return testing.TestClient(falcon.asgi.App())
+
+
+class DataReaderWithoutClose:
+    def __init__(self, data):
+        self._stream = io.BytesIO(data)
+        self.close_called = False
+
+    async def read(self, num_bytes):
+        return self._stream.read(num_bytes)
+
+
+class DataReader(DataReaderWithoutClose):
+    async def close(self):
+        self.close_called = True
+
+
+class HelloResource:
+    sample_status = '200 OK'
+    sample_unicode = ('Hello World! \x80 - ' + testing.rand_string(0, 5))
+    sample_utf8 = sample_unicode.encode('utf-8')
+
+    def __init__(self, mode):
+        self.called = False
+        self.mode = mode
+
+    async def on_get(self, req, resp):
+        self.called = True
+        self.req, self.resp = req, resp
+
+        resp.status = falcon.HTTP_200
+
+        if 'stream' in self.mode:
+            if 'filelike' in self.mode:
+                stream = DataReader(self.sample_utf8)
+            else:
+                async def data_emitter():
+                    for b in self.sample_utf8:
+                        yield bytes([b])
+
+                if 'stream_genfunc' in self.mode:
+                    stream = data_emitter
+                elif 'stream_nongenfunc' in self.mode:
+                    stream = 42
+                else:
+                    stream = data_emitter()
+
+            if 'stream_len' in self.mode:
+                stream_len = len(self.sample_utf8)
+            else:
+                stream_len = None
+
+            if 'use_helper' in self.mode:
+                resp.set_stream(stream, stream_len)
+            else:
+                resp.stream = stream
+                resp.content_length = stream_len
+
+        if 'body' in self.mode:
+            if 'bytes' in self.mode:
+                resp.body = self.sample_utf8
+            else:
+                resp.body = self.sample_unicode
+
+        if 'data' in self.mode:
+            resp.data = self.sample_utf8
+
+    async def on_head(self, req, resp):
+        await self.on_get(req, resp)
+
+
+class ClosingFilelikeHelloResource:
+    sample_status = '200 OK'
+    sample_unicode = ('Hello World! \x80' + testing.rand_string(0, 0))
+
+    sample_utf8 = sample_unicode.encode('utf-8')
+
+    def __init__(self, stream_factory):
+        self.called = False
+        self.stream = stream_factory(self.sample_utf8)
+        self.stream_len = len(self.sample_utf8)
+
+    async def on_get(self, req, resp):
+        self.called = True
+        self.req, self.resp = req, resp
+        resp.status = falcon.HTTP_200
+        resp.set_stream(self.stream, self.stream_len)
+
+
+class NoStatusResource:
+    async def on_get(self, req, resp):
+        pass
+
+
+class TestHelloWorld:
+
+    def test_env_headers_list_of_tuples(self):
+        env = testing.create_environ(headers=[('User-Agent', 'Falcon-Test')])
+        assert env['HTTP_USER_AGENT'] == 'Falcon-Test'
+
+    def test_root_route(self, client):
+        doc = {'message': 'Hello world!'}
+        resource = testing.SimpleTestResource(json=doc)
+        client.app.add_route('/', resource)
+
+        result = client.simulate_get()
+        assert result.json == doc
+
+    def test_no_route(self, client):
+        result = client.simulate_get('/seenoevil')
+        assert result.status_code == 404
+
+    @pytest.mark.parametrize('path,resource,get_body', [
+        ('/body', HelloResource('body'), lambda r: r.body.encode('utf-8')),
+        ('/bytes', HelloResource('body, bytes'), lambda r: r.body),
+        ('/data', HelloResource('data'), lambda r: r.data),
+    ])
+    def test_body(self, client, path, resource, get_body):
+        client.app.add_route(path, resource)
+
+        result = client.simulate_get(path)
+        resp = resource.resp
+
+        content_length = int(result.headers['content-length'])
+        assert content_length == len(resource.sample_utf8)
+
+        assert result.status == resource.sample_status
+        assert resp.status == resource.sample_status
+        assert get_body(resp) == resource.sample_utf8
+        assert result.content == resource.sample_utf8
+
+    def test_no_body_on_head(self, client):
+        resource = HelloResource('body')
+        client.app.add_route('/body', resource)
+        result = client.simulate_head('/body')
+
+        assert not result.content
+        assert result.status_code == 200
+        assert resource.called
+        assert result.headers['content-length'] == str(len(HelloResource.sample_utf8))
+
+    def test_stream_chunked(self, client):
+        resource = HelloResource('stream')
+        client.app.add_route('/chunked-stream', resource)
+
+        result = client.simulate_get('/chunked-stream')
+
+        assert result.content == resource.sample_utf8
+        assert 'content-length' not in result.headers
+
+    def test_stream_known_len(self, client):
+        resource = HelloResource('stream, stream_len')
+        client.app.add_route('/stream', resource)
+
+        result = client.simulate_get('/stream')
+        assert resource.called
+
+        expected_len = int(resource.resp.content_length)
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+        assert result.content == resource.sample_utf8
+
+    def test_filelike(self, client):
+        resource = HelloResource('stream, stream_len, filelike')
+        client.app.add_route('/filelike', resource)
+
+        result = client.simulate_get('/filelike')
+        assert resource.called
+
+        expected_len = int(resource.resp.content_length)
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+        result = client.simulate_get('/filelike')
+        assert resource.called
+
+        expected_len = int(resource.resp.content_length)
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+    def test_genfunc_error(self, client):
+        resource = HelloResource('stream, stream_len, stream_genfunc')
+        client.app.add_route('/filelike', resource)
+
+        with pytest.raises(TypeError):
+            client.simulate_get('/filelike')
+
+    def test_nongenfunc_error(self, client):
+        resource = HelloResource('stream, stream_len, stream_nongenfunc')
+        client.app.add_route('/filelike', resource)
+
+        with pytest.raises(TypeError):
+            client.simulate_get('/filelike')
+
+    @pytest.mark.parametrize('stream_factory,assert_closed', [
+        (DataReader, True),  # Implements close()
+        (DataReaderWithoutClose, False),
+    ])
+    def test_filelike_closing(self, client, stream_factory, assert_closed):
+        resource = ClosingFilelikeHelloResource(stream_factory)
+        client.app.add_route('/filelike-closing', resource)
+
+        result = client.simulate_get('/filelike-closing')
+        assert resource.called
+
+        expected_len = int(resource.resp.content_length)
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+        if assert_closed:
+            assert resource.stream.close_called
+
+    def test_filelike_using_helper(self, client):
+        resource = HelloResource('stream, stream_len, filelike, use_helper')
+        client.app.add_route('/filelike-helper', resource)
+
+        result = client.simulate_get('/filelike-helper')
+        assert resource.called
+
+        expected_len = int(resource.resp.content_length)
+        actual_len = int(result.headers['content-length'])
+        assert actual_len == expected_len
+        assert len(result.content) == expected_len
+
+    def test_status_not_set(self, client):
+        client.app.add_route('/nostatus', NoStatusResource())
+
+        result = client.simulate_get('/nostatus')
+
+        assert not result.content
+        assert result.status_code == 200

--- a/tests/asgi/test_lifespan_handlers.py
+++ b/tests/asgi/test_lifespan_handlers.py
@@ -1,0 +1,203 @@
+import pytest
+
+from falcon import testing
+from falcon.asgi import App
+
+
+def test_at_least_one_event_method_required():
+    class Foo:
+        pass
+
+    app = App()
+
+    with pytest.raises(TypeError):
+        app.add_lifespan_handler(Foo())
+
+
+def test_startup_only():
+    class Foo:
+        async def process_startup(self, scope, event):
+            self._called = True
+
+    foo = Foo()
+
+    app = App()
+    app.add_lifespan_handler(foo)
+    client = testing.TestClient(app)
+
+    client.simulate_get()
+
+    assert foo._called
+
+
+def test_startup_raises():
+    class Foo:
+        def __init__(self):
+            self._shutdown_called = False
+
+        async def process_startup(self, scope, event):
+            raise Exception('testing 123')
+
+        async def process_shutdown(self, scope, event):
+            self._shutdown_called = True
+
+    class Bar:
+        def __init__(self):
+            self._startup_called = False
+            self._shutdown_called = False
+
+        async def process_startup(self, scope, event):
+            self._startup_called = True
+
+        async def process_shutdown(self, scope, event):
+            self._shutdown_called = True
+
+    foo = Foo()
+    bar = Bar()
+
+    app = App()
+    app.add_lifespan_handler(foo)
+    app.add_lifespan_handler(bar)
+    client = testing.TestClient(app)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        client.simulate_get()
+
+    message = str(excinfo.value)
+
+    assert message.startswith('ASGI app returned lifespan.startup.failed.')
+    assert 'testing 123' in message
+
+    assert not foo._shutdown_called
+    assert not bar._startup_called
+    assert not bar._shutdown_called
+
+
+def test_shutdown_raises():
+    class HandlerA:
+        def __init__(self):
+            self._startup_called = False
+
+        async def process_startup(self, scope, event):
+            self._startup_called = True
+
+        async def process_shutdown(self, scope, event):
+            raise Exception('testing 321')
+
+    class HandlerB:
+        def __init__(self):
+            self._startup_called = False
+            self._shutdown_called = False
+
+        async def process_startup(self, scope, event):
+            self._startup_called = True
+
+        async def process_shutdown(self, scope, event):
+            self._shutdown_called = True
+
+    a = HandlerA()
+    b1 = HandlerB()
+    b2 = HandlerB()
+
+    app = App()
+    app.add_lifespan_handler(b1)
+    app.add_lifespan_handler(a)
+    app.add_lifespan_handler(b2)
+    client = testing.TestClient(app)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        client.simulate_get()
+
+    message = str(excinfo.value)
+
+    assert message.startswith('ASGI app returned lifespan.shutdown.failed.')
+    assert 'testing 321' in message
+
+    assert a._startup_called
+    assert b1._startup_called
+    assert not b1._shutdown_called
+    assert b2._startup_called
+    assert b2._shutdown_called
+
+
+def test_shutdown_only():
+    class Foo:
+        async def process_shutdown(self, scope, event):
+            self._called = True
+
+    foo = Foo()
+
+    app = App()
+    app.add_lifespan_handler(foo)
+    client = testing.TestClient(app)
+
+    client.simulate_get()
+
+    assert foo._called
+
+
+def test_multiple_handlers():
+    counter = 0
+
+    class HandlerA:
+        async def process_startup(self, scope, event):
+            nonlocal counter
+            self._called_startup = counter
+            counter += 1
+
+    class HandlerB:
+        async def process_startup(self, scope, event):
+            nonlocal counter
+            self._called_startup = counter
+            counter += 1
+
+        async def process_shutdown(self, scope, event):
+            nonlocal counter
+            self._called_shutdown = counter
+            counter += 1
+
+    class HandlerC:
+        async def process_shutdown(self, scope, event):
+            nonlocal counter
+            self._called_shutdown = counter
+            counter += 1
+
+    class HandlerD:
+        async def process_startup(self, scope, event):
+            nonlocal counter
+            self._called_startup = counter
+            counter += 1
+
+    class HandlerE:
+        async def process_startup(self, scope, event):
+            nonlocal counter
+            self._called_startup = counter
+            counter += 1
+
+        async def process_shutdown(self, scope, event):
+            nonlocal counter
+            self._called_shutdown = counter
+            counter += 1
+
+    app = App()
+
+    a = HandlerA()
+    b = HandlerB()
+    c = HandlerC()
+    d = HandlerD()
+    e = HandlerE()
+
+    for handler in (a, b, c, d, e):
+        app.add_lifespan_handler(handler)
+
+    client = testing.TestClient(app)
+    client.simulate_get()
+
+    assert a._called_startup == 0
+    assert b._called_startup == 1
+    assert d._called_startup == 2
+    assert e._called_startup == 3
+
+    assert e._called_shutdown == 4
+    assert c._called_shutdown == 5
+    assert b._called_shutdown == 6

--- a/tests/asgi/test_middleware_asgi.py
+++ b/tests/asgi/test_middleware_asgi.py
@@ -1,0 +1,31 @@
+import pytest
+
+import falcon
+
+
+class MiddlewareIncompatibleWithWSGI_A:
+    async def process_request(self, req, resp):
+        pass
+
+
+class MiddlewareIncompatibleWithWSGI_B:
+    async def process_resource(self, req, resp, resource, params):
+        pass
+
+
+class MiddlewareIncompatibleWithWSGI_C:
+    async def process_response(self, req, resp, resource, req_succeeded):
+        pass
+
+
+@pytest.mark.parametrize('middleware', [
+    MiddlewareIncompatibleWithWSGI_A(),
+    MiddlewareIncompatibleWithWSGI_B(),
+    MiddlewareIncompatibleWithWSGI_C(),
+    (MiddlewareIncompatibleWithWSGI_C(), MiddlewareIncompatibleWithWSGI_A()),
+])
+def test_raise_on_incompatible(middleware):
+    api = falcon.API()
+
+    with pytest.raises(falcon.CompatibilityError):
+        api.add_middleware(middleware)

--- a/tests/asgi/test_request_body_asgi.py
+++ b/tests/asgi/test_request_body_asgi.py
@@ -1,0 +1,86 @@
+import pytest
+
+import falcon
+import falcon.asgi
+import falcon.request
+import falcon.testing as testing
+
+
+SIZE_1_KB = 1024
+
+
+@pytest.fixture
+def resource():
+    return testing.SimpleTestResourceAsync()
+
+
+@pytest.fixture
+def client():
+    app = falcon.asgi.App()
+    return testing.TestClient(app)
+
+
+class TestRequestBody:
+    def test_empty_body(self, client, resource):
+        client.app.add_route('/', resource)
+        client.simulate_request(path='/', body='')
+        stream = resource.captured_req.stream
+        assert stream.tell() == 0
+
+    def test_tiny_body(self, client, resource):
+        client.app.add_route('/', resource)
+        expected_body = '.'
+
+        headers = {'capture-req-body-bytes': '1'}
+        client.simulate_request(path='/', body=expected_body, headers=headers)
+        stream = resource.captured_req.stream
+
+        assert resource.captured_req_body == expected_body.encode('utf-8')
+        assert stream.tell() == 1
+
+    def test_tiny_body_overflow(self, client, resource):
+        client.app.add_route('/', resource)
+        expected_body = '.'
+        expected_len = len(expected_body)
+
+        # Read too many bytes; shouldn't block
+        headers = {'capture-req-body-bytes': str(len(expected_body) + 1)}
+        client.simulate_request(path='/', body=expected_body, headers=headers)
+        stream = resource.captured_req.stream
+
+        assert resource.captured_req_body == expected_body.encode('utf-8')
+        assert stream.tell() == expected_len
+
+    def test_read_body(self, client, resource):
+        client.app.add_route('/', resource)
+        expected_body = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+        expected_len = len(expected_body)
+
+        headers = {
+            'Content-Length': str(expected_len),
+            'Capture-Req-Body-Bytes': '-1',
+        }
+        client.simulate_request(path='/', body=expected_body, headers=headers)
+
+        content_len = resource.captured_req.get_header('content-length')
+        assert content_len == str(expected_len)
+
+        stream = resource.captured_req.stream
+
+        assert resource.captured_req_body == expected_body.encode('utf-8')
+        assert stream.tell() == expected_len
+
+    def test_bounded_stream_alias(self):
+        scope = testing.create_scope()
+        req_event_emitter = testing.ASGIRequestEventEmitter(b'', 0)
+        req = falcon.asgi.Request(scope, req_event_emitter)
+
+        assert req.bounded_stream is req.stream
+
+    def test_request_repr(self):
+        scope = testing.create_scope()
+        req_event_emitter = testing.ASGIRequestEventEmitter(b'', 0)
+        req = falcon.asgi.Request(scope, req_event_emitter)
+
+        _repr = '<%s: %s %r>' % (req.__class__.__name__, req.method, req.url)
+        assert req.__repr__() == _repr

--- a/tests/asgi/test_request_context_asgi.py
+++ b/tests/asgi/test_request_context_asgi.py
@@ -1,0 +1,53 @@
+import pytest
+
+from falcon.asgi import Request
+import falcon.testing as testing
+
+
+class TestRequestContext:
+
+    def test_default_request_context(self,):
+        req = testing.create_asgi_req()
+
+        req.context.hello = 'World'
+        assert req.context.hello == 'World'
+        assert req.context['hello'] == 'World'
+
+        req.context['note'] = 'Default Request.context_type used to be dict.'
+        assert 'note' in req.context
+        assert hasattr(req.context, 'note')
+        assert req.context.get('note') == req.context['note']
+
+    def test_custom_request_context(self):
+
+        # Define a Request-alike with a custom context type
+        class MyCustomContextType():
+            pass
+
+        class MyCustomRequest(Request):
+            context_type = MyCustomContextType
+
+        req = testing.create_asgi_req(req_type=MyCustomRequest)
+        assert isinstance(req.context, MyCustomContextType)
+
+    def test_custom_request_context_failure(self):
+
+        # Define a Request-alike with a non-callable custom context type
+        class MyCustomRequest(Request):
+            context_type = False
+
+        with pytest.raises(TypeError):
+            testing.create_asgi_req(req_type=MyCustomRequest)
+
+    def test_custom_request_context_request_access(self):
+
+        def create_context(req):
+            return {'uri': req.uri}
+
+        # Define a Request-alike with a custom context type
+        class MyCustomRequest(Request):
+            context_type = create_context
+
+        req = testing.create_asgi_req(req_type=MyCustomRequest)
+        assert isinstance(req.context, dict)
+        assert req.context['uri'] == req.uri

--- a/tests/asgi/test_response_media_asgi.py
+++ b/tests/asgi/test_response_media_asgi.py
@@ -1,0 +1,164 @@
+import json
+
+import pytest
+
+import falcon
+from falcon import errors, media, testing
+import falcon.asgi
+
+
+def create_client(resource, handlers=None):
+    app = falcon.asgi.App()
+    app.add_route('/', resource)
+
+    if handlers:
+        app.resp_options.media_handlers.update(handlers)
+
+    client = testing.TestClient(app, headers={'capture-resp-media': 'yes'})
+
+    return client
+
+
+class SimpleMediaResource:
+
+    def __init__(self, document, media_type=falcon.MEDIA_JSON):
+        self._document = document
+        self._media_type = media_type
+
+    async def on_get(self, req, resp):
+        resp.content_type = self._media_type
+        resp.media = self._document
+        resp.status = falcon.HTTP_OK
+
+
+@pytest.mark.parametrize('media_type', [
+    ('*/*'),
+    (falcon.MEDIA_JSON),
+    ('application/json; charset=utf-8'),
+])
+def test_json(media_type):
+    class TestResource:
+        async def on_get(self, req, resp):
+            resp.content_type = media_type
+            resp.media = {'something': True}
+
+            body = await resp.render_body()
+
+            assert json.loads(body.decode('utf-8')) == {'something': True}
+
+    client = create_client(TestResource())
+    client.simulate_get('/')
+
+
+@pytest.mark.parametrize('document', [
+    '',
+    'I am a \u1d0a\ua731\u1d0f\u0274 string.',
+    ['\u2665', '\u2660', '\u2666', '\u2663'],
+    {'message': '\xa1Hello Unicode! \U0001F638'},
+    {
+        'description': 'A collection of primitive Python type examples.',
+        'bool': False is not True and True is not False,
+        'dict': {'example': 'mapping'},
+        'float': 1.0,
+        'int': 1337,
+        'list': ['a', 'sequence', 'of', 'items'],
+        'none': None,
+        'str': 'ASCII string',
+        'unicode': 'Hello Unicode! \U0001F638',
+    },
+])
+def test_non_ascii_json_serialization(document):
+    client = create_client(SimpleMediaResource(document))
+    resp = client.simulate_get('/')
+    assert resp.json == document
+
+
+@pytest.mark.parametrize('media_type', [
+    (falcon.MEDIA_MSGPACK),
+    ('application/msgpack; charset=utf-8'),
+    ('application/x-msgpack'),
+])
+def test_msgpack(media_type):
+
+    class TestResource:
+        async def on_get(self, req, resp):
+            resp.content_type = media_type
+
+            # Bytes
+            resp.media = {b'something': True}
+            assert (await resp.render_body()) == b'\x81\xc4\tsomething\xc3'
+
+            # Unicode
+            resp.media = {'something': True}
+            body = await resp.render_body()
+            assert body == b'\x81\xa9something\xc3'
+
+            # Ensure that the result is being cached
+            assert (await resp.render_body()) is body
+
+    client = create_client(TestResource(), handlers={
+        'application/msgpack': media.MessagePackHandler(),
+        'application/x-msgpack': media.MessagePackHandler(),
+    })
+    client.simulate_get('/')
+
+
+def test_unknown_media_type():
+    class TestResource:
+        async def on_get(self, req, resp):
+            resp.content_type = 'nope/json'
+            resp.media = {'something': True}
+
+            try:
+                await resp.render_body()
+            except Exception as ex:
+                # NOTE(kgriffs): pytest.raises triggers a failed test even
+                #   when the correct error is raises, so we check it like
+                #   this instead.
+                assert isinstance(ex, errors.HTTPUnsupportedMediaType)
+                raise
+
+    client = create_client(TestResource())
+    result = client.simulate_get('/')
+    assert result.status_code == 415
+
+
+def test_default_media_type():
+    doc = {'something': True}
+
+    class TestResource:
+        async def on_get(self, req, resp):
+            resp.content_type = ''
+            resp.media = {'something': True}
+
+            body = await resp.render_body()
+            assert json.loads(body.decode('utf-8')) == doc
+            assert resp.content_type == 'application/json'
+
+    client = create_client(TestResource())
+    result = client.simulate_get('/')
+    assert result.json == doc
+
+
+def test_mimeparse_edgecases():
+    doc = {'something': True}
+
+    class TestResource:
+        async def on_get(self, req, resp):
+            resp.content_type = 'application/vnd.something'
+            with pytest.raises(errors.HTTPUnsupportedMediaType):
+                resp.media = {'something': False}
+                await resp.render_body()
+
+            resp.content_type = 'invalid'
+            with pytest.raises(errors.HTTPUnsupportedMediaType):
+                resp.media = {'something': False}
+                await resp.render_body()
+
+            # Clear the content type, shouldn't raise this time
+            resp.content_type = None
+            resp.media = doc
+
+    client = create_client(TestResource())
+    result = client.simulate_get('/')
+    assert result.json == doc

--- a/tests/asgi/test_scheduled_callbacks.py
+++ b/tests/asgi/test_scheduled_callbacks.py
@@ -1,0 +1,50 @@
+from collections import Counter
+import time
+
+from falcon import testing
+from falcon.asgi import App
+
+
+def test_multiple():
+    class SomeResource:
+        def __init__(self):
+            self.counter = Counter()
+
+        async def on_get(self, req, resp):
+            async def background_job_async():
+                self.counter['backround:on_get:async'] += 1
+
+            def background_job_sync():
+                self.counter['backround:on_get:sync'] += 20
+
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_sync)
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_sync)
+
+        async def on_post(self, req, resp):
+            async def background_job_async():
+                self.counter['backround:on_get:async'] += 1000
+
+            def background_job_sync():
+                self.counter['backround:on_get:sync'] += 2000
+
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_async)
+            resp.schedule(background_job_sync)
+            resp.schedule(background_job_sync)
+
+    resource = SomeResource()
+
+    app = App()
+    app.add_route('/', resource)
+
+    client = testing.TestClient(app)
+
+    client.simulate_get()
+    client.simulate_post()
+
+    time.sleep(0.5)
+
+    assert resource.counter['backround:on_get:async'] == 2002
+    assert resource.counter['backround:on_get:sync'] == 4040

--- a/tests/asgi/test_scope.py
+++ b/tests/asgi/test_scope.py
@@ -1,0 +1,175 @@
+import asyncio
+
+import pytest
+
+from falcon import testing
+from falcon.asgi import App
+from falcon.errors import UnsupportedScopeError
+
+
+def test_missing_asgi_version():
+    scope = testing.create_scope()
+    del scope['asgi']
+
+    resource = _call_with_scope(scope)
+
+    # NOTE(kgriffs): According to the ASGI spec, the version should
+    #   default to "2.0".
+    assert resource.captured_req.scope['asgi']['version'] == '2.0'
+
+
+@pytest.mark.parametrize('version, supported', [
+    ('3.0', True),
+    ('3.1', True),
+    ('3.10', True),
+    ('30.0', False),
+    ('31.0', False),
+    ('4.0', False),
+    ('4.1', False),
+    ('4.10', False),
+    ('40.0', False),
+    ('41.0', False),
+    ('2.0', False),
+    ('2.1', False),
+    ('2.10', False),
+    (None, False),
+])
+def test_supported_asgi_version(version, supported):
+    scope = testing.create_scope()
+
+    if version:
+        scope['asgi']['version'] = version
+    else:
+        del scope['asgi']['version']
+
+    if supported:
+        _call_with_scope(scope)
+    else:
+        with pytest.raises(UnsupportedScopeError):
+            _call_with_scope(scope)
+
+
+@pytest.mark.parametrize('scope_type', ['websocket', 'tubes', 'http3', 'htt'])
+def test_unsupported_scope_type(scope_type):
+    scope = testing.create_scope()
+    scope['type'] = scope_type
+    with pytest.raises(UnsupportedScopeError):
+        _call_with_scope(scope)
+
+
+@pytest.mark.parametrize('spec_version, supported', [
+    ('0.0', False),
+    ('1.0', False),
+    ('11.0', False),
+    ('2.0', True),
+    ('2.1', True),
+    ('2.10', True),
+    ('20.0', False),
+    ('22.0', False),
+    ('3.0', False),
+    ('3.1', False),
+    ('30.0', False),
+])
+def test_supported_http_spec(spec_version, supported):
+    scope = testing.create_scope()
+    scope['asgi']['spec_version'] = spec_version
+
+    if supported:
+        _call_with_scope(scope)
+    else:
+        with pytest.raises(UnsupportedScopeError):
+            _call_with_scope(scope)
+
+
+def test_lifespan_scope_default_version():
+    app = App()
+
+    resource = testing.SimpleTestResourceAsync()
+
+    app.add_route('/', resource)
+
+    shutting_down = asyncio.Condition()
+    req_event_emitter = testing.ASGILifespanEventEmitter(shutting_down)
+    resp_event_collector = testing.ASGIResponseEventCollector()
+
+    scope = {'type': 'lifespan'}
+
+    async def conductor():
+        t = asyncio.create_task(app(scope, req_event_emitter, resp_event_collector))
+
+        # NOTE(kgriffs): Yield to the lifespan task above
+        await asyncio.sleep(0.001)
+
+        async with shutting_down:
+            shutting_down.notify()
+
+        await t
+
+    testing.invoke_coroutine_sync(conductor)
+
+    assert not resource.called
+
+
+@pytest.mark.parametrize('spec_version, supported', [
+    ('0.0', False),
+    ('1.0', True),
+    ('1.1', True),
+    ('1.10', True),
+    ('2.0', True),
+    ('2.1', True),
+    ('2.10', True),
+    ('3.0', False),
+    ('4.0', False),
+    ('11.0', False),
+    ('22.0', False),
+])
+def test_lifespan_scope_version(spec_version, supported):
+    app = App()
+
+    shutting_down = asyncio.Condition()
+    req_event_emitter = testing.ASGILifespanEventEmitter(shutting_down)
+    resp_event_collector = testing.ASGIResponseEventCollector()
+
+    scope = {
+        'type': 'lifespan',
+        'asgi': {'spec_version': spec_version, 'version': '3.0'}
+    }
+
+    if not supported:
+        with pytest.raises(UnsupportedScopeError):
+            testing.invoke_coroutine_sync(
+                app.__call__, scope, req_event_emitter, resp_event_collector
+            )
+
+        return
+
+    async def conductor():
+        t = asyncio.create_task(app(scope, req_event_emitter, resp_event_collector))
+
+        # NOTE(kgriffs): Yield to the lifespan task above
+        await asyncio.sleep(0.001)
+
+        async with shutting_down:
+            shutting_down.notify()
+
+        await t
+
+    testing.invoke_coroutine_sync(conductor)
+
+
+def _call_with_scope(scope):
+    app = App()
+
+    resource = testing.SimpleTestResourceAsync()
+
+    app.add_route('/', resource)
+
+    req_event_emitter = testing.ASGIRequestEventEmitter()
+    resp_event_collector = testing.ASGIResponseEventCollector()
+
+    testing.invoke_coroutine_sync(
+        app.__call__, scope, req_event_emitter, resp_event_collector
+    )
+
+    assert resource.called
+    return resource

--- a/tests/asgi/test_sse.py
+++ b/tests/asgi/test_sse.py
@@ -1,0 +1,164 @@
+import pytest
+
+from falcon import testing
+from falcon.asgi import App, SSEvent
+
+
+def test_no_events():
+
+    class Emitter:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise StopAsyncIteration
+
+    class SomeResource:
+        async def on_get(self, req, resp):
+            self._called = True
+            resp.sse = Emitter()
+
+    resource = SomeResource()
+
+    app = App()
+    app.add_route('/', resource)
+
+    client = testing.TestClient(app)
+    client.simulate_get()
+
+    assert resource._called
+
+
+def test_single_event():
+    class SomeResource:
+        async def on_get(self, req, resp):
+            async def emitter():
+                yield
+
+            resp.sse = emitter()
+
+        async def on_post(self, req, resp):
+            async def emitter():
+                yield SSEvent()
+
+            resp.sse = emitter()
+
+    resource = SomeResource()
+
+    app = App()
+    app.add_route('/', resource)
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get()
+    assert result.text == ': ping\n\n'
+
+    result = client.simulate_post()
+    assert result.text == ': ping\n\n'
+
+
+def test_multiple_events():
+    class SomeResource:
+        async def on_get(self, req, resp):
+            async def emitter():
+                yield SSEvent(data=b'ketchup')
+                yield SSEvent(data=b'mustard', event='condiment')
+                yield SSEvent(data=b'mayo', event='condiment', event_id='1234')
+                yield SSEvent(data=b'onions', event='topping', event_id='5678', retry=100)
+                yield SSEvent(text='guacamole \u1F951', retry=100.5, comment='Serve with chips.')
+                yield SSEvent(json={'condiment': 'salsa'}, retry='100')
+
+            resp.sse = emitter()
+
+    resource = SomeResource()
+
+    app = App()
+    app.add_route('/', resource)
+
+    client = testing.TestClient(app)
+
+    result = client.simulate_get()
+    assert result.text == (
+        'data: ketchup\n'
+        '\n'
+        'event: condiment\n'
+        'data: mustard\n'
+        '\n'
+        'event: condiment\n'
+        'id: 1234\n'
+        'data: mayo\n'
+        '\n'
+        'event: topping\n'
+        'id: 5678\n'
+        'retry: 100\n'
+        'data: onions\n'
+        '\n'
+        ': Serve with chips.\n'
+        'retry: 100\n'
+        'data: guacamole \u1F951\n'
+        '\n'
+        'retry: 100\n'
+        'data: {"condiment": "salsa"}\n'
+        '\n'
+    )
+
+
+def test_invalid_event_values():
+    with pytest.raises(TypeError):
+        SSEvent(data='notbytes')
+
+    with pytest.raises(TypeError):
+        SSEvent(data=12345)
+
+    with pytest.raises(TypeError):
+        SSEvent(text=b'notbytes')
+
+    with pytest.raises(TypeError):
+        SSEvent(text=23455)
+
+    with pytest.raises(TypeError):
+        SSEvent(json=set()).serialize()
+
+    with pytest.raises(TypeError):
+        SSEvent(event=b'name')
+
+    with pytest.raises(TypeError):
+        SSEvent(event=1234)
+
+    with pytest.raises(TypeError):
+        SSEvent(event_id=b'idbytes')
+
+    with pytest.raises(TypeError):
+        SSEvent(event_id=52085)
+
+    with pytest.raises(ValueError):
+        SSEvent(retry='5808.25')
+
+    with pytest.raises(TypeError):
+        SSEvent(comment=b'somebytes')
+
+    with pytest.raises(TypeError):
+        SSEvent(comment=1234)
+
+
+def test_non_iterable():
+    class SomeResource:
+        async def on_get(self, req, resp):
+            async def emitter():
+                yield
+
+            resp.sse = emitter
+
+    resource = SomeResource()
+
+    app = App()
+    app.add_route('/', resource)
+
+    client = testing.TestClient(app)
+
+    with pytest.raises(TypeError):
+        client.simulate_get()
+
+
+# TODO: Test with uvicorn
+# TODO: Test in browser with JavaScript

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,24 @@
+import os
+
 import pytest
 
 import falcon
+
+
+@pytest.fixture(params=[True, False])
+def asgi(request):
+    is_asgi = request.param
+
+    if is_asgi and falcon.PY35:
+        pytest.skip('ASGI requires Python 3.6+')
+
+    return is_asgi
+
+
+@pytest.fixture(autouse=True, scope='session')
+def set_env_variables():
+    os.environ['FALCON_TESTING_SESSION'] = 'Y'
+    os.environ['FALCON_ASGI_WRAP_RESPONDERS'] = 'Y'
 
 
 # NOTE(kgriffs): Some modules actually run a wsgiref server, so
@@ -10,3 +28,11 @@ import falcon
 def reset_request_stream_detection():
     falcon.Request._wsgi_input_type_known = False
     falcon.Request._always_wrap_wsgi_input = False
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    if item.cls:
+        item.cls._item = item
+
+    yield

--- a/tests/dump_asgi.py
+++ b/tests/dump_asgi.py
@@ -1,0 +1,25 @@
+import asyncio
+import time
+
+
+async def _say_hi():
+    print(f'[{time.time()}] Hi!')
+
+
+async def app(scope, receive, send):
+    # import pdb; pdb.set_trace()
+
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [
+            [b'content-type', b'application/json'],
+        ]
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': f'[{time.time()}] Hello world!'.encode(),
+    })
+
+    loop = asyncio.get_event_loop()
+    loop.create_task(_say_hi())

--- a/tests/test_after_hooks.py
+++ b/tests/test_after_hooks.py
@@ -5,6 +5,7 @@ import pytest
 
 import falcon
 from falcon import testing
+from ._util import create_app
 
 
 # --------------------------------------------------------------------
@@ -17,9 +18,9 @@ def wrapped_resource_aware():
     return ClassResourceWithAwareHooks()
 
 
-@pytest.fixture
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
 
     resource = WrappedRespondersResource()
     app.add_route('/', resource)

--- a/tests/test_boundedstream.py
+++ b/tests/test_boundedstream.py
@@ -10,8 +10,8 @@ def bounded_stream():
     return BoundedStream(io.BytesIO(), 1024)
 
 
-def test_not_writeable(bounded_stream):
-    assert not bounded_stream.writeable()
+def test_not_writable(bounded_stream):
+    assert not bounded_stream.writable()
 
     with pytest.raises(IOError):
         bounded_stream.write(b'something something')

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -7,6 +7,7 @@ import pytest
 import falcon
 import falcon.testing as testing
 from falcon.util import http_date_to_dt, TimezoneGMT
+from ._util import create_app
 
 
 UNICODE_TEST_STRING = 'Unicode_\xc3\xa6\xc3\xb8'
@@ -58,9 +59,9 @@ class CookieResourceMaxAgeFloatString:
             'foostring', 'bar', max_age='15', secure=False, http_only=False)
 
 
-@pytest.fixture()
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
     app.add_route('/', CookieResource())
     app.add_route('/test-convert', CookieResourceMaxAgeFloatString())
 

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -2,14 +2,14 @@ import textwrap
 
 import pytest
 
-import falcon
 from falcon import testing
 from falcon.routing import DefaultRouter
+from ._util import create_app
 
 
-@pytest.fixture
-def client():
-    return testing.TestClient(falcon.API())
+@pytest.fixture(params=[True, False])
+def client(request):
+    return testing.TestClient(create_app(asgi=request.param))
 
 
 @pytest.fixture
@@ -244,13 +244,14 @@ def test_user_regression_special_chars(uri_template, path, expected_params):
 # =====================================================================
 
 
+@pytest.mark.parametrize('asgi', [True, False])
 @pytest.mark.parametrize('uri_template', [
     {},
     set(),
     object()
 ])
-def test_not_str(uri_template):
-    app = falcon.API()
+def test_not_str(asgi, uri_template):
+    app = create_app(asgi)
     with pytest.raises(TypeError):
         app.add_route(uri_template, ResourceWithId(-1))
 

--- a/tests/test_hello.py
+++ b/tests/test_hello.py
@@ -147,11 +147,14 @@ class TestHelloWorld:
         assert result.content == resource.sample_utf8
 
     def test_no_body_on_head(self, client):
-        client.app.add_route('/body', HelloResource('body'))
+        resource = HelloResource('body')
+        client.app.add_route('/body', resource)
         result = client.simulate_head('/body')
 
         assert not result.content
         assert result.status_code == 200
+        assert resource.called
+        assert result.headers['content-length'] == str(len(HelloResource.sample_utf8))
 
     def test_stream_chunked(self, client):
         resource = HelloResource('stream')

--- a/tests/test_http_custom_method_routing.py
+++ b/tests/test_http_custom_method_routing.py
@@ -1,17 +1,17 @@
 import importlib
 import os
 
+try:
+    import cython
+except ImportError:
+    cython = None
 import pytest
 
 import falcon
 from falcon import testing
 import falcon.constants
 from falcon.routing import util
-
-try:
-    import cython
-except ImportError:
-    cython = None
+from ._util import create_app
 
 FALCON_CUSTOM_HTTP_METHODS = ['FOO', 'BAR']
 
@@ -35,11 +35,11 @@ def cleanup_constants():
         del os.environ['FALCON_CUSTOM_HTTP_METHODS']
 
 
-@pytest.fixture
-def custom_http_client(cleanup_constants, resource_things):
+@pytest.fixture(params=[True, False])
+def custom_http_client(request, cleanup_constants, resource_things):
     falcon.constants.COMBINED_METHODS += FALCON_CUSTOM_HTTP_METHODS
 
-    app = falcon.API()
+    app = create_app(asgi=request.param)
     app.add_route('/things', resource_things)
     return testing.TestClient(app)
 

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -4,6 +4,8 @@ import pytest
 
 import falcon
 import falcon.testing as testing
+from ._util import create_app
+
 
 HTTP_METHODS = (
     'CONNECT',
@@ -48,9 +50,9 @@ def resource_get_with_faulty_put():
     return GetWithFaultyPutResource()
 
 
-@pytest.fixture
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
 
     app.add_route('/stonewall', Stonewall())
 

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -9,11 +9,12 @@ import yaml
 import falcon
 import falcon.testing as testing
 from falcon.util import json
+from ._util import create_app
 
 
-@pytest.fixture
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
 
     resource = FaultyResource()
     app.add_route('/fail', resource)
@@ -696,8 +697,9 @@ class TestHTTPError:
         parsed_body = json.loads(response.content.decode())
         assert parsed_body['code'] == code
 
-    def test_416(self, client):
-        client.app = falcon.API()
+    @pytest.mark.parametrize('asgi', [True, False])
+    def test_416(self, client, asgi):
+        client.app = create_app(asgi)
         client.app.add_route('/416', RangeNotSatisfiableResource())
         response = client.simulate_request(path='/416', headers={'accept': 'text/xml'})
 

--- a/tests/test_httpstatus.py
+++ b/tests/test_httpstatus.py
@@ -1,8 +1,25 @@
 # -*- coding: utf-8
 
+import pytest
+
 import falcon
 from falcon.http_status import HTTPStatus
 import falcon.testing as testing
+from ._util import create_app
+
+
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
+    app.add_route('/status', TestStatusResource())
+    return testing.TestClient(app)
+
+
+@pytest.fixture(params=[True, False])
+def hook_test_client(request):
+    app = create_app(asgi=request.param)
+    app.add_route('/status', TestHookResource())
+    return testing.TestClient(app)
 
 
 def before_hook(req, resp, resource, params):
@@ -74,62 +91,45 @@ class TestHookResource:
 
 
 class TestHTTPStatus:
-    def test_raise_status_in_before_hook(self):
+    def test_raise_status_in_before_hook(self, client):
         """ Make sure we get the 200 raised by before hook """
-        app = falcon.API()
-        app.add_route('/status', TestStatusResource())
-        client = testing.TestClient(app)
-
         response = client.simulate_request(path='/status', method='GET')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_in_responder(self):
+    def test_raise_status_in_responder(self, client):
         """ Make sure we get the 200 raised by responder """
-        app = falcon.API()
-        app.add_route('/status', TestStatusResource())
-        client = testing.TestClient(app)
-
         response = client.simulate_request(path='/status', method='POST')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_runs_after_hooks(self):
+    def test_raise_status_runs_after_hooks(self, client):
         """ Make sure after hooks still run """
-        app = falcon.API()
-        app.add_route('/status', TestStatusResource())
-        client = testing.TestClient(app)
-
         response = client.simulate_request(path='/status', method='PUT')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_survives_after_hooks(self):
+    def test_raise_status_survives_after_hooks(self, client):
         """ Make sure after hook doesn't overwrite our status """
-        app = falcon.API()
-        app.add_route('/status', TestStatusResource())
-        client = testing.TestClient(app)
-
         response = client.simulate_request(path='/status', method='DELETE')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_empty_body(self):
+    def test_raise_status_empty_body(self, client):
         """ Make sure passing None to body results in empty body """
-        app = falcon.API()
-        app.add_route('/status', TestStatusResource())
-        client = testing.TestClient(app)
-
         response = client.simulate_request(path='/status', method='PATCH')
         assert response.text == ''
 
 
 class TestHTTPStatusWithMiddleware:
-    def test_raise_status_in_process_request(self):
+
+    def test_raise_status_in_process_request(self, hook_test_client):
+        client = hook_test_client
+
         """ Make sure we can raise status from middleware process request """
         class TestMiddleware:
             def process_request(self, req, resp):
@@ -137,16 +137,16 @@ class TestHTTPStatusWithMiddleware:
                                  headers={'X-Failed': 'False'},
                                  body='Pass')
 
-        app = falcon.API(middleware=TestMiddleware())
-        app.add_route('/status', TestHookResource())
-        client = testing.TestClient(app)
+        client.app.add_middleware(TestMiddleware())
 
         response = client.simulate_request(path='/status', method='GET')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_in_process_resource(self):
+    def test_raise_status_in_process_resource(self, hook_test_client):
+        client = hook_test_client
+
         """ Make sure we can raise status from middleware process resource """
         class TestMiddleware:
             def process_resource(self, req, resp, resource, params):
@@ -154,16 +154,17 @@ class TestHTTPStatusWithMiddleware:
                                  headers={'X-Failed': 'False'},
                                  body='Pass')
 
-        app = falcon.API(middleware=TestMiddleware())
-        app.add_route('/status', TestHookResource())
-        client = testing.TestClient(app)
+        # NOTE(kgriffs): Pass a list to test that add_middleware can handle it
+        client.app.add_middleware([TestMiddleware()])
 
         response = client.simulate_request(path='/status', method='GET')
         assert response.status == falcon.HTTP_200
         assert response.headers['x-failed'] == 'False'
         assert response.text == 'Pass'
 
-    def test_raise_status_runs_process_response(self):
+    def test_raise_status_runs_process_response(self, hook_test_client):
+        client = hook_test_client
+
         """ Make sure process_response still runs """
         class TestMiddleware:
             def process_response(self, req, resp, resource, req_succeeded):
@@ -171,9 +172,9 @@ class TestHTTPStatusWithMiddleware:
                 resp.set_header('X-Failed', 'False')
                 resp.body = 'Pass'
 
-        app = falcon.API(middleware=TestMiddleware())
-        app.add_route('/status', TestHookResource())
-        client = testing.TestClient(app)
+        # NOTE(kgriffs): Pass a generic iterable to test that add_middleware
+        #   can handle it.
+        client.app.add_middleware(iter([TestMiddleware()]))
 
         response = client.simulate_request(path='/status', method='GET')
         assert response.status == falcon.HTTP_200

--- a/tests/test_python_version_requirements.py
+++ b/tests/test_python_version_requirements.py
@@ -1,0 +1,12 @@
+import pytest
+
+from falcon import PY35
+
+
+def test_asgi():
+    if PY35:
+        with pytest.raises(ImportError):
+            import falcon.asgi
+    else:
+        # Should not raise
+        import falcon.asgi  # NOQA

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -7,6 +7,7 @@ import pytest
 import falcon
 from falcon.errors import HTTPInvalidParam
 import falcon.testing as testing
+from ._util import create_app
 
 
 class Resource(testing.SimpleTestResource):
@@ -42,9 +43,9 @@ def resource():
     return Resource()
 
 
-@pytest.fixture
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
     app.req_options.auto_parse_form_urlencoded = True
     return testing.TestClient(app)
 
@@ -884,9 +885,10 @@ class TestPostQueryParams:
         assert req.get_param('q') is None
 
 
+@pytest.mark.parametrize('asgi', [True, False])
 class TestPostQueryParamsDefaultBehavior:
-    def test_dont_auto_parse_by_default(self):
-        app = falcon.API()
+    def test_dont_auto_parse_by_default(self, asgi):
+        app = create_app(asgi)
         resource = testing.SimpleTestResource()
         app.add_route('/', resource)
 

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -2,11 +2,12 @@ import pytest
 
 import falcon
 import falcon.testing as testing
+from ._util import create_app
 
 
-@pytest.fixture
-def client():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client(request):
+    app = create_app(asgi=request.param)
 
     resource = RedirectingResource()
     app.add_route('/', resource)
@@ -14,9 +15,9 @@ def client():
     return testing.TestClient(app)
 
 
-@pytest.fixture
-def client_exercising_headers():
-    app = falcon.API()
+@pytest.fixture(params=[True, False])
+def client_exercising_headers(request):
+    app = create_app(asgi=request.param)
 
     resource = RedirectingResourceWithHeaders()
     app.add_route('/', resource)

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -9,8 +9,9 @@ from falcon.request_helpers import _parse_etags
 import falcon.testing as testing
 import falcon.uri
 from falcon.util.structures import ETag
+from ._util import create_req
 
-_PROTOCOLS = ['HTTP/1.0', 'HTTP/1.1']
+_HTTP_VERSIONS = ['1.0', '1.1', '2']
 
 
 def _make_etag(value, is_weak=False):
@@ -30,9 +31,29 @@ def _make_etag(value, is_weak=False):
     return etag
 
 
+def test_missing_qs():
+    env = testing.create_environ()
+    if 'QUERY_STRING' in env:
+        del env['QUERY_STRING']
+
+    # Should not cause an exception when Request is instantiated
+    Request(env)
+
+
+def test_app_missing():
+    env = testing.create_environ()
+    del env['SCRIPT_NAME']
+    req = Request(env)
+
+    assert req.app == ''
+
+
+@pytest.mark.parametrize('asgi', [True, False])
 class TestRequestAttributes:
 
     def setup_method(self, method):
+        asgi = self._item.callspec.getparam('asgi')
+
         self.qs = 'marker=deadbeef&limit=10'
 
         self.headers = {
@@ -41,81 +62,81 @@ class TestRequestAttributes:
             'Authorization': ''
         }
 
-        self.app = '/test'
+        self.root_path = '/test'
         self.path = '/hello'
         self.relative_uri = self.path + '?' + self.qs
 
-        self.req = Request(testing.create_environ(
-            app=self.app,
+        self.req = create_req(
+            asgi,
+            root_path=self.root_path,
             port=8080,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
-        self.req_noqs = Request(testing.create_environ(
-            app=self.app,
+        self.req_noqs = create_req(
+            asgi,
+            root_path=self.root_path,
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
 
-    def test_missing_qs(self):
-        env = testing.create_environ()
-        if 'QUERY_STRING' in env:
-            del env['QUERY_STRING']
-
-        # Should not cause an exception when Request is instantiated
-        Request(env)
-
-    def test_empty(self):
+    def test_empty(self, asgi):
         assert self.req.auth is None
 
-    def test_host(self):
+    def test_host(self, asgi):
         assert self.req.host == testing.DEFAULT_HOST
 
-    def test_subdomain(self):
-        req = Request(testing.create_environ(
+    def test_subdomain(self, asgi):
+        req = create_req(
+            asgi,
             host='com',
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert req.subdomain is None
 
-        req = Request(testing.create_environ(
+        req = create_req(
+            asgi,
             host='example.com',
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert req.subdomain == 'example'
 
-        req = Request(testing.create_environ(
+        req = create_req(
+            asgi,
             host='highwire.example.com',
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert req.subdomain == 'highwire'
 
-        req = Request(testing.create_environ(
+        req = create_req(
+            asgi,
             host='lb01.dfw01.example.com',
             port=8080,
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert req.subdomain == 'lb01'
 
         # NOTE(kgriffs): Behavior for IP addresses is undefined,
         # so just make sure it doesn't blow up.
-        req = Request(testing.create_environ(
+        req = create_req(
+            asgi,
             host='127.0.0.1',
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert type(req.subdomain) == str
 
         # NOTE(kgriffs): Test fallback to SERVER_NAME by using
         # HTTP 1.0, which will cause .create_environ to not set
         # HTTP_HOST.
-        req = Request(testing.create_environ(
-            protocol='HTTP/1.0',
+        req = create_req(
+            asgi,
+            http_version='1.0',
             host='example.com',
             path='/hello',
-            headers=self.headers))
+            headers=self.headers)
         assert req.subdomain == 'example'
 
-    def test_reconstruct_url(self):
+    def test_reconstruct_url(self, asgi):
         req = self.req
 
         scheme = req.scheme
@@ -136,7 +157,7 @@ class TestRequestAttributes:
         '/test/%E5%BB%B6%E5%AE%89',
         '/test/%C3%A4%C3%B6%C3%BC%C3%9F%E2%82%AC',
     ])
-    def test_nonlatin_path(self, test_path):
+    def test_nonlatin_path(self, asgi, test_path):
         # NOTE(kgriffs): When a request comes in, web servers decode
         # the path.  The decoded path may contain UTF-8 characters,
         # but according to the WSGI spec, no strings can contain chars
@@ -153,15 +174,16 @@ class TestRequestAttributes:
         #   path = tunnelled_path.encode('iso-8859-1').decode('utf-8', 'replace')
         #
 
-        req = Request(testing.create_environ(
+        req = create_req(
+            asgi,
             host='com',
             path=test_path,
-            headers=self.headers))
+            headers=self.headers)
 
         assert req.path == falcon.uri.decode(test_path)
 
-    def test_uri(self):
-        prefix = 'http://' + testing.DEFAULT_HOST + ':8080' + self.app
+    def test_uri(self, asgi):
+        prefix = 'http://' + testing.DEFAULT_HOST + ':8080' + self.root_path
         uri = prefix + self.relative_uri
 
         assert self.req.url == uri
@@ -171,15 +193,15 @@ class TestRequestAttributes:
         assert self.req.uri == uri
         assert self.req.uri == uri
 
-        uri_noqs = ('http://' + testing.DEFAULT_HOST + self.app + self.path)
+        uri_noqs = ('http://' + testing.DEFAULT_HOST + self.root_path + self.path)
         assert self.req_noqs.uri == uri_noqs
 
-    def test_uri_https(self):
+    def test_uri_https(self, asgi):
         # =======================================================
         # Default port, implicit
         # =======================================================
-        req = Request(testing.create_environ(
-            path='/hello', scheme='https'))
+        req = create_req(
+            asgi, path='/hello', scheme='https')
         uri = ('https://' + testing.DEFAULT_HOST + '/hello')
 
         assert req.uri == uri
@@ -187,8 +209,8 @@ class TestRequestAttributes:
         # =======================================================
         # Default port, explicit
         # =======================================================
-        req = Request(testing.create_environ(
-            path='/hello', scheme='https', port=443))
+        req = create_req(
+            asgi, path='/hello', scheme='https', port=443)
         uri = ('https://' + testing.DEFAULT_HOST + '/hello')
 
         assert req.uri == uri
@@ -196,94 +218,100 @@ class TestRequestAttributes:
         # =======================================================
         # Non-default port
         # =======================================================
-        req = Request(testing.create_environ(
-            path='/hello', scheme='https', port=22))
+        req = create_req(
+            asgi, path='/hello', scheme='https', port=22)
         uri = ('https://' + testing.DEFAULT_HOST + ':22/hello')
 
         assert req.uri == uri
 
-    def test_uri_http_1_0(self):
+    def test_uri_http_1_0(self, asgi):
         # =======================================================
         # HTTP, 80
         # =======================================================
-        req = Request(testing.create_environ(
-            protocol='HTTP/1.0',
-            app=self.app,
+        req = create_req(
+            asgi,
+            http_version='1.0',
+            root_path=self.root_path,
             port=80,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         uri = ('http://' + testing.DEFAULT_HOST +
-               self.app + self.relative_uri)
+               self.root_path + self.relative_uri)
 
         assert req.uri == uri
 
         # =======================================================
         # HTTP, 80
         # =======================================================
-        req = Request(testing.create_environ(
-            protocol='HTTP/1.0',
-            app=self.app,
+        req = create_req(
+            asgi,
+            http_version='1.0',
+            root_path=self.root_path,
             port=8080,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         uri = ('http://' + testing.DEFAULT_HOST + ':8080' +
-               self.app + self.relative_uri)
+               self.root_path + self.relative_uri)
 
         assert req.uri == uri
 
         # =======================================================
         # HTTP, 80
         # =======================================================
-        req = Request(testing.create_environ(
-            protocol='HTTP/1.0',
+        req = create_req(
+            asgi,
+            http_version='1.0',
             scheme='https',
-            app=self.app,
+            root_path=self.root_path,
             port=443,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         uri = ('https://' + testing.DEFAULT_HOST +
-               self.app + self.relative_uri)
+               self.root_path + self.relative_uri)
 
         assert req.uri == uri
 
         # =======================================================
         # HTTP, 80
         # =======================================================
-        req = Request(testing.create_environ(
-            protocol='HTTP/1.0',
+        req = create_req(
+            asgi,
+            http_version='1.0',
             scheme='https',
-            app=self.app,
+            root_path=self.root_path,
             port=22,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         uri = ('https://' + testing.DEFAULT_HOST + ':22' +
-               self.app + self.relative_uri)
+               self.root_path + self.relative_uri)
 
         assert req.uri == uri
 
-    def test_relative_uri(self):
-        assert self.req.relative_uri == self.app + self.relative_uri
-        assert self.req_noqs.relative_uri == self.app + self.path
+    def test_relative_uri(self, asgi):
+        assert self.req.relative_uri == self.root_path + self.relative_uri
+        assert self.req_noqs.relative_uri == self.root_path + self.path
 
-        req_noapp = Request(testing.create_environ(
+        req_noapp = create_req(
+            asgi,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         assert req_noapp.relative_uri == self.relative_uri
 
-        req_noapp = Request(testing.create_environ(
+        req_noapp = create_req(
+            asgi,
             path='/hello/',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         relative_trailing_uri = self.path + '/?' + self.qs
         # NOTE(kgriffs): Call twice to check caching works
@@ -292,117 +320,118 @@ class TestRequestAttributes:
 
         options = RequestOptions()
         options.strip_url_path_trailing_slash = False
-        req_noapp = Request(testing.create_environ(
+        req_noapp = create_req(
+            asgi,
+            options=options,
             path='/hello/',
             query_string=self.qs,
-            headers=self.headers),
-            options=options)
+            headers=self.headers)
 
         assert req_noapp.relative_uri == '/hello/' + '?' + self.qs
 
-    def test_client_accepts(self):
+    def test_client_accepts(self, asgi):
         headers = {'Accept': 'application/xml'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('application/xml')
 
         headers = {'Accept': '*/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('application/xml')
         assert req.client_accepts('application/json')
         assert req.client_accepts('application/x-msgpack')
 
         headers = {'Accept': 'application/x-msgpack'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts('application/xml')
         assert not req.client_accepts('application/json')
         assert req.client_accepts('application/x-msgpack')
 
         headers = {}  # NOTE(kgriffs): Equivalent to '*/*' per RFC
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('application/xml')
 
         headers = {'Accept': 'application/json'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts('application/xml')
 
         headers = {'Accept': 'application/x-msgpack'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('application/x-msgpack')
 
         headers = {'Accept': 'application/xm'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts('application/xml')
 
         headers = {'Accept': 'application/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('application/json')
         assert req.client_accepts('application/xml')
         assert req.client_accepts('application/x-msgpack')
 
         headers = {'Accept': 'text/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('text/plain')
         assert req.client_accepts('text/csv')
         assert not req.client_accepts('application/xhtml+xml')
 
         headers = {'Accept': 'text/*, application/xhtml+xml; q=0.0'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('text/plain')
         assert req.client_accepts('text/csv')
         assert not req.client_accepts('application/xhtml+xml')
 
         headers = {'Accept': 'text/*; q=0.1, application/xhtml+xml; q=0.5'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('text/plain')
         assert req.client_accepts('application/xhtml+xml')
 
         headers = {'Accept': 'text/*,         application/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('text/plain')
         assert req.client_accepts('application/xml')
         assert req.client_accepts('application/json')
         assert req.client_accepts('application/x-msgpack')
 
         headers = {'Accept': 'text/*,application/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts('text/plain')
         assert req.client_accepts('application/xml')
         assert req.client_accepts('application/json')
         assert req.client_accepts('application/x-msgpack')
 
-    def test_client_accepts_bogus(self):
+    def test_client_accepts_bogus(self, asgi):
         headers = {'Accept': '~'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts('text/plain')
         assert not req.client_accepts('application/json')
 
-    def test_client_accepts_props(self):
+    def test_client_accepts_props(self, asgi):
         headers = {'Accept': 'application/xml'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts_xml
         assert not req.client_accepts_json
         assert not req.client_accepts_msgpack
 
         headers = {'Accept': 'application/*'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts_xml
         assert req.client_accepts_json
         assert req.client_accepts_msgpack
 
         headers = {'Accept': 'application/json'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts_xml
         assert req.client_accepts_json
         assert not req.client_accepts_msgpack
 
         headers = {'Accept': 'application/x-msgpack'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts_xml
         assert not req.client_accepts_json
         assert req.client_accepts_msgpack
 
         headers = {'Accept': 'application/msgpack'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert not req.client_accepts_xml
         assert not req.client_accepts_json
         assert req.client_accepts_msgpack
@@ -410,14 +439,14 @@ class TestRequestAttributes:
         headers = {
             'Accept': 'application/json,application/xml,application/x-msgpack'
         }
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.client_accepts_xml
         assert req.client_accepts_json
         assert req.client_accepts_msgpack
 
-    def test_client_prefers(self):
+    def test_client_prefers(self, asgi):
         headers = {'Accept': 'application/xml'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         preferred_type = req.client_prefers(['application/xml'])
         assert preferred_type == 'application/xml'
 
@@ -429,62 +458,62 @@ class TestRequestAttributes:
         assert preferred_type == 'application/xml'
 
         headers = {'Accept': 'text/*; q=0.1, application/xhtml+xml; q=0.5'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         preferred_type = req.client_prefers(['application/xhtml+xml'])
         assert preferred_type == 'application/xhtml+xml'
 
         headers = {'Accept': '3p12845j;;;asfd;'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         preferred_type = req.client_prefers(['application/xhtml+xml'])
         assert preferred_type is None
 
-    def test_range(self):
+    def test_range(self, asgi):
         headers = {'Range': 'bytes=10-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (10, -1)
 
         headers = {'Range': 'bytes=10-20'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (10, 20)
 
         headers = {'Range': 'bytes=-10240'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (-10240, -1)
 
         headers = {'Range': 'bytes=0-2'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (0, 2)
 
         headers = {'Range': ''}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPInvalidHeader):
             req.range
 
-        req = Request(testing.create_environ())
+        req = create_req(asgi)
         assert req.range is None
 
-    def test_range_unit(self):
+    def test_range_unit(self, asgi):
         headers = {'Range': 'bytes=10-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (10, -1)
         assert req.range_unit == 'bytes'
 
         headers = {'Range': 'items=10-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.range == (10, -1)
         assert req.range_unit == 'items'
 
         headers = {'Range': ''}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPInvalidHeader):
             req.range_unit
 
-        req = Request(testing.create_environ())
+        req = create_req(asgi)
         assert req.range_unit is None
 
-    def test_range_invalid(self):
+    def test_range_invalid(self, asgi):
         headers = {'Range': 'bytes=10240'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
@@ -493,60 +522,61 @@ class TestRequestAttributes:
                          'invalid. The range offsets are missing.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
         headers = {'Range': 'bytes=--'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=-3-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=-3-4'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=3-3-4'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=3-3-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=3-3- '}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=fizbit'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=a-'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=a-3'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=-b'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
         headers = {'Range': 'bytes=3-b'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         with pytest.raises(falcon.HTTPBadRequest):
             req.range
 
@@ -556,7 +586,8 @@ class TestRequestAttributes:
                          'according to RFC 7233.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
         headers = {'Range': 'bytes=0-0,-1'}
         expected_desc = ('The value provided for the Range '
@@ -564,7 +595,8 @@ class TestRequestAttributes:
                          'continuous range.')
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
         headers = {'Range': '10-'}
         expected_desc = ('The value provided for the Range '
@@ -572,59 +604,64 @@ class TestRequestAttributes:
                          "prefixed with a range unit, e.g. 'bytes='")
         self._test_error_details(headers, 'range',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
-    def test_missing_attribute_header(self):
-        req = Request(testing.create_environ())
+    def test_missing_attribute_header(self, asgi):
+        req = create_req(asgi)
         assert req.range is None
 
-        req = Request(testing.create_environ())
+        req = create_req(asgi)
         assert req.content_length is None
 
-    def test_content_length(self):
+    def test_content_length(self, asgi):
         headers = {'content-length': '5656'}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.content_length == 5656
 
         headers = {'content-length': ''}
-        req = Request(testing.create_environ(headers=headers))
+        req = create_req(asgi, headers=headers)
         assert req.content_length is None
 
-    def test_bogus_content_length_nan(self):
+    def test_bogus_content_length_nan(self, asgi):
         headers = {'content-length': 'fuzzy-bunnies'}
         expected_desc = ('The value provided for the '
                          'Content-Length header is invalid. The value '
                          'of the header must be a number.')
         self._test_error_details(headers, 'content_length',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
-    def test_bogus_content_length_neg(self):
+    def test_bogus_content_length_neg(self, asgi):
         headers = {'content-length': '-1'}
         expected_desc = ('The value provided for the Content-Length '
                          'header is invalid. The value of the header '
                          'must be a positive number.')
         self._test_error_details(headers, 'content_length',
                                  falcon.HTTPInvalidHeader,
-                                 'Invalid header value', expected_desc)
+                                 'Invalid header value', expected_desc,
+                                 asgi)
 
     @pytest.mark.parametrize('header,attr', [
         ('Date', 'date'),
         ('If-Modified-Since', 'if_modified_since'),
         ('If-Unmodified-Since', 'if_unmodified_since'),
     ])
-    def test_date(self, header, attr):
+    def test_date(self, asgi, header, attr):
         date = datetime.datetime(2013, 4, 4, 5, 19, 18)
         date_str = 'Thu, 04 Apr 2013 05:19:18 GMT'
 
-        self._test_header_expected_value(header, date_str, attr, date)
+        headers = {header: date_str}
+        req = create_req(asgi, headers=headers)
+        assert getattr(req, attr) == date
 
     @pytest.mark.parametrize('header,attr', [
         ('Date', 'date'),
         ('If-Modified-Since', 'if_modified_since'),
         ('If-Unmodified-Since', 'if_unmodified_since'),
     ])
-    def test_date_invalid(self, header, attr):
+    def test_date_invalid(self, asgi, header, attr):
 
         # Date formats don't conform to RFC 1123
         headers = {header: 'Thu, 04 Apr 2013'}
@@ -635,91 +672,90 @@ class TestRequestAttributes:
         self._test_error_details(headers, attr,
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value',
-                                 expected_desc.format(header))
+                                 expected_desc.format(header),
+                                 asgi)
 
         headers = {header: ''}
         self._test_error_details(headers, attr,
                                  falcon.HTTPInvalidHeader,
                                  'Invalid header value',
-                                 expected_desc.format(header))
+                                 expected_desc.format(header),
+                                 asgi)
 
     @pytest.mark.parametrize('attr', ('date', 'if_modified_since', 'if_unmodified_since'))
-    def test_date_missing(self, attr):
-        req = Request(testing.create_environ())
+    def test_date_missing(self, asgi, attr):
+        req = create_req(asgi)
         assert getattr(req, attr) is None
 
-    def test_attribute_headers(self):
-        date = 'Wed, 21 Oct 2015 07:28:00 GMT'
-        auth = 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af'
-        agent = 'testing/1.0.1'
-        default_agent = 'curl/7.24.0 (x86_64-apple-darwin12.0)'
-        referer = 'https://www.google.com/'
+    @pytest.mark.parametrize('name,value,attr,default', [
+        ('Accept', 'x-falcon', 'accept', '*/*'),
+        ('Authorization', 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af', 'auth', None),
+        ('Content-Type', 'text/plain', 'content_type', None),
+        ('Expect', '100-continue', 'expect', None),
+        ('If-Range', 'Wed, 21 Oct 2015 07:28:00 GMT', 'if_range', None),
+        ('User-Agent', 'testing/3.0', 'user_agent', None),
+        ('Referer', 'https://www.google.com/', 'referer', None),
+    ])
+    def test_attribute_headers(self, asgi, name, value, attr, default):
+        headers = {name: value}
+        req = create_req(asgi, headers=headers)
+        assert getattr(req, attr) == value
 
-        self._test_attribute_header('Accept', 'x-falcon', 'accept',
-                                    default='*/*')
+        req = create_req(asgi)
+        assert getattr(req, attr) == default
 
-        self._test_attribute_header('Authorization', auth, 'auth')
-
-        self._test_attribute_header('Content-Type', 'text/plain',
-                                    'content_type')
-        self._test_attribute_header('Expect', '100-continue', 'expect')
-
-        self._test_attribute_header('If-Range', date, 'if_range')
-
-        self._test_attribute_header('User-Agent', agent, 'user_agent',
-                                    default=default_agent)
-        self._test_attribute_header('Referer', referer, 'referer')
-
-    def test_method(self):
+    def test_method(self, asgi):
         assert self.req.method == 'GET'
 
-        self.req = Request(testing.create_environ(path='', method='HEAD'))
+        self.req = create_req(asgi, path='', method='HEAD')
         assert self.req.method == 'HEAD'
 
-    def test_empty_path(self):
-        self.req = Request(testing.create_environ(path=''))
+    def test_empty_path(self, asgi):
+        self.req = create_req(asgi, path='')
         assert self.req.path == '/'
 
-    def test_content_type_method(self):
+    def test_content_type_method(self, asgi):
         assert self.req.get_header('content-type') == 'text/plain'
 
-    def test_content_length_method(self):
+    def test_content_length_method(self, asgi):
         assert self.req.get_header('content-length') == '4829'
 
     # TODO(kgriffs): Migrate to pytest and parametrized fixtures
     # to DRY things up a bit.
-    @pytest.mark.parametrize('protocol', _PROTOCOLS)
-    def test_port_explicit(self, protocol):
+    @pytest.mark.parametrize('http_version', _HTTP_VERSIONS)
+    def test_port_explicit(self, asgi, http_version):
         port = 9000
-        req = Request(testing.create_environ(
-            protocol=protocol,
+        req = create_req(
+            asgi,
+            http_version=http_version,
             port=port,
-            app=self.app,
+            root_path=self.root_path,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         assert req.port == port
 
-    @pytest.mark.parametrize('protocol', _PROTOCOLS)
-    def test_scheme_https(self, protocol):
+    @pytest.mark.parametrize('http_version', _HTTP_VERSIONS)
+    def test_scheme_https(self, asgi, http_version):
         scheme = 'https'
-        req = Request(testing.create_environ(
-            protocol=protocol,
+        req = create_req(
+            asgi,
+            http_version=http_version,
             scheme=scheme,
-            app=self.app,
+            root_path=self.root_path,
             path='/hello',
             query_string=self.qs,
-            headers=self.headers))
+            headers=self.headers)
 
         assert req.scheme == scheme
         assert req.port == 443
 
     @pytest.mark.parametrize(
-        'protocol, set_forwarded_proto',
-        list(itertools.product(_PROTOCOLS, [True, False]))
+        'http_version, set_forwarded_proto',
+        list(itertools.product(_HTTP_VERSIONS, [True, False]))
     )
-    def test_scheme_http(self, protocol, set_forwarded_proto):
+    def test_scheme_http(self, asgi, http_version, set_forwarded_proto):
         scheme = 'http'
         forwarded_scheme = 'HttPs'
 
@@ -728,13 +764,14 @@ class TestRequestAttributes:
         if set_forwarded_proto:
             headers['X-Forwarded-Proto'] = forwarded_scheme
 
-        req = Request(testing.create_environ(
-            protocol=protocol,
+        req = create_req(
+            asgi,
+            http_version=http_version,
             scheme=scheme,
-            app=self.app,
+            root_path=self.root_path,
             path='/hello',
             query_string=self.qs,
-            headers=headers))
+            headers=headers)
 
         assert req.scheme == scheme
         assert req.port == 80
@@ -744,63 +781,58 @@ class TestRequestAttributes:
         else:
             assert req.forwarded_scheme == scheme
 
-    @pytest.mark.parametrize('protocol', _PROTOCOLS)
-    def test_netloc_default_port(self, protocol):
-        req = Request(testing.create_environ(
-            protocol=protocol,
-            app=self.app,
-            path='/hello',
-            query_string=self.qs,
-            headers=self.headers))
-
-        assert req.netloc == 'falconframework.org'
-
-    @pytest.mark.parametrize('protocol', _PROTOCOLS)
-    def test_netloc_nondefault_port(self, protocol):
-        req = Request(testing.create_environ(
-            protocol=protocol,
-            port='8080',
-            app=self.app,
-            path='/hello',
-            query_string=self.qs,
-            headers=self.headers))
-
-        assert req.netloc == 'falconframework.org:8080'
-
-    @pytest.mark.parametrize('protocol', _PROTOCOLS)
-    def test_netloc_from_env(self, protocol):
-        port = 9000
-        host = 'example.org'
-        env = testing.create_environ(
-            protocol=protocol,
-            host=host,
-            port=port,
-            app=self.app,
+    @pytest.mark.parametrize('http_version', _HTTP_VERSIONS)
+    def test_netloc_default_port(self, asgi, http_version):
+        req = create_req(
+            asgi,
+            http_version=http_version,
+            root_path=self.root_path,
             path='/hello',
             query_string=self.qs,
             headers=self.headers)
 
-        req = Request(env)
+        assert req.netloc == 'falconframework.org'
+
+    @pytest.mark.parametrize('http_version', _HTTP_VERSIONS)
+    def test_netloc_nondefault_port(self, asgi, http_version):
+        req = create_req(
+            asgi,
+            http_version=http_version,
+            port='8080',
+            root_path=self.root_path,
+            path='/hello',
+            query_string=self.qs,
+            headers=self.headers)
+
+        assert req.netloc == 'falconframework.org:8080'
+
+    @pytest.mark.parametrize('http_version', _HTTP_VERSIONS)
+    def test_netloc_from_env(self, asgi, http_version):
+        port = 9000
+        host = 'example.org'
+
+        req = create_req(
+            asgi,
+            http_version=http_version,
+            host=host,
+            port=port,
+            root_path=self.root_path,
+            path='/hello',
+            query_string=self.qs,
+            headers=self.headers)
 
         assert req.port == port
         assert req.netloc == '{}:{}'.format(host, port)
 
-    def test_app_present(self):
-        req = Request(testing.create_environ(app='/moving-pictures'))
+    def test_app_present(self, asgi):
+        req = create_req(asgi, root_path='/moving-pictures')
         assert req.app == '/moving-pictures'
 
-    def test_app_blank(self):
-        req = Request(testing.create_environ(app=''))
+    def test_app_blank(self, asgi):
+        req = create_req(asgi, root_path='')
         assert req.app == ''
 
-    def test_app_missing(self):
-        env = testing.create_environ()
-        del env['SCRIPT_NAME']
-        req = Request(env)
-
-        assert req.app == ''
-
-    @pytest.mark.parametrize('etag,expected', [
+    @pytest.mark.parametrize('etag,expected_value', [
         ('', None),
         (' ', None),
         ('   ', None),
@@ -898,45 +930,13 @@ class TestRequestAttributes:
             ]
         ),
     ])
-    def test_etag(self, etag, expected):
-        self._test_header_etag('If-Match', etag, 'if_match', expected)
-        self._test_header_etag('If-None-Match', etag, 'if_none_match', expected)
-
-    def test_etag_is_missing(self):
-        # NOTE(kgriffs): Loop in order to test caching
-        for __ in range(3):
-            assert self.req.if_match is None
-            assert self.req.if_none_match is None
-
-    @pytest.mark.parametrize('header_value', ['', ' ', '  '])
-    def test_etag_parsing_helper(self, header_value):
-        # NOTE(kgriffs): Test a couple of cases that are not directly covered
-        #   elsewhere (but that we want the helper to still support
-        #   for the sake of avoiding suprises if they are ever called without
-        #   preflighting the header value).
-
-        assert _parse_etags(header_value) is None
-
-    # -------------------------------------------------------------------------
-    # Helpers
-    # -------------------------------------------------------------------------
-
-    def _test_attribute_header(self, name, value, attr, default=None):
-        headers = {name: value}
-        req = Request(testing.create_environ(headers=headers))
-        assert getattr(req, attr) == value
-
-        req = Request(testing.create_environ())
-        assert getattr(req, attr) == default
-
-    def _test_header_expected_value(self, name, value, attr, expected_value):
-        headers = {name: value}
-        req = Request(testing.create_environ(headers=headers))
-        assert getattr(req, attr) == expected_value
-
-    def _test_header_etag(self, name, value, attr, expected_value):
-        headers = {name: value}
-        req = Request(testing.create_environ(headers=headers))
+    @pytest.mark.parametrize('name,attr', [
+        ('If-Match', 'if_match'),
+        ('If-None-Match', 'if_none_match'),
+    ])
+    def test_etag(self, asgi, name, attr, etag, expected_value):
+        headers = {name: etag}
+        req = create_req(asgi, headers=headers)
 
         # NOTE(kgriffs): Loop in order to test caching
         for __ in range(3):
@@ -953,9 +953,28 @@ class TestRequestAttributes:
                 if isinstance(expected_element, ETag):
                     assert element.is_weak == expected_element.is_weak
 
+    def test_etag_is_missing(self, asgi):
+        # NOTE(kgriffs): Loop in order to test caching
+        for __ in range(3):
+            assert self.req.if_match is None
+            assert self.req.if_none_match is None
+
+    @pytest.mark.parametrize('header_value', ['', ' ', '  '])
+    def test_etag_parsing_helper(self, asgi, header_value):
+        # NOTE(kgriffs): Test a couple of cases that are not directly covered
+        #   elsewhere (but that we want the helper to still support
+        #   for the sake of avoiding suprises if they are ever called without
+        #   preflighting the header value).
+
+        assert _parse_etags(header_value) is None
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
     def _test_error_details(self, headers, attr_name,
-                            error_type, title, description):
-        req = Request(testing.create_environ(headers=headers))
+                            error_type, title, description, asgi):
+        req = create_req(asgi, headers=headers)
 
         try:
             getattr(req, attr_name)

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -30,8 +30,8 @@ class TestRequestBody:
             stream = stream.stream
         if isinstance(stream, InputWrapper):
             stream = stream.input
-        if isinstance(stream, io.BytesIO):
-            return stream
+
+        return stream
 
     def test_empty_body(self, client, resource):
         client.app.add_route('/', resource)

--- a/tests/test_request_context.py
+++ b/tests/test_request_context.py
@@ -6,9 +6,8 @@ import falcon.testing as testing
 
 class TestRequestContext:
 
-    def test_default_request_context(self):
-        env = testing.create_environ()
-        req = Request(env)
+    def test_default_request_context(self,):
+        req = testing.create_req()
 
         req.context.hello = 'World'
         assert req.context.hello == 'World'

--- a/tests/test_request_media.py
+++ b/tests/test_request_media.py
@@ -1,22 +1,66 @@
 import pytest
 
-import falcon
 from falcon import errors, media, testing
+from ._util import create_app
 
 
-def create_client(handlers=None):
-    res = testing.SimpleTestResource()
+def create_client(asgi, handlers=None, resource=None):
+    if not resource:
+        resource = testing.SimpleTestResourceAsync() if asgi else testing.SimpleTestResource()
 
-    app = falcon.API()
-    app.add_route('/', res)
+    app = create_app(asgi)
+    app.add_route('/', resource)
 
     if handlers:
         app.req_options.media_handlers.update(handlers)
 
-    client = testing.TestClient(app)
-    client.resource = res
+    client = testing.TestClient(app, headers={'capture-req-media': 'yes'})
+    client.resource = resource
 
     return client
+
+
+@pytest.fixture(params=[True, False])
+def client(request):
+    return create_client(request.param)
+
+
+class ResourceCachedMedia:
+    def on_post(self, req, resp, **kwargs):
+        self.captured_req_media = req.media
+
+        # NOTE(kgriffs): Ensure that the media object is cached
+        assert self.captured_req_media is req.media
+
+
+class ResourceCachedMediaAsync:
+    async def on_post(self, req, resp, **kwargs):
+        self.captured_req_media = await req.media
+
+        # NOTE(kgriffs): Ensure that the media object is cached
+        assert self.captured_req_media is await req.media
+
+
+class ResourceInvalidMedia:
+    def __init__(self, expected_error):
+        self._expected_error = expected_error
+
+    def on_post(self, req, resp, **kwargs):
+        with pytest.raises(self._expected_error) as error:
+            req.media
+
+        self.captured_error = error
+
+
+class ResourceInvalidMediaAsync:
+    def __init__(self, expected_error):
+        self._expected_error = expected_error
+
+    async def on_post(self, req, resp, **kwargs):
+        with pytest.raises(self._expected_error) as error:
+            await req.media
+
+        self.captured_error = error
 
 
 @pytest.mark.parametrize('media_type', [
@@ -25,13 +69,12 @@ def create_client(handlers=None):
     ('application/json'),
     ('application/json; charset=utf-8'),
 ])
-def test_json(media_type):
-    client = create_client()
+def test_json(client, media_type):
     expected_body = b'{"something": true}'
     headers = {'Content-Type': media_type}
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    media = client.resource.captured_req.media
+    media = client.resource.captured_req_media
     assert media is not None
     assert media.get('something') is True
 
@@ -41,8 +84,8 @@ def test_json(media_type):
     ('application/msgpack; charset=utf-8'),
     ('application/x-msgpack'),
 ])
-def test_msgpack(media_type):
-    client = create_client({
+def test_msgpack(asgi, media_type):
+    client = create_client(asgi, {
         'application/msgpack': media.MessagePackHandler(),
         'application/x-msgpack': media.MessagePackHandler(),
     })
@@ -52,91 +95,77 @@ def test_msgpack(media_type):
     expected_body = b'\x81\xc4\tsomething\xc3'
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    req_media = client.resource.captured_req.media
+    req_media = client.resource.captured_req_media
     assert req_media.get(b'something') is True
 
     # Unicode
     expected_body = b'\x81\xa9something\xc3'
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    req_media = client.resource.captured_req.media
+    req_media = client.resource.captured_req_media
     assert req_media.get('something') is True
 
 
 @pytest.mark.parametrize('media_type', [
     ('nope/json'),
 ])
-def test_unknown_media_type(media_type):
-    client = create_client()
+def test_unknown_media_type(asgi, media_type):
+    client = _create_client_invalid_media(asgi, errors.HTTPUnsupportedMediaType)
+
     headers = {'Content-Type': media_type}
     client.simulate_post('/', body=b'something', headers=headers)
 
-    with pytest.raises(errors.HTTPUnsupportedMediaType) as err:
-        client.resource.captured_req.media
-
     title_msg = '415 Unsupported Media Type'
     description_msg = '{} is an unsupported media type.'.format(media_type)
-    assert err.value.title == title_msg
-    assert err.value.description == description_msg
+    assert client.resource.captured_error.value.title == title_msg
+    assert client.resource.captured_error.value.description == description_msg
 
 
 @pytest.mark.parametrize('media_type', [
     ('application/json'),
 ])
-def test_exhausted_stream(media_type):
-    client = create_client({
+def test_exhausted_stream(asgi, media_type):
+    client = create_client(asgi, {
         'application/json': media.JSONHandler(),
     })
     headers = {'Content-Type': media_type}
     client.simulate_post('/', body='', headers=headers)
 
-    assert client.resource.captured_req.media is None
+    assert client.resource.captured_req_media is None
 
 
-def test_invalid_json():
-    client = create_client()
+def test_invalid_json(asgi):
+    client = _create_client_invalid_media(asgi, errors.HTTPBadRequest)
+
     expected_body = b'{'
     headers = {'Content-Type': 'application/json'}
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    with pytest.raises(errors.HTTPBadRequest) as err:
-        client.resource.captured_req.media
-
-    assert 'Could not parse JSON body' in err.value.description
+    assert 'Could not parse JSON body' in client.resource.captured_error.value.description
 
 
-def test_invalid_msgpack():
-    client = create_client({'application/msgpack': media.MessagePackHandler()})
+def test_invalid_msgpack(asgi):
+    handlers = {
+        'application/msgpack': media.MessagePackHandler()
+    }
+    client = _create_client_invalid_media(asgi, errors.HTTPBadRequest, handlers=handlers)
+
     expected_body = '/////////////////////'
     headers = {'Content-Type': 'application/msgpack'}
     client.simulate_post('/', body=expected_body, headers=headers)
 
-    with pytest.raises(errors.HTTPBadRequest) as err:
-        client.resource.captured_req.media
-
     desc = 'Could not parse MessagePack body - unpack(b) received extra data.'
-    assert err.value.description == desc
+    assert client.resource.captured_error.value.description == desc
 
 
-def test_invalid_stream_fails_gracefully():
-    client = create_client()
+def test_invalid_stream_fails_gracefully(client):
     client.simulate_post('/')
 
     req = client.resource.captured_req
     req.headers['Content-Type'] = 'application/json'
     req._bounded_stream = None
 
-    assert req.media is None
-
-
-def test_use_cached_media():
-    client = create_client()
-    client.simulate_post('/')
-
-    req = client.resource.captured_req
-    req._media = {'something': True}
-
-    assert req.media == {'something': True}
+    assert client.resource.captured_req_media is None
 
 
 class NopeHandler(media.BaseHandler):
@@ -148,8 +177,8 @@ class NopeHandler(media.BaseHandler):
         pass
 
 
-def test_complete_consumption():
-    client = create_client({
+def test_complete_consumption(asgi):
+    client = create_client(asgi, {
         'nope/nope': NopeHandler()
     })
     body = b'{"something": "abracadabra"}'
@@ -157,27 +186,27 @@ def test_complete_consumption():
 
     client.simulate_post('/', body=body, headers=headers)
 
-    req_media = client.resource.captured_req.media
+    req_media = client.resource.captured_req_media
     assert req_media is None
     req_bounded_stream = client.resource.captured_req.bounded_stream
-    assert not req_bounded_stream.read()
+    assert req_bounded_stream.eof
 
 
 @pytest.mark.parametrize('payload', [False, 0, 0.0, '', [], {}])
-def test_empty_json_media(payload):
-    client = create_client()
+def test_empty_json_media(asgi, payload):
+    resource = ResourceCachedMediaAsync() if asgi else ResourceCachedMedia()
+    client = create_client(asgi, resource=resource)
     client.simulate_post('/', json=payload)
-
-    req = client.resource.captured_req
-    for access in range(3):
-        assert req.media == payload
+    assert resource.captured_req_media == payload
 
 
-def test_null_json_media():
-    client = create_client()
+def test_null_json_media(client):
     client.simulate_post('/', body='null',
                          headers={'Content-Type': 'application/json'})
+    assert client.resource.captured_req_media is None
 
-    req = client.resource.captured_req
-    for access in range(3):
-        assert req.media is None
+
+def _create_client_invalid_media(asgi, error_type, handlers=None):
+    resource_type = ResourceInvalidMediaAsync if asgi else ResourceInvalidMedia
+    resource = resource_type(error_type)
+    return create_client(asgi, handlers=handlers, resource=resource)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,25 +1,27 @@
 import pytest
 
-import falcon
 from falcon import MEDIA_TEXT
+from ._util import create_resp
 
 
-def test_response_set_content_type_set():
-    resp = falcon.Response()
+@pytest.fixture(params=[True, False])
+def resp(request):
+    return create_resp(asgi=request.param)
+
+
+def test_response_set_content_type_set(resp):
     resp._set_media_type(MEDIA_TEXT)
     assert resp._headers['content-type'] == MEDIA_TEXT
 
 
-def test_response_set_content_type_not_set():
-    resp = falcon.Response()
+def test_response_set_content_type_not_set(resp):
     assert 'content-type' not in resp._headers
 
     resp._set_media_type()
     assert 'content-type' not in resp._headers
 
 
-def test_response_get_headers():
-    resp = falcon.Response()
+def test_response_get_headers(resp):
     resp.append_header('x-things1', 'thing-1')
     resp.append_header('x-things2', 'thing-2')
     resp.append_header('X-Things3', 'Thing-3')
@@ -34,9 +36,7 @@ def test_response_get_headers():
     assert 'set-cookie' not in headers
 
 
-def test_response_attempt_to_set_read_only_headers():
-    resp = falcon.Response()
-
+def test_response_attempt_to_set_read_only_headers(resp):
     resp.append_header('x-things1', 'thing-1')
     resp.append_header('x-things2', 'thing-2')
     resp.append_header('x-things3', 'thing-3a')
@@ -51,9 +51,7 @@ def test_response_attempt_to_set_read_only_headers():
     assert headers['x-things3'] == 'thing-3a, thing-3b'
 
 
-def test_response_removed_stream_len():
-    resp = falcon.Response()
-
+def test_response_removed_stream_len(resp):
     with pytest.raises(AttributeError):
         resp.stream_len = 128
 

--- a/tests/test_response_body.py
+++ b/tests/test_response_body.py
@@ -1,12 +1,17 @@
+import pytest
 
-import falcon
+from ._util import create_resp
+
+
+@pytest.fixture(params=[True, False])
+def resp(request):
+    return create_resp(asgi=request.param)
 
 
 class TestResponseBody:
 
-    def test_append_body(self):
+    def test_append_body(self, resp):
         text = 'Hello beautiful world! '
-        resp = falcon.Response()
         resp.body = ''
 
         for token in text.split():
@@ -15,7 +20,6 @@ class TestResponseBody:
 
         assert resp.body == text
 
-    def test_response_repr(self):
-        resp = falcon.Response()
+    def test_response_repr(self, resp):
         _repr = '<%s: %s>' % (resp.__class__.__name__, resp.status)
         assert resp.__repr__() == _repr

--- a/tests/test_response_media.py
+++ b/tests/test_response_media.py
@@ -6,6 +6,11 @@ import falcon
 from falcon import errors, media, testing
 
 
+@pytest.fixture(params=[True, False])
+def client(request):
+    return create_client()
+
+
 def create_client(handlers=None):
     res = testing.SimpleTestResource()
 
@@ -38,8 +43,7 @@ class SimpleMediaResource:
     (falcon.MEDIA_JSON),
     ('application/json; charset=utf-8'),
 ])
-def test_json(media_type):
-    client = create_client()
+def test_json(client, media_type):
     client.simulate_get('/')
 
     resp = client.resource.captured_resp
@@ -99,8 +103,7 @@ def test_msgpack(media_type):
     assert resp.data == b'\x81\xa9something\xc3'
 
 
-def test_unknown_media_type():
-    client = create_client()
+def test_unknown_media_type(client):
     client.simulate_get('/')
 
     resp = client.resource.captured_resp
@@ -112,20 +115,17 @@ def test_unknown_media_type():
     assert err.value.description == 'nope/json is an unsupported media type.'
 
 
-def test_use_cached_media():
-    expected = {'something': True}
-
-    client = create_client()
+def test_use_cached_media(client):
     client.simulate_get('/')
 
     resp = client.resource.captured_resp
-    resp._media = expected
 
+    expected = {'something': True}
+    resp._media = expected
     assert resp.media == expected
 
 
-def test_default_media_type():
-    client = create_client()
+def test_default_media_type(client):
     client.simulate_get('/')
 
     resp = client.resource.captured_resp
@@ -136,8 +136,7 @@ def test_default_media_type():
     assert resp.content_type == 'application/json'
 
 
-def test_mimeparse_edgecases():
-    client = create_client()
+def test_mimeparse_edgecases(client):
     client.simulate_get('/')
 
     resp = client.resource.captured_resp

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -4,6 +4,7 @@ import pytest
 
 import falcon
 import falcon.testing as testing
+from ._util import create_app
 
 
 class Proxy:
@@ -12,7 +13,6 @@ class Proxy:
 
 
 class Sink:
-
     def __init__(self):
         self._proxy = Proxy()
 
@@ -21,8 +21,9 @@ class Sink:
         self.kwargs = kwargs
 
 
-def sink_too(req, resp):
-    resp.status = falcon.HTTP_781
+class SinkAsync(Sink):
+    async def __call__(self, req, resp, **kwargs):
+        super().__call__(req, resp, **kwargs)
 
 
 class BookCollection(testing.SimpleTestResource):
@@ -35,13 +36,13 @@ def resource():
 
 
 @pytest.fixture
-def sink():
-    return Sink()
+def sink(asgi):
+    return SinkAsync() if asgi else Sink()
 
 
 @pytest.fixture
-def client():
-    app = falcon.API()
+def client(asgi):
+    app = create_app(asgi)
     return testing.TestClient(app)
 
 
@@ -78,7 +79,14 @@ class TestDefaultRouting:
         response = client.simulate_request(path='/user/sally')
         assert response.status == falcon.HTTP_404
 
-    def test_multiple_patterns(self, client, sink, resource):
+    def test_multiple_patterns(self, asgi, client, sink, resource):
+        if asgi:
+            async def sink_too(req, resp):
+                resp.status = falcon.HTTP_781
+        else:
+            def sink_too(req, resp):
+                resp.status = falcon.HTTP_781
+
         client.app.add_sink(sink, r'/foo')
         client.app.add_sink(sink_too, r'/foo')  # Last duplicate wins
 

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,22 +1,25 @@
 import pytest
 
-from falcon import Request, Response
 import falcon.testing as testing
 
 
 class TestSlots:
 
-    def test_slots_request(self):
-        env = testing.create_environ()
-        req = Request(env)
+    def test_slots_request(self, asgi):
+        req = testing.create_asgi_req() if asgi else testing.create_req()
 
         try:
             req.doesnt = 'exist'
         except AttributeError:
             pytest.fail('Unable to add additional variables dynamically')
 
-    def test_slots_response(self):
-        resp = Response()
+    def test_slots_response(self, asgi):
+        if asgi:
+            import falcon.asgi
+            resp = falcon.asgi.Response()
+        else:
+            import falcon
+            resp = falcon.Response()
 
         try:
             resp.doesnt = 'exist'

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,7 +1,7 @@
 import pytest
 
 from falcon import status_codes
-from falcon.testing import closed_wsgi_iterable, TestClient
+from falcon import testing
 
 
 def another_dummy_wsgi_app(environ, start_response):
@@ -11,7 +11,7 @@ def another_dummy_wsgi_app(environ, start_response):
 
 
 def test_testing_client_handles_wsgi_generator_app():
-    client = TestClient(another_dummy_wsgi_app)
+    client = testing.TestClient(another_dummy_wsgi_app)
 
     response = client.simulate_get('/nevermind')
 
@@ -26,4 +26,4 @@ def test_testing_client_handles_wsgi_generator_app():
     (b'Hello, ', b'World', b'!\n'),
 ])
 def test_closed_wsgi_iterable(items):
-    assert tuple(closed_wsgi_iterable(items)) == items
+    assert tuple(testing.closed_wsgi_iterable(items)) == items

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -13,6 +13,7 @@ import pytest
 import falcon
 from falcon import testing
 from falcon.routing.util import SuffixedMethodNotFoundError
+from ._util import create_app
 
 
 _TEST_UUID = uuid.uuid4()
@@ -119,9 +120,9 @@ def resource():
     return testing.SimpleTestResource()
 
 
-@pytest.fixture
-def client():
-    return testing.TestClient(falcon.API())
+@pytest.fixture(params=[True, False])
+def client(request):
+    return testing.TestClient(create_app(asgi=request.param))
 
 
 def test_root_path(client, resource):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime
 import functools
+import http
+import os
 import random
 from urllib.parse import quote, unquote_plus
 
@@ -11,6 +13,12 @@ import falcon
 from falcon import testing
 from falcon import util
 from falcon.util import json, misc, structures, uri
+from ._util import create_app, to_coroutine
+
+
+@pytest.fixture(params=[True, False])
+def app(request):
+    return create_app(asgi=request.param)
 
 
 def _arbitrary_uris(count, length):
@@ -36,8 +44,10 @@ class TestFalconUtils:
         def old_thing():
             pass
 
+        del os.environ['FALCON_TESTING_SESSION']
         with pytest.warns(UserWarning) as rec:
             old_thing()
+        os.environ['FALCON_TESTING_SESSION'] = '1'
 
         warn = rec.pop()
         assert msg in str(warn.message)
@@ -332,6 +342,48 @@ class TestFalconUtils:
             falcon.get_http_status('-404.3')
         assert falcon.get_http_status(123, 'Go Away') == '123 Go Away'
 
+    @pytest.mark.parametrize(
+        'v_in,v_out',
+        [
+            (703, falcon.HTTP_703),
+            (404, falcon.HTTP_404),
+            (404.9, falcon.HTTP_404),
+            ('404', falcon.HTTP_404),
+            (123, '123'),
+        ]
+    )
+    def test_code_to_http_status(self, v_in, v_out):
+        assert falcon.code_to_http_status(v_in) == v_out
+
+    @pytest.mark.parametrize(
+        'v',
+        ['not_a_number', 0, '0', 99, '99', '404.3', -404.3, '-404', '-404.3']
+    )
+    def test_code_to_http_status_neg(self, v):
+        with pytest.raises(ValueError):
+            falcon.code_to_http_status(v)
+
+    @pytest.mark.parametrize(
+        'v_in,v_out',
+        [
+            (http.HTTPStatus(404), 404),
+            ('404', 404),
+            (b'404 Not Found', 404),
+            ('404 Not Found', 404),
+            ('123 Wow Such Status', 123),
+        ]
+    )
+    def test_http_status_to_code(self, v_in, v_out):
+        assert falcon.http_status_to_code(v_in) == v_out
+
+    @pytest.mark.parametrize(
+        'v',
+        ['', ' ', '1', '12', '99', 'catsup', b'']
+    )
+    def test_http_status_to_code_neg(self, v):
+        with pytest.raises(ValueError):
+            falcon.http_status_to_code(v)
+
     def test_etag_dumps_to_header_format(self):
         etag = structures.ETag('67ab43')
 
@@ -382,14 +434,17 @@ class TestFalconUtils:
         falcon.HTTP_METHODS * 2
     )
 )
-def test_simulate_request_protocol(protocol, method):
+def test_simulate_request_protocol(asgi, protocol, method):
     sink_called = [False]
 
     def sink(req, resp):
         sink_called[0] = True
         assert req.protocol == protocol
 
-    app = falcon.API()
+    if asgi:
+        sink = to_coroutine(sink)
+
+    app = create_app(asgi)
     app.add_sink(sink, '/test')
 
     client = testing.TestClient(app)
@@ -412,13 +467,16 @@ def test_simulate_request_protocol(protocol, method):
     testing.simulate_patch,
     testing.simulate_delete,
 ])
-def test_simulate_free_functions(simulate):
+def test_simulate_free_functions(asgi, simulate):
     sink_called = [False]
 
     def sink(req, resp):
         sink_called[0] = True
 
-    app = falcon.API()
+    if asgi:
+        sink = to_coroutine(sink)
+
+    app = create_app(asgi)
     app.add_sink(sink, '/test')
 
     simulate(app, '/test')
@@ -444,8 +502,7 @@ class TestFalconTestingUtils:
         env = testing.create_environ('/', headers={'X-Foo': None})
         assert env['HTTP_X_FOO'] == ''
 
-    def test_decode_empty_result(self):
-        app = falcon.API()
+    def test_decode_empty_result(self, app):
         client = testing.TestClient(app)
         response = client.simulate_request(path='/')
         assert response.text == ''
@@ -453,8 +510,7 @@ class TestFalconTestingUtils:
     def test_httpnow_alias_for_backwards_compat(self):
         assert testing.httpnow is util.http_now
 
-    def test_default_headers(self):
-        app = falcon.API()
+    def test_default_headers(self, app):
         resource = testing.SimpleTestResource()
         app.add_route('/', resource)
 
@@ -470,8 +526,7 @@ class TestFalconTestingUtils:
         client.simulate_get(headers=None)
         assert resource.captured_req.auth == headers['Authorization']
 
-    def test_default_headers_with_override(self):
-        app = falcon.API()
+    def test_default_headers_with_override(self, app):
         resource = testing.SimpleTestResource()
         app.add_route('/', resource)
 
@@ -491,8 +546,7 @@ class TestFalconTestingUtils:
         assert resource.captured_req.accept == headers['Accept']
         assert resource.captured_req.get_header('X-Override-Me') == override_after
 
-    def test_status(self):
-        app = falcon.API()
+    def test_status(self, app):
         resource = testing.SimpleTestResource(status=falcon.HTTP_702)
         app.add_route('/', resource)
         client = testing.TestClient(app)
@@ -505,15 +559,13 @@ class TestFalconTestingUtils:
         assert not result.content
         assert result.json is None
 
-    def test_path_must_start_with_slash(self):
-        app = falcon.API()
+    def test_path_must_start_with_slash(self, app):
         app.add_route('/', testing.SimpleTestResource())
         client = testing.TestClient(app)
         with pytest.raises(ValueError):
             client.simulate_get('foo')
 
-    def test_cached_text_in_result(self):
-        app = falcon.API()
+    def test_cached_text_in_result(self, app):
         app.add_route('/', testing.SimpleTestResource(body='test'))
         client = testing.TestClient(app)
 
@@ -524,7 +576,7 @@ class TestFalconTestingUtils:
         with pytest.raises(ValueError):
             testing.SimpleTestResource(body='', json={})
 
-    def test_query_string(self):
+    def test_query_string(self, app):
         class SomeResource:
             def on_get(self, req, resp):
                 doc = {}
@@ -536,7 +588,6 @@ class TestFalconTestingUtils:
 
                 resp.body = json.dumps(doc)
 
-        app = falcon.API()
         app.req_options.auto_parse_qs_csv = True
         app.add_route('/', SomeResource())
         client = testing.TestClient(app)
@@ -567,15 +618,13 @@ class TestFalconTestingUtils:
                                      params_csv=False)
         assert result.json['query_string'] == expected_qs
 
-    def test_query_string_no_question(self):
-        app = falcon.API()
+    def test_query_string_no_question(self, app):
         app.add_route('/', testing.SimpleTestResource())
         client = testing.TestClient(app)
         with pytest.raises(ValueError):
             client.simulate_get(query_string='?x=1')
 
-    def test_query_string_in_path(self):
-        app = falcon.API()
+    def test_query_string_in_path(self, app):
         resource = testing.SimpleTestResource()
         app.add_route('/thing', resource)
         client = testing.TestClient(app)
@@ -613,25 +662,25 @@ class TestFalconTestingUtils:
             'next': None,
         },
     ])
-    def test_simulate_json_body(self, document):
-        app = falcon.API()
-        resource = testing.SimpleTestResource()
+    def test_simulate_json_body(self, asgi, document):
+        resource = testing.SimpleTestResourceAsync() if asgi else testing.SimpleTestResource()
+        app = create_app(asgi)
         app.add_route('/', resource)
 
         json_types = ('application/json', 'application/json; charset=UTF-8')
         client = testing.TestClient(app)
-        client.simulate_post('/', json=document)
-        captured_body = resource.captured_req.bounded_stream.read().decode('utf-8')
-        assert json.loads(captured_body) == document
+        client.simulate_post('/', json=document, headers={'capture-req-body-bytes': '-1'})
+        assert json.loads(resource.captured_req_body.decode()) == document
         assert resource.captured_req.content_type in json_types
 
         headers = {
             'Content-Type': 'x-falcon/peregrine',
             'X-Falcon-Type': 'peregrine',
+            'capture-req-media': 'y'
         }
         body = 'If provided, `json` parameter overrides `body`.'
         client.simulate_post('/', headers=headers, body=body, json=document)
-        assert resource.captured_req.media == document
+        assert resource.captured_req_media == document
         assert resource.captured_req.content_type in json_types
         assert resource.captured_req.get_header('X-Falcon-Type') == 'peregrine'
 
@@ -642,13 +691,12 @@ class TestFalconTestingUtils:
         '104.24.101.85',
         '2606:4700:30::6818:6455',
     ])
-    def test_simulate_remote_addr(self, remote_addr):
+    def test_simulate_remote_addr(self, app, remote_addr):
         class ShowMyIPResource:
             def on_get(self, req, resp):
                 resp.body = req.remote_addr
                 resp.content_type = falcon.MEDIA_TEXT
 
-        app = falcon.API()
         app.add_route('/', ShowMyIPResource())
 
         client = testing.TestClient(app)
@@ -660,8 +708,7 @@ class TestFalconTestingUtils:
         else:
             assert resp.text == remote_addr
 
-    def test_simulate_hostname(self):
-        app = falcon.API()
+    def test_simulate_hostname(self, app):
         resource = testing.SimpleTestResource()
         app.add_route('/', resource)
 
@@ -673,7 +720,7 @@ class TestFalconTestingUtils:
     @pytest.mark.parametrize('extras,expected_headers', [
         (
             {},
-            (('user-agent', 'curl/7.24.0 (x86_64-apple-darwin12.0)'),),
+            (('user-agent', None),),
         ),
         (
             {'HTTP_USER_AGENT': 'URL/Emacs', 'HTTP_X_FALCON': 'peregrine'},
@@ -699,23 +746,43 @@ class TestFalconTestingUtils:
         with pytest.raises(ValueError):
             client.simulate_get('/', extras={'REQUEST_METHOD': 'PATCH'})
 
-        resp = client.simulate_get('/', extras={'REQUEST_METHOD': 'GET'})
-        assert resp.status_code == 200
-        assert resp.text == 'test'
+        result = client.simulate_get('/', extras={'REQUEST_METHOD': 'GET'})
+        assert result.status_code == 200
+        assert result.text == 'test'
 
 
-class TestNoApiClass(testing.TestCase):
+class TestNoAppClass(testing.TestCase):
     def test_something(self):
         self.assertTrue(isinstance(self.app, falcon.API))
 
 
-class TestSetupApi(testing.TestCase):
+if not falcon.PY35:
+    class TestSetupUnitTestASGI(testing.TestCase):
+        def setUp(self):
+            super().setUp()
+            self.app = create_app(True)
+            self.app.add_route('/', testing.SimpleTestResource(body='test'))
+
+        def test_something(self):
+            import falcon.asgi
+            self.assertTrue(isinstance(self.app, falcon.asgi.App))
+
+            result = self.simulate_get()
+            assert result.status_code == 200
+            assert result.text == 'test'
+
+
+class TestSetupUnitTest(testing.TestCase):
     def setUp(self):
-        super(TestSetupApi, self).setUp()
-        self.api = falcon.API()
+        super().setUp()
+        self.app.add_route('/', testing.SimpleTestResource(body='test'))
 
     def test_something(self):
-        self.assertTrue(isinstance(self.api, falcon.API))
+        self.assertTrue(isinstance(self.app, falcon.API))
+
+        result = self.simulate_get()
+        assert result.status_code == 200
+        assert result.text == 'test'
 
 
 def test_get_argnames():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,15 +1,29 @@
-try:
-    import jsonschema
-except ImportError:
-    jsonschema = None
+import asyncio
+import os
 
+try:
+    import jsonschema as _jsonschema  # NOQA
+except ImportError:
+    pass
 import pytest
 
 import falcon
 from falcon import testing
 from falcon.media import validators
+from ._util import create_app
 
-basic_schema = {
+
+# NOTE(kgriffs): Default to None if missing. We do it like this, here, instead
+#   of in the body of the except statement, above, to avoid flake8 import
+#   ordering errors.
+jsonschema = globals().get('_jsonschema')
+
+
+_VALID_MEDIA = {'message': 'something'}
+_INVALID_MEDIA = {}
+
+
+_TEST_SCHEMA = {
     'type': 'object',
     'properies': {
         'message': {
@@ -27,93 +41,151 @@ skip_missing_dep = pytest.mark.skipif(
 
 
 class Resource:
-    @validators.jsonschema.validate(req_schema=basic_schema)
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA)
     def request_validated(self, req, resp):
         assert req.media is not None
         return resp
 
-    @validators.jsonschema.validate(resp_schema=basic_schema)
+    @validators.jsonschema.validate(resp_schema=_TEST_SCHEMA)
     def response_validated(self, req, resp):
         assert resp.media is not None
         return resp
 
-    @validators.jsonschema.validate(req_schema=basic_schema, resp_schema=basic_schema)
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA, resp_schema=_TEST_SCHEMA)
     def both_validated(self, req, resp):
         assert req.media is not None
         assert resp.media is not None
         return req, resp
 
-    @validators.jsonschema.validate(req_schema=basic_schema, resp_schema=basic_schema)
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA, resp_schema=_TEST_SCHEMA)
     def on_put(self, req, resp):
         assert req.media is not None
-        resp.media = GoodData.media
+        resp.media = _VALID_MEDIA
 
 
-class GoodData:
-    media = {'message': 'something'}
+class ResourceAsync:
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA)
+    async def request_validated(self, req, resp):
+        assert req.media is not None
+        return resp
+
+    @validators.jsonschema.validate(resp_schema=_TEST_SCHEMA)
+    async def response_validated(self, req, resp):
+        assert resp.media is not None
+        return resp
+
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA, resp_schema=_TEST_SCHEMA)
+    async def both_validated(self, req, resp):
+        assert req.media is not None
+        assert resp.media is not None
+        return req, resp
+
+    @validators.jsonschema.validate(req_schema=_TEST_SCHEMA, resp_schema=_TEST_SCHEMA)
+    async def on_put(self, req, resp):
+        assert req.media is not None
+        resp.media = _VALID_MEDIA
 
 
-class BadData:
-    media = {}
+class MockReq:
+    def __init__(self, asgi, valid=True):
+        media = _VALID_MEDIA if valid else {}
+
+        if asgi:
+            self._media = media
+            self.media = self._media_async
+        else:
+            self.media = media
+
+    @property
+    async def _media_async(self):
+        return self._media
+
+
+class MockResp:
+    def __init__(self, valid=True):
+        self.media = _VALID_MEDIA if valid else {}
+
+
+def call_method(asgi, method_name, *args):
+    resource = ResourceAsync() if asgi else Resource()
+
+    result = getattr(resource, method_name)(*args)
+    if asgi:
+        return asyncio.get_event_loop().run_until_complete(result)
+    else:
+        return result
 
 
 @skip_missing_dep
-def test_req_schema_validation_success():
-    data = GoodData()
-    assert Resource().request_validated(GoodData(), data) is data
+def test_req_schema_validation_success(asgi):
+    data = MockResp()
+    assert call_method(asgi, 'request_validated', MockReq(asgi), data) is data
 
 
 @skip_missing_dep
-def test_req_schema_validation_failure():
+def test_req_schema_validation_failure(asgi):
     with pytest.raises(falcon.HTTPBadRequest) as excinfo:
-        Resource().request_validated(BadData(), None)
+        call_method(asgi, 'request_validated', MockReq(asgi, False), None)
 
     assert excinfo.value.description == "'message' is a required property"
 
 
 @skip_missing_dep
-def test_resp_schema_validation_success():
-    data = GoodData()
-    assert Resource().response_validated(GoodData(), data) is data
+def test_resp_schema_validation_success(asgi):
+    data = MockResp()
+    assert call_method(asgi, 'response_validated', MockReq(asgi), data) is data
 
 
 @skip_missing_dep
-def test_resp_schema_validation_failure():
+def test_resp_schema_validation_failure(asgi):
     with pytest.raises(falcon.HTTPInternalServerError) as excinfo:
-        Resource().response_validated(GoodData(), BadData())
+        call_method(asgi, 'response_validated', MockReq(asgi), MockResp(False))
 
     assert excinfo.value.title == 'Response data failed validation'
 
 
 @skip_missing_dep
-def test_both_schemas_validation_success():
-    req_data = GoodData()
-    resp_data = GoodData()
+def test_both_schemas_validation_success(asgi):
+    req = MockReq(asgi)
+    resp = MockResp()
 
-    result = Resource().both_validated(req_data, resp_data)
+    result = call_method(asgi, 'both_validated', req, resp)
 
-    assert result[0] is req_data
-    assert result[1] is resp_data
+    assert result[0] is req
+    assert result[1] is resp
 
-    client = testing.TestClient(falcon.API())
-    client.app.add_route('/test', Resource())
-    result = client.simulate_put('/test', json=GoodData.media)
-    assert result.json == resp_data.media
+    client = testing.TestClient(create_app(asgi))
+    resource = ResourceAsync() if asgi else Resource()
+    client.app.add_route('/test', resource)
+
+    result = client.simulate_put('/test', json=_VALID_MEDIA)
+    assert result.json == resp.media
 
 
 @skip_missing_dep
-def test_both_schemas_validation_failure():
+def test_both_schemas_validation_failure(asgi):
+    bad_resp = MockResp(False)
+
     with pytest.raises(falcon.HTTPInternalServerError) as excinfo:
-        Resource().both_validated(GoodData(), BadData())
+        call_method(asgi, 'both_validated', MockReq(asgi), bad_resp)
 
     assert excinfo.value.title == 'Response data failed validation'
 
     with pytest.raises(falcon.HTTPBadRequest) as excinfo:
-        Resource().both_validated(BadData(), GoodData())
+        call_method(asgi, 'both_validated', MockReq(asgi, False), MockResp())
 
     assert excinfo.value.title == 'Request data failed validation'
 
-    client = testing.TestClient(falcon.API())
-    client.app.add_route('/test', Resource())
-    result = client.simulate_put('/test', json=BadData.media)
+    client = testing.TestClient(create_app(asgi))
+    resource = ResourceAsync() if asgi else Resource()
+
+    should_wrap = 'FALCON_ASGI_WRAP_RESPONDERS' in os.environ
+
+    if should_wrap:
+        del os.environ['FALCON_ASGI_WRAP_RESPONDERS']
+    client.app.add_route('/test', resource)
+    if should_wrap:
+        os.environ['FALCON_ASGI_WRAP_RESPONDERS'] = 'y'
+
+    result = client.simulate_put('/test', json=_INVALID_MEDIA)
     assert result.status_code == 400

--- a/tools/mintest.sh
+++ b/tools/mintest.sh
@@ -3,4 +3,4 @@
 pip install -U tox coverage
 
 rm -f .coverage.*
-tox -e pep8 && tox -e py37 && tools/testing/combine_coverage.sh
+tox -e pep8 && tox -e py35,py37 && tools/testing/combine_coverage.sh

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,14 @@ whitelist_externals = mkdir
 commands = "{toxinidir}/tools/clean.sh" "{toxinidir}/falcon"
            coverage run -m pytest tests []
 
+[testenv:py35]
+deps = {[testenv]deps}
+       pytest-randomly
+       jsonschema
+whitelist_externals = {[with-coverage]whitelist_externals}
+commands = "{toxinidir}/tools/clean.sh" "{toxinidir}/falcon"
+           coverage run -m pytest tests --ignore=tests/asgi []
+
 [testenv:py37]
 deps = {[testenv]deps}
        pytest-randomly
@@ -67,6 +75,8 @@ deps = -r{toxinidir}/requirements/tests
 [testenv:py3_debug]
 basepython = python3.7
 deps = {[with-debug-tools]deps}
+       uvicorn
+       jsonschema
 
 # --------------------------------------------------------------------
 # Cython
@@ -79,6 +89,7 @@ deps = -r{toxinidir}/requirements/tests
 [testenv:py35_cython]
 basepython = python3.5
 deps = {[with-cython]deps}
+commands = {[testenv:py35]commands}
 
 [testenv:py36_cython]
 basepython = python3.6


### PR DESCRIPTION
# Summary of Changes

This patch adds the much-anticipated async support to Falcon by way of a new ASGI interface, additional testing helpers, and updated internals. 

- Note that only the HTTP ASGI interface is implemented. WebSocket support is planned to follow.
- I still need to get this to 100% test coverage before we can do a final review and merge.
- Docs will arrive in a follow-up patch once we think the implementation is ready to merge.

Changelog snippets will be added in a separate patch or a revision of this one (TBD).

In order to reconcile differences between the WSGI and ASGI interfaces, several breaking changes were made in this patch, as follows:

BREAKING CHANGE: create_environ no longer sets a default user agent header

BREAKING CHANGE: Renamed `protocol` kwarg for create_environ() to
	`http_version` and also the renamed kwarg only takes the version string
	(no longer prefixed with "HTTP/")

BREAKING CHANGE: Renamed `app` kwarg for create_environ() to `root_path`.
	and deprecated, may be removed in a future release.

BREAKING CHANGE: get_http_status() is deprecated, no longer accepts floats

BREAKING CHANGE: BoundedStream.writeable() changed to writable() per the
	standard file-like I/O interface (the old name was a misspelling).

BREAKING CHANGE: api_helpers.prepare_middleware() no longer accepts a single
	object; the value that is passed must be an iterable.

BREAKING CHANGE: Removed outer "finally" block from API and APP; add an
	exception handler for the base Exception type if you need to deal with
	unhandled exceptions.

BREAKING CHANGE: falcon.request.access_route will now include the value of
  the remote_addr property as the last element in the route, if not already present
  in one of the headers that are checked.

BREAKING CHANGE: When the 'REMOTE_ADDR' field is not present in the WSGI
	environ, Falcon will assume '127.0.0.1' for the value, rather than
	simply returning `None` for Request.remote_addr.

# Related Issues

#1358 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
