### PR TITLE
chore(dockerfiles): remove "<2" from django dependency

### DIFF
--- a/docker/bench_py37.Dockerfile
+++ b/docker/bench_py37.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 MAINTAINER Falcon Framework Maintainers
 
 RUN pip install --no-cache-dir falcon
-RUN pip install --no-cache-dir bottle "django<2" flask
+RUN pip install --no-cache-dir bottle "django" flask
 COPY ./benchmark.sh /benchmark.sh
 
 CMD /benchmark.sh

--- a/docker/bench_py37_cython.Dockerfile
+++ b/docker/bench_py37_cython.Dockerfile
@@ -7,7 +7,7 @@ RUN pip install cython
 # RUN pip install orjson
 
 RUN pip install -v --no-cache-dir --no-binary :all: falcon
-RUN pip install --no-cache-dir bottle "django<2" flask
+RUN pip install --no-cache-dir bottle "django" flask
 COPY ./benchmark.sh /benchmark.sh
 
 CMD /benchmark.sh

--- a/docker/bench_pypy3.Dockerfile
+++ b/docker/bench_pypy3.Dockerfile
@@ -2,7 +2,7 @@ FROM pypy:3-slim
 MAINTAINER Falcon Framework Maintainers
 
 RUN pip install --no-cache-dir falcon
-RUN pip install --no-cache-dir bottle "django<2" flask
+RUN pip install --no-cache-dir bottle "django" flask
 COPY ./benchmark.sh benchmark.sh
 
 CMD /benchmark.sh


### PR DESCRIPTION
the maximum version is no longer necessary
because only recent Python 3.x versions are beeing tested

closes #1582

# Summary of Changes

Removed "<2" restrictions in all Dockerfiles.

# Related Issues

N/A

# Pull Request Checklist

- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)