### PR TITLE
feat(testing): Accept a content_type kwarg when simulating requests

### DIFF
--- a/docs/_newsfragments/simulate-request-content-type.feature.rst
+++ b/docs/_newsfragments/simulate-request-content-type.feature.rst
@@ -1,0 +1,3 @@
+:meth:`falcon.testing.simulate_request` now accepts a
+`content_type` keyword argument. This provides a more convenient way to set
+this common header vs. the `headers` argument.

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -254,9 +254,9 @@ class Result:
 #   appears to be "hanging", which might indicates that the app is
 #   not handling the reception of events correctly.
 def simulate_request(app, method='GET', path='/', query_string=None,
-                     headers=None, body=None, json=None, file_wrapper=None,
-                     wsgierrors=None, params=None, params_csv=True,
-                     protocol='http', host=helpers.DEFAULT_HOST,
+                     headers=None, content_type=None, body=None, json=None,
+                     file_wrapper=None, wsgierrors=None, params=None,
+                     params_csv=True, protocol='http', host=helpers.DEFAULT_HOST,
                      remote_addr=None, extras=None, http_version='1.1',
                      port=None, root_path=None, asgi_chunk_size=4096,
                      asgi_disconnect_ttl=300) -> Result:
@@ -301,6 +301,11 @@ def simulate_request(app, method='GET', path='/', query_string=None,
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
+        content_type (str): The value to use for the Content-Type header in
+            the request. If specified, this value will take precedence over
+            any value set for the Content-Type header in the
+            `headers` keyword argument. The ``falcon`` module provides a number
+            of :ref:`constants for common media types <media_type_constants>`.
         headers (dict): Extra headers as a dict-like (Mapping) object, or an
             iterable yielding a series of two-member (*name*, *value*)
             iterables. Each pair of strings provides the name and value
@@ -314,8 +319,9 @@ def simulate_request(app, method='GET', path='/', query_string=None,
             may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
-            overrides `body` and the Content-Type header in
-            `headers`.
+            overrides `body` and sets the Content-Type header to
+            ``'application/json'``, overriding any value specified by either
+            the `content_type` or `headers` arguments.
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
             WSGI environ (default: ``None``). This can be used to test
@@ -370,6 +376,10 @@ def simulate_request(app, method='GET', path='/', query_string=None,
             comma_delimited_lists=params_csv,
             prefix=False,
         )
+
+    if content_type is not None:
+        headers = headers or {}
+        headers['Content-Type'] = content_type
 
     if json is not None:
         body = util_json.dumps(json, ensure_ascii=False)
@@ -699,6 +709,11 @@ def simulate_post(app, path, **kwargs) -> Result:
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
+        content_type (str): The value to use for the Content-Type header in
+            the request. If specified, this value will take precedence over
+            any value set for the Content-Type header in the
+            `headers` keyword argument. The ``falcon`` module provides a number
+            of :ref:`constants for common media types <media_type_constants>`.
         headers (dict): Extra headers as a dict-like (Mapping) object, or an
             iterable yielding a series of two-member (*name*, *value*)
             iterables. Each pair of strings provides the name and value
@@ -712,8 +727,9 @@ def simulate_post(app, path, **kwargs) -> Result:
             may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
-            overrides `body` and the Content-Type header in
-            `headers`.
+            overrides `body` and sets the Content-Type header to
+            ``'application/json'``, overriding any value specified by either
+            the `content_type` or `headers` arguments.
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
             WSGI environ (default: ``None``). This can be used to test
@@ -785,6 +801,11 @@ def simulate_put(app, path, **kwargs) -> Result:
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
+        content_type (str): The value to use for the Content-Type header in
+            the request. If specified, this value will take precedence over
+            any value set for the Content-Type header in the
+            `headers` keyword argument. The ``falcon`` module provides a number
+            of :ref:`constants for common media types <media_type_constants>`.
         headers (dict): Extra headers as a dict-like (Mapping) object, or an
             iterable yielding a series of two-member (*name*, *value*)
             iterables. Each pair of strings provides the name and value
@@ -798,8 +819,9 @@ def simulate_put(app, path, **kwargs) -> Result:
             may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
-            overrides `body` and the Content-Type header in
-            `headers`.
+            overrides `body` and sets the Content-Type header to
+            ``'application/json'``, overriding any value specified by either
+            the `content_type` or `headers` arguments.
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
             WSGI environ (default: ``None``). This can be used to test
@@ -945,6 +967,11 @@ def simulate_patch(app, path, **kwargs) -> Result:
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
+        content_type (str): The value to use for the Content-Type header in
+            the request. If specified, this value will take precedence over
+            any value set for the Content-Type header in the
+            `headers` keyword argument. The ``falcon`` module provides a number
+            of :ref:`constants for common media types <media_type_constants>`.
         headers (dict): Extra headers as a dict-like (Mapping) object, or an
             iterable yielding a series of two-member (*name*, *value*)
             iterables. Each pair of strings provides the name and value
@@ -958,8 +985,9 @@ def simulate_patch(app, path, **kwargs) -> Result:
             may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
-            overrides `body` and the Content-Type header in
-            `headers`.
+            overrides `body` and sets the Content-Type header to
+            ``'application/json'``, overriding any value specified by either
+            the `content_type` or `headers` arguments.
         host(str): A string to use for the hostname part of the fully
             qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
@@ -1026,6 +1054,11 @@ def simulate_delete(app, path, **kwargs) -> Result:
         query_string (str): A raw query string to include in the
             request (default: ``None``). If specified, overrides
             `params`.
+        content_type (str): The value to use for the Content-Type header in
+            the request. If specified, this value will take precedence over
+            any value set for the Content-Type header in the
+            `headers` keyword argument. The ``falcon`` module provides a number
+            of :ref:`constants for common media types <media_type_constants>`.
         headers (dict): Extra headers as a dict-like (Mapping) object, or an
             iterable yielding a series of two-member (*name*, *value*)
             iterables. Each pair of strings provides the name and value
@@ -1039,8 +1072,9 @@ def simulate_delete(app, path, **kwargs) -> Result:
             may be passed, in which case it will be used as-is.
         json(JSON serializable): A JSON document to serialize as the
             body of the request (default: ``None``). If specified,
-            overrides `body` and the Content-Type header in
-            `headers`.
+            overrides `body` and sets the Content-Type header to
+            ``'application/json'``, overriding any value specified by either
+            the `content_type` or `headers` arguments.
         host(str): A string to use for the hostname part of the fully
             qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the

--- a/tests/test_app_initializers.py
+++ b/tests/test_app_initializers.py
@@ -42,7 +42,6 @@ def test_api_media_type_overriding(client):
     assert response.text == "{'foo': 'bar'}"
     assert response.headers['content-type'] == falcon.MEDIA_TEXT
 
-    h = {'content-type': falcon.MEDIA_TEXT}
-    response = client.simulate_post('/', body='foobar', headers=h)
+    response = client.simulate_post('/', body='foobar', content_type=falcon.MEDIA_TEXT)
     assert response.text == 'foobar'
     assert response.headers['content-type'] == falcon.MEDIA_TEXT


### PR DESCRIPTION
# Summary of Changes

It is often the case that the only reason to pass the headers kwarg to
simulate_request() is to set the content type. This patch adds a
convenience kwarg for this use case.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
