### PR TITLE
Fix sphinx error - duplicate object description of falcon

### DIFF
--- a/docs/api/hooks.rst
+++ b/docs/api/hooks.rst
@@ -91,5 +91,6 @@ requests.
     passes through the framework.
 
 .. automodule:: falcon
+    :noindex:
     :members: before, after
     :undoc-members:

--- a/docs/api/redirects.rst
+++ b/docs/api/redirects.rst
@@ -13,5 +13,6 @@ Redirects
 ---------
 
 .. automodule:: falcon
+    :noindex:
     :members: HTTPMovedPermanently, HTTPFound, HTTPSeeOther,
         HTTPTemporaryRedirect, HTTPPermanentRedirect

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -14,6 +14,7 @@ Miscellaneous
 -------------
 
 .. automodule:: falcon
+    :noindex:
     :members: deprecated, http_now, dt_to_http, http_date_to_dt,
         to_query_str, get_http_status, get_bound_method
 


### PR DESCRIPTION
# Summary of Changes

Sphinx run was failing for `TOXENV=docs`. This fixes that.