### PR TITLE
test: Clean up pytest warnings and fix missing comma in WEBDAV_METHODS

### DIFF
--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -25,7 +25,7 @@ WEBDAV_METHODS = [
     'PROPPATCH',
     'REPORT',
     'UNCHECKIN',
-    'UNLOCK'
+    'UNLOCK',
     'UPDATE',
     'VERSION-CONTROL',
 ]

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -23,17 +23,19 @@ from typing import Dict, Optional, Union
 import warnings
 import wsgiref.validate
 
-from falcon.constants import MEDIA_JSON
+from falcon.constants import COMBINED_METHODS, MEDIA_JSON
 from falcon.testing import helpers
 from falcon.testing.srmock import StartResponseMock
 from falcon.util import CaseInsensitiveDict, http_cookies, http_date_to_dt, to_query_str
 from falcon.util import json as util_json
 
 warnings.filterwarnings(
-    'ignore',
+    'error',
     (
-        'Unknown REQUEST_METHOD: '
-        "'(CONNECT|CHECKIN|CHECKOUT|UNCHECKIN|UPDATE|VERSION-CONTROL|REPORT|SETECASTRONOMY)'"
+        'Unknown REQUEST_METHOD: ' +
+        "'({})'".format(
+            '|'.join(COMBINED_METHODS)
+        )
     ),
     wsgiref.validate.WSGIWarning,
     '',

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,6 @@ universal = 1
 test=pytest
 
 [tool:pytest]
-addopts = --ignore falcon --ignore examples
+filterwarnings =
+    ignore:Unknown REQUEST_METHOD. '(CONNECT|DELETE|GET|HEAD|OPTIONS|PATCH|POST|PUT|TRACE|CHECKIN|CHECKOUT|COPY|LOCK|MKCOL|MOVE|PROPFIND|PROPPATCH|REPORT|UNCHECKIN|UNLOCK|UPDATE|VERSION-CONTROL)':wsgiref.validate.WSGIWarning
+    ignore:cannot collect test class 'TestClient':pytest.PytestCollectionWarning

--- a/tests/test_http_custom_method_routing.py
+++ b/tests/test_http_custom_method_routing.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+import wsgiref.validate
 
 import pytest
 
@@ -92,7 +93,9 @@ def test_environment_override(cleanup_constants, resource_things, env_str, expec
 def test_foo(custom_http_client, resource_things):
     """FOO is a supported method, so returns HTTP_204"""
     custom_http_client.app.add_route('/things', resource_things)
-    response = custom_http_client.simulate_request(path='/things', method='FOO')
+
+    with pytest.warns(wsgiref.validate.WSGIWarning):
+        response = custom_http_client.simulate_request(path='/things', method='FOO')
 
     assert 'FOO' in falcon.constants.COMBINED_METHODS
     assert response.status == falcon.HTTP_204
@@ -102,7 +105,9 @@ def test_foo(custom_http_client, resource_things):
 def test_bar(custom_http_client, resource_things):
     """BAR is not supported by ResourceThing"""
     custom_http_client.app.add_route('/things', resource_things)
-    response = custom_http_client.simulate_request(path='/things', method='BAR')
+
+    with pytest.warns(wsgiref.validate.WSGIWarning):
+        response = custom_http_client.simulate_request(path='/things', method='BAR')
 
     assert 'BAR' in falcon.constants.COMBINED_METHODS
     assert response.status == falcon.HTTP_405

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -1,23 +1,26 @@
 from functools import wraps
+import wsgiref.validate
 
 import pytest
 
 import falcon
 import falcon.testing as testing
 
-HTTP_METHODS = (
+# RFC 7231, 5789 methods
+HTTP_METHODS = [
     'CONNECT',
     'DELETE',
     'GET',
     'HEAD',
     'OPTIONS',
+    'PATCH',
     'POST',
     'PUT',
     'TRACE',
-    'PATCH'
-)
+]
 
-WEBDAV_METHODS = (
+# RFC 2518 and 4918 methods
+WEBDAV_METHODS = [
     'CHECKIN',
     'CHECKOUT',
     'COPY',
@@ -28,10 +31,10 @@ WEBDAV_METHODS = (
     'PROPPATCH',
     'REPORT',
     'UNCHECKIN',
-    'UNLOCK'
+    'UNLOCK',
     'UPDATE',
     'VERSION-CONTROL',
-)
+]
 
 
 @pytest.fixture
@@ -274,6 +277,9 @@ class TestHttpMethodRouting:
     def test_bogus_method(self, client, resource_things):
         client.app.add_route('/things', resource_things)
         client.app.add_route('/things/{id}/stuff/{sid}', resource_things)
-        response = client.simulate_request(path='/things', method='SETECASTRONOMY')
+
+        with pytest.warns(wsgiref.validate.WSGIWarning):
+            response = client.simulate_request(path='/things', method='SETECASTRONOMY')
+
         assert not resource_things.called
         assert response.status == falcon.HTTP_400

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8
 
 import datetime
+import wsgiref.validate
 import xml.etree.ElementTree as et  # noqa: I202
 
 import pytest
@@ -379,7 +380,12 @@ class TestHTTPError:
         client.app.add_route('/notfound', NotFoundResourceWithBody())
         client.app.set_error_serializer(_simple_serializer)
 
-        resp = client.simulate_request(path=path, method=method)
+        if method not in falcon.COMBINED_METHODS:
+            with pytest.warns(wsgiref.validate.WSGIWarning):
+                resp = client.simulate_request(path=path, method=method)
+        else:
+            resp = client.simulate_request(path=path, method=method)
+
         assert resp.json['title']
         assert resp.json['status'] == status
 


### PR DESCRIPTION
# Summary of Changes

This patch cleans up the less-than-useful warnings that are typically reported by pytest runs whenever there are any test failures. Along the way, I discovered that the `WEBDAV_METHODS` list was missing a comma.
