### PR TITLE
feat(API): on exception, select most specific error handler available

### DIFF
--- a/docs/_newsfragments/1603-smart-exception-handler-precedence.feature.rst
+++ b/docs/_newsfragments/1603-smart-exception-handler-precedence.feature.rst
@@ -1,0 +1,1 @@
+Exceptions are now handled by the registered handler for the most specific matching exception class, rather than in reverse order of registration. "Specificity" is determined by the method resolution order of the raised exception type. (See :meth:`~.App.add_error_handler` for more details.)

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -827,10 +827,9 @@ class App:
 
                 return True
 
-        # NOTE(kgriffs): No error handlers are defined for ex
-        # and it is not one of (HTTPStatus, HTTPError), since it
-        # would have matched one of the corresponding default
-        # handlers.
+        # NOTE(kgriffs): No error handlers are defined for ex and it
+        # is not one of (HTTPStatus, HTTPError, Exception), since it
+        # would have matched one of the corresponding default handlers.
         return False
 
     # PERF(kgriffs): Moved from api_helpers since it is slightly faster

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -596,6 +596,11 @@ class App:
                 If an iterable of exception types is specified instead of
                 a single type, the handler must be explicitly specified.
 
+        .. versionchanged:: 3.0
+            Breaking change: error handler now selected by most specific
+            matching error class, rather than most recently registered matching
+            error class.
+
         """
         def wrap_old_handler(old_handler):
             @wraps(old_handler)

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -91,14 +91,14 @@ class TestErrorHandler:
         assert result.status_code == 723
         assert result.text == 'error: CustomException'
 
-    def test_error_order_duplicate(self, client):
+    def test_error_precedence_duplicate(self, client):
         client.app.add_error_handler(Exception, capture_error)
         client.app.add_error_handler(Exception, handle_error_first)
 
         result = client.simulate_get()
         assert result.text == 'first error handler'
 
-    def test_error_order_subclass(self, client):
+    def test_error_precedence_subclass(self, client):
         client.app.add_error_handler(Exception, capture_error)
         client.app.add_error_handler(CustomException, handle_error_first)
 
@@ -110,13 +110,13 @@ class TestErrorHandler:
         assert result.status_code == 723
         assert result.text == 'error: Plain Exception'
 
-    def test_error_order_subclass_masked(self, client):
+    def test_error_precedence_subclass_order_indifference(self, client):
         client.app.add_error_handler(CustomException, handle_error_first)
         client.app.add_error_handler(Exception, capture_error)
 
         result = client.simulate_delete()
-        assert result.status_code == 723
-        assert result.text == 'error: CustomException'
+        assert result.status_code == 200
+        assert result.text == 'first error handler'
 
     @pytest.mark.parametrize('exceptions', [
         (Exception, CustomException),


### PR DESCRIPTION
# Summary of Changes

Rather than selecting error handlers in LIFO order of registration, select the error handler corresponding to the nearest direct ancestor of the exception type raised. So, for example, if an app only adds a custom error handler for the Python ``Exception`` class, and an ``HTTPForbidden`` error is raised, then we use the default handler for ``HTTPError`` rather than the more general ``Exception`` handler (which is the pre-existing behavior). 

This is implemented by storing error handlers on the API object as a dict rather than a list and looking them up using the method resolution order attribute (`__mro__`) on the raised exception class. 

### NOTE: 
~~This commit only includes the actual implementation and does not address testing or documentation. I am seeking implementation feedback before completing those additional changes.~~ Tests and documentation have been added. Thanks @vytas7 for implementation notes!

### BREAKING CHANGE: 
Registration of a new error handler for type `E` will no longer override previously-registered error handlers for subclasses of type `E`. Registration order will no longer matter *except* when multiple error handlers are registered for the exact same exception type, in which case the most recently registered error handler overrides the previous ones. 

# Related Issues

Addresses #1514.

~~I believe it would also allow reversion of https://github.com/falconry/falcon/pull/1599.~~ Not true. I misremembered why #1599 was needed.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
