### PR TITLE
doc: Group guides in sidebar nav, and rename "Classes and Functions" section

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,5 +1,5 @@
-Classes and Functions
-=====================
+Framework Reference
+===================
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,7 +116,7 @@ Documentation
    :maxdepth: 2
 
    user/index
-   api/index
    deploy/index
    community/index
+   api/index
    changes/index


### PR DESCRIPTION
# Summary of Changes

This patch groups the guide sections together in the nav sidebar. It also renames the "Classes and Functions" setting to "Framework Reference" because it contains additional feature docs for media, middleware, etc.
