### PR TITLE
test: Added tests, which check whether App/API initializers are overriding

### DIFF
--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -32,17 +32,7 @@ def client(request):
     return testing.TestClient(app)
 
 
-@pytest.mark.parametrize('client', (falcon.App,), indirect=True)
-def test_app_media_type_overriding(client):
-    response = client.simulate_get('/')
-    actual_header = response.headers['content-type']
-    actual_text = response.text
-
-    assert actual_header == falcon.MEDIA_HTML
-    assert actual_text == "{'foo': 'bar'}"
-
-
-@pytest.mark.parametrize('client', (falcon.API,), indirect=True)
+@pytest.mark.parametrize('client', (falcon.App, falcon.API,), indirect=True)
 def test_api_media_type_overriding(client):
     response = client.simulate_get('/')
     actual_header = response.headers['content-type']

--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -1,5 +1,5 @@
 import falcon
-import falcon.testing as testing
+from falcon import testing
 
 
 class MediaTypeResource:

--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -6,7 +6,7 @@ from falcon import media, testing
 
 class MediaResource:
     def on_get(self, req, resp):
-        resp.media = {"foo": "bar"}
+        resp.media = {'foo': 'bar'}
 
 
 class MediaHTMLHandler(media.BaseHandler):

--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -33,7 +33,7 @@ def client(request):
 
 
 @pytest.mark.parametrize('client', (falcon.App,), indirect=True)
-def test_api_media_type_overriding(client):
+def test_app_media_type_overriding(client):
     response = client.simulate_get('/')
     actual_header = response.headers['content-type']
     actual_text = response.text
@@ -43,7 +43,7 @@ def test_api_media_type_overriding(client):
 
 
 @pytest.mark.parametrize('client', (falcon.API,), indirect=True)
-def test_app_media_type_overriding(client):
+def test_api_media_type_overriding(client):
     response = client.simulate_get('/')
     actual_header = response.headers['content-type']
     actual_text = response.text

--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -1,0 +1,33 @@
+import falcon
+import falcon.testing as testing
+
+
+class MediaTypeResource:
+    def on_get(self, req, resp):
+        resp.body = 'foo bar'
+
+
+def test_api_media_type_overriding():
+    expected_header = 'text/html'
+
+    api = falcon.API(media_type=expected_header)
+    api.add_route('/', MediaTypeResource())
+    client = testing.TestClient(api)
+
+    response = client.simulate_get('/')
+    actual_header = response.headers['content-type']
+
+    assert expected_header == actual_header
+
+
+def test_app_media_type_overriding():
+    expected_header = 'text/html'
+
+    api = falcon.App(media_type=expected_header)
+    api.add_route('/', MediaTypeResource())
+    client = testing.TestClient(api)
+
+    response = client.simulate_get('/')
+    actual_header = response.headers['content-type']
+
+    assert expected_header == actual_header


### PR DESCRIPTION
# Summary of Changes

Added tests for `falcon.API`, `falcon.App` initializers, which check whether a `media_type` is overriding.

# Related Issues

https://github.com/falconry/falcon/issues/1577

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
