### PR TITLE
chore(Travis): do not install (unused) coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 dist: xenial
 
-install: pip install tox coveralls
+install: pip install tox
 cache:
     directories:
         - $HOME/.cache/pip


### PR DESCRIPTION
Fix our coverage CI gate by removing the unused `coveralls` dependency which was pulling in older `codecov`, which was in turn conflicting with the newest one installed into `tox` environments.

This is probably preferred to just pinning coverage to an older version, as attempted in https://github.com/falconry/falcon/pull/1622.