### PR TITLE
feat: Added HTTPHeadersMapping abstract class

### DIFF
--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -27,6 +27,7 @@ import json  # NOQA
 from falcon.util.structures import *  # NOQA
 from falcon.util.misc import *  # NOQA
 from falcon.util.time import *  # NOQA
+from falcon.util.mappings import *  # NOQA
 
 
 # NOTE(kgriffs): Backport support for the new 'SameSite' attribute

--- a/falcon/util/mappings.py
+++ b/falcon/util/mappings.py
@@ -1,0 +1,16 @@
+"""Mapping classes."""
+
+import abc
+
+
+class HTTPHeadersMapping(dict):
+    """Abstract class for setting HTTP headers"""
+
+    @abc.abstractmethod
+    def items(self):
+        """Preparing HTTP header keys/values
+
+        Returns:
+            list: Prepared list of tuples with HTTP header keys/values.
+        """
+        pass


### PR DESCRIPTION
# Summary of Changes

**the PR is POC.**

Added **HTTPHeadersMapping** abstract class which allows creating `dict`-like behavior in order to set headers for a `Response` class via `Response.set_headers` method.

1. [Here](https://github.com/falconry/falcon/pull/1627/files#diff-6081bb7e410da436b4c228430a6f5f40R6) I inherited `dict`, the reason is - keep backward compatibility.

2. Also, I marked a [method](https://github.com/falconry/falcon/pull/1627/files#diff-6081bb7e410da436b4c228430a6f5f40R10) as `abstract` it will notify a user that, it a strict rule, and the `items()` method should be implemented, it will allow avoiding a lot of potential errors.

If the approach is good, I'll update docs/tests as well.

@vytas7 @kgriffs @tribals thoughts?

# Related Issue

https://github.com/falconry/falcon/issues/1546

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [] Updated **documentation** for changed code.
    - [x ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*