### PR TITLE
Move version fetching to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+version = attr: falcon.__version__
+
 [egg_info]
 tag_build = dev1
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import glob
-import imp
 import io
 import os
 from os import path
@@ -9,10 +8,6 @@ import sys
 from setuptools import Extension, find_packages, setup
 
 MYDIR = path.abspath(os.path.dirname(__file__))
-
-VERSION = imp.load_source('version', path.join('.', 'falcon', 'version.py'))
-VERSION = VERSION.__version__
-
 REQUIRES = []
 
 try:
@@ -132,7 +127,6 @@ def load_description():
 
 setup(
     name='falcon',
-    version=VERSION,
     description='An unladen web framework for building APIs and app backends.',
     long_description=load_description(),
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
# Summary of Changes

Fixes a deprecation warning in setup.py. I wonder if we should move more items to setup.cfg?

I could have rewritten this with `importlib` but it seemed simpler to add code where setup.cfg does this automatically. Open to other suggestions

# Related Issues

Fixes GH-1651

# Pull Request Checklist

- [ ] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
