### PR TITLE
chore(tutorial): unpin Gunicorn in the `look` test requirements

### DIFF
--- a/examples/look/requirements/test
+++ b/examples/look/requirements/test
@@ -1,4 +1,4 @@
-gunicorn==19.9.0
+gunicorn>=20.0.1
 mock>=2.0.0
 msgpack>=0.6.0
 pytest>=5.0.0


### PR DESCRIPTION
In https://github.com/falconry/falcon/pull/1611, we were unable to use the latest Gunicorn due to how the `look` tutorial was specifying app in the command line.

The latest Gunicorn release seems to address the issue (https://github.com/benoitc/gunicorn/issues/2175), so we no longer need to pin an old Gunicorn version.
