### PR TITLE
Rewrites behaviour of Response.set_headers() method

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+recursive-include falcon *.pyx
 recursive-include tests *.py
 recursive-include docs *.rst
 include .coveragerc

--- a/docs/_newsfragments/1630-set-response.feature.rst
+++ b/docs/_newsfragments/1630-set-response.feature.rst
@@ -1,0 +1,2 @@
+The :meth:`~.Response.set_headers` method now can retrieve an instance of an object
+which implements ``items()`` method.

--- a/docs/_newsfragments/1630-set-response.feature.rst
+++ b/docs/_newsfragments/1630-set-response.feature.rst
@@ -1,2 +1,2 @@
-The :meth:`~.Response.set_headers` method now can retrieve an instance of an object
-which implements ``items()`` method.
+The :meth:`~.Response.set_headers` method now accepts an instance of any dict-like
+object that implements an ``items()`` method.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -662,8 +662,8 @@ class Response:
 
         header_items = getattr(headers, 'items', None)
 
-        if header_items and callable(header_items):
-            headers = headers.items()
+        if callable(header_items):
+            headers = header_items()
 
         # NOTE(kgriffs): We can't use dict.update because we have to
         # normalize the header names.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -635,21 +635,25 @@ class Response:
             :meth:`~.append_header` or :meth:`~.set_cookie`.
 
         Args:
-            headers (dict or list): A dictionary of header names and values
+            headers (dict or list or object): A dictionary of header names and values
                 to set, or a ``list`` of (*name*, *value*) tuples. Both
                 *name* and *value* must be of type ``str`` and
-                contain only US-ASCII characters.
+                contain only US-ASCII characters, also an instance of an object
+                which implements ``items()`` method can be passed, the method should
+                return a ``dict`` or ``list`` of ``tuple``.
 
                 Note:
                     Falcon can process a list of tuples slightly faster
                     than a dict.
 
         Raises:
-            ValueError: `headers` was not a ``dict`` or ``list`` of ``tuple``.
-
+            ValueError: `headers` was not a ``dict`` or ``list`` of ``tuple`
+                         or an instance of an object which implements ``items()`` method.
         """
 
-        if isinstance(headers, dict):
+        header_items = getattr(headers, 'items', None)
+
+        if header_items and callable(header_items):
             headers = headers.items()
 
         # NOTE(kgriffs): We can't use dict.update because we have to

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -635,20 +635,18 @@ class Response:
             :meth:`~.append_header` or :meth:`~.set_cookie`.
 
         Args:
-            headers (dict or list or object): A dictionary of header names and values
-                to set, or a ``list`` of (*name*, *value*) tuples. Both
-                *name* and *value* must be of type ``str`` and
-                contain only US-ASCII characters, also an instance of an object
-                which implements ``items()`` method can be passed, the method should
-                return a ``dict`` or ``list`` of ``tuple``.
+            headers (Iterable[[str, str]]): An iterable of ``[name, value]`` two-member
+                iterables, or a dict-like object that implements an ``items()`` method.
+                Both *name* and *value* must be of type ``str`` and
+                contain only US-ASCII characters.
 
                 Note:
-                    Falcon can process a list of tuples slightly faster
+                    Falcon can process an iterable of tuples slightly faster
                     than a dict.
 
         Raises:
-            ValueError: `headers` was not a ``dict`` or ``list`` of ``tuple`
-                         or an instance of an object which implements ``items()`` method.
+            ValueError: `headers` was not a ``dict`` or ``list`` of ``tuple``
+                         or ``Iterable[[str, str]]``.
         """
 
         header_items = getattr(headers, 'items', None)

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -249,6 +249,17 @@ class CORSHeaderResource:
         resp.body = "I'm a CORS test response"
 
 
+class CustomHeaders:
+    def items(self):
+        return [('test-header', 'test-value')]
+
+
+class CustomHeadersResource:
+    def on_get(self, req, resp):
+        headers = CustomHeaders()
+        resp.set_headers(headers)
+
+
 class TestHeaders:
 
     def test_content_length(self, client):
@@ -781,6 +792,14 @@ class TestHeaders:
         assert result.headers['Access-Control-Allow-Methods'] == 'DELETE, GET'
         assert result.headers['Access-Control-Allow-Headers'] == '*'
         assert result.headers['Access-Control-Max-Age'] == '86400'  # 24 hours in seconds
+
+    def test_set_headers_with_custom_class(self, client):
+        client.app.add_route('/', CustomHeadersResource())
+
+        result = client.simulate_get('/')
+
+        assert 'test-header' in result.headers
+        assert result.headers['test-header'] == 'test-value'
 
     # ----------------------------------------------------------------------
     # Helpers

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -254,7 +254,7 @@ class CustomHeaders:
         return [('test-header', 'test-value')]
 
 
-class CustomHeadersNotCallableResource:
+class CustomHeadersNotCallable:
     def __init__(self):
         self.items = {'test-header': 'test-value'}
 
@@ -265,7 +265,7 @@ class CustomHeadersResource:
         resp.set_headers(headers)
 
     def on_post(self, req, resp):
-        resp.set_headers(CustomHeadersNotCallableResource())
+        resp.set_headers(CustomHeadersNotCallable())
 
 
 class TestHeaders:

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -254,10 +254,18 @@ class CustomHeaders:
         return [('test-header', 'test-value')]
 
 
+class CustomHeadersNotCallableResource:
+    def __init__(self):
+        self.items = {'test-header': 'test-value'}
+
+
 class CustomHeadersResource:
     def on_get(self, req, resp):
         headers = CustomHeaders()
         resp.set_headers(headers)
+
+    def on_post(self, req, resp):
+        resp.set_headers(CustomHeadersNotCallableResource())
 
 
 class TestHeaders:
@@ -800,6 +808,13 @@ class TestHeaders:
 
         assert 'test-header' in result.headers
         assert result.headers['test-header'] == 'test-value'
+
+    def test_headers_with_custom_class_not_callable(self, client):
+        client.app.add_route('/', CustomHeadersResource())
+
+        result = client.simulate_post('/')
+
+        assert 'test-header' not in result.headers
 
     # ----------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
# Summary of Changes

Changed behavior in `Response.set_headers()` the method, now we're checking for interface compliance, instead of check whether an object is an instance of ``dict``.

Also, new changes allow passing a custom class which will be setting headers for a response.
e.g
```python
class CustomHeaders:
    # ... custom flow etc.
    def items(self):
        return [('header', 'value')]  # or return {'header': 'value'}


class Resource:
    def on_get(self, req, resp):
        custom_headers = CustomHeaders()

        resp.set_headers(custom_headers)
```

# Related Issues

https://github.com/falconry/falcon/issues/1546

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
