### PR TITLE
doc/refactor(asgi): Start fleshing out docstrings, tweak doc refs, remove add_error_handler shimming

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -164,6 +164,13 @@ pre {
     font-size: smaller;
 }
 
+
+/* NOTE(kgriffs): Make sure that characters in plain text blocks line up correctly. */
+.highlight-none .highlight pre {
+    line-height: 1em;
+    font-family: monospace;
+}
+
 /* Fix drifting to the left in some parameters lists. */
 .field-body li .highlight pre {
     float: right;
@@ -253,4 +260,10 @@ dl.field-list.simple dd ul li p:not(:first-child) {
 
 dl.attribute > dd > p {
     margin: 0;
+}
+
+/* NOTE(kgriffs): Fix spacing issue with embedded Note blocks, and make
+     things generally more readable by spacing the paragraphs. */
+.field-list p {
+    margin-bottom: 1em;
 }

--- a/docs/api/app.rst
+++ b/docs/api/app.rst
@@ -3,16 +3,28 @@
 The App Class
 =============
 
-Falcon's App class is a WSGI "application" that you can host with any
-standard-compliant WSGI server.
+Falcon supports both the WSGI (:class:`falcon.App`) and
+ASGI (:class:`falcon.asgi.App`) protocols. This is done
+by instantiating the respective ``App`` class to create a
+callable WSGI or ASGI "application".
+
+Because Falcon's ``App`` classes are built on
+`WSGI <https://www.python.org/dev/peps/pep-3333/>`_ and
+`ASGI <https://asgi.readthedocs.io/en/latest/>`_,
+you can host them with any standard-compliant server.
 
 .. code:: python
 
     import falcon
+    import falcon.asgi
 
-    app = falcon.App()
+    wsgi_app = falcon.App()
+    asgi_app = falcon.asgi.App()
 
 .. autoclass:: falcon.App
+    :members:
+
+.. autoclass:: falcon.asgi.App
     :members:
 
 .. autoclass:: falcon.RequestOptions

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -99,8 +99,9 @@ the request.
 When running your application in a development environment, you can
 disable this default behavior by setting
 :py:attr:`~.ResponseOptions.secure_cookies_by_default` to ``False``
-via :any:`App.resp_options`. This lets you test your app locally
-without having to set up TLS. You can make this option configurable to
+via :py:attr:`falcon.App.resp_options` or
+:py:attr:`falcon.asgi.App.resp_options`. This lets you test your app
+locally without having to set up TLS. You can make this option configurable to
 easily switch between development and production environments.
 
 See also: `RFC 6265, Section 4.1.2.5`_

--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -63,7 +63,7 @@ All classes are available directly in the ``falcon`` package namespace::
 Note also that any exception (not just instances of
 :class:`~.HTTPError`) can be caught, logged, and otherwise handled
 at the global level by registering one or more custom error handlers.
-See also :meth:`~.App.add_error_handler` to learn more about this
+See also :meth:`~.falcon.App.add_error_handler` to learn more about this
 feature.
 
 .. note::

--- a/docs/api/middleware.rst
+++ b/docs/api/middleware.rst
@@ -158,7 +158,7 @@ which case the framework will use the latter exception to update the
 
     By default, the framework installs two handlers, one for
     :class:`~.HTTPError` and one for :class:`~.HTTPStatus`. These can
-    be overridden via :meth:`~.App.add_error_handler`.
+    be overridden via :meth:`~.falcon.App.add_error_handler`.
 
 Regardless, the framework will continue unwinding the middleware
 stack. For example, if *mob2.process_request* were to raise an

--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -52,9 +52,9 @@ Default Router
 Falcon's default routing engine is based on a decision tree that is
 first compiled into Python code, and then evaluated by the runtime.
 
-The :meth:`~.App.add_route` method is used to associate a URI template
-with a resource. Falcon then maps incoming requests to resources
-based on these templates.
+The :meth:`falcon.App.add_route` and :meth:`falcon.asgi.App.add_route` methods
+are used to associate a URI template with a resource. Falcon then maps incoming
+requests to resources based on these templates.
 
 Falcon's default router uses Python classes to represent resources. In
 practice, these classes act as controllers in your application. They
@@ -63,7 +63,7 @@ compose a response back to the client based on the results of those
 actions. (See also:
 :ref:`Tutorial: Creating Resources <tutorial_resources>`)
 
-.. code::
+.. code:: none
 
                ┌────────────┐
     request  → │            │
@@ -109,8 +109,8 @@ data to hooks and middleware methods.
     object, a responder may raise an instance of either
     :class:`~.HTTPError` or :class:`~.HTTPStatus`. Falcon will
     convert these exceptions to appropriate HTTP responses.
-    Alternatively, you can handle them youself via
-    :meth:`~.App.add_error_handler`.
+    Alternatively, you can handle them yourself via
+    :meth:`~.falcon.App.add_error_handler`.
 
 In addition to the standard `req` and `resp` parameters, if the
 route's template contains field expressions, any responder that

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -421,7 +421,7 @@ now look like this:
         ├── __init__.py
         └── test_app.py
 
-Falcon supports :ref:`testing <testing>` its :class:`~.App` object by
+Falcon supports :ref:`testing <testing>` its :class:`~falcon.App` object by
 simulating HTTP requests.
 
 Tests can either be written using Python's standard :mod:`unittest`
@@ -1403,7 +1403,7 @@ for each error type.
     for logging and otherwise handling exceptions raised by
     responders, hooks, and middleware components.
 
-    See also: :meth:`~.App.add_error_handler`.
+    See also: :meth:`~.falcon.App.add_error_handler`.
 
 Let's see a quick example of how this works. Try requesting an invalid
 image name from your application:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1803,8 +1803,9 @@ class Request:
 class RequestOptions:
     """Defines a set of configurable request options.
 
-    An instance of this class is exposed via :any:`App.req_options` for
-    configuring certain :py:class:`~.Request` behaviors.
+    An instance of this class is exposed via :attr:`falcon.App.req_options` and
+    :attr:`falcon.asgi.App.req_options` for configuring certain
+    :py:class:`~.Request` behaviors.
 
     Attributes:
         keep_blank_qs_values (bool): Set to ``False`` to ignore query string
@@ -1865,11 +1866,13 @@ class RequestOptions:
             certain cases, such as when working with authentication
             schemes that employ URL-based signatures.
 
-        default_media_type (str): The default media-type to use when
-            deserializing a response. This value is normally set to the media
-            type provided when a :class:`falcon.App` is initialized; however,
-            if created independently, this will default to the
-            ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
+        default_media_type (str): The default media-type used to
+            deserialize a request body, when the Content-Type header is
+            missing or ambiguous. This value is normally
+            set to the media type provided to the :class:`falcon.App` or
+            :class:`falcon.asgi.App` initializer; however, if created
+            independently, this will default to
+            :attr:`falcon.DEFAULT_MEDIA_TYPE`.
 
         media_handlers (Handlers): A dict-like object that allows you to
             configure the media-types that you would like to handle.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -1028,8 +1028,9 @@ class Response:
 class ResponseOptions:
     """Defines a set of configurable response options.
 
-    An instance of this class is exposed via :any:`App.resp_options` for
-    configuring certain :py:class:`~.Response` behaviors.
+    An instance of this class is exposed via :attr:`falcon.App.resp_options`
+    and :attr:`falcon.asgi.App.resp_options` for configuring certain
+    :py:class:`~.Response` behaviors.
 
     Attributes:
         secure_cookies_by_default (bool): Set to ``False`` in development
@@ -1039,10 +1040,11 @@ class ResponseOptions:
             be overridden via `set_cookie()`'s `secure` kwarg.
 
         default_media_type (str): The default Internet media type (RFC 2046) to
-            use when deserializing a response. This value is normally set to the
+            use when rendering a response, when the Content-Type header
+            is not set explicitly. This value is normally set to the
             media type provided when a :class:`falcon.App` is initialized;
-            however, if created independently, this will default to the
-            ``DEFAULT_MEDIA_TYPE`` specified by Falcon.
+            however, if created independently, this will default to
+            :attr:`falcon.DEFAULT_MEDIA_TYPE`..
 
         media_handlers (Handlers): A dict-like object that allows you to
             configure the media-types that you would like to handle.

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -720,8 +720,9 @@ class ConverterDict(UserDict):
 class CompiledRouterOptions:
     """Defines a set of configurable router options.
 
-    An instance of this class is exposed via :any:`App.router_options`
-    for configuring certain :py:class:`~.CompiledRouter` behaviors.
+    An instance of this class is exposed via :py:attr:`falcon.App.router_options`
+    and :py:attr:`falcon.asgi.App.router_options` for configuring certain
+    :py:class:`~.CompiledRouter` behaviors.
 
     Attributes:
         converters: Represents the collection of named

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -188,7 +188,7 @@ class TestErrorHandler:
         with pytest.raises(TypeError):
             client.app.add_error_handler(exceptions, capture_error)
 
-    def test_handler_signature_shim(self, client):
+    def test_handler_signature_shim(self):
         def check_args(ex, req, resp):
             assert isinstance(ex, BaseException)
             assert isinstance(req, falcon.Request)
@@ -203,6 +203,10 @@ class TestErrorHandler:
         def legacy_handler3(err, rq, rs, prms):
             check_args(err, rq, rs)
 
+        app = create_app(asgi=False)
+        app.add_route('/', ErroredClassResource())
+        client = testing.TestClient(app)
+
         client.app.add_error_handler(Exception, legacy_handler1)
         client.app.add_error_handler(CustomBaseException, legacy_handler2)
         client.app.add_error_handler(CustomException, legacy_handler3)
@@ -210,22 +214,6 @@ class TestErrorHandler:
         client.simulate_delete()
         client.simulate_get()
         client.simulate_head()
-
-    def test_handler_signature_shim_asgi(self):
-        def check_args(ex, req, resp):
-            assert isinstance(ex, BaseException)
-            assert isinstance(req, falcon.Request)
-            assert isinstance(resp, falcon.Response)
-
-        async def legacy_handler(err, rq, rs, prms):
-            check_args(err, rq, rs)
-
-        app = create_app(True)
-        app.add_route('/', ErroredClassResource())
-        app.add_error_handler(Exception, legacy_handler)
-        client = testing.TestClient(app)
-
-        client.simulate_get()
 
     def test_handler_must_be_coroutine_for_asgi(self):
         async def legacy_handler(err, rq, rs, prms):


### PR DESCRIPTION
This patch is a bit of a grab bag of items that I noticed and
fixed while starting work on fleshing out the docs for the new ASGI
implementation.

Note that there is still quite a bit of work to do in order to integrate
ASGI into the docs. Many docs need to be combed and updated to work with
ASGI and WSGI side-by-side, and there are still plenty of missing docs for
the new ASGI classes and functions.