### PR TITLE
Fix tests on windows

### DIFF
--- a/docs/_newsfragments/1656-tests-on-windows.misc.rst
+++ b/docs/_newsfragments/1656-tests-on-windows.misc.rst
@@ -1,0 +1,1 @@
+Fix test errors on Windows

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -1069,5 +1069,6 @@ class ResponseOptions:
         self.default_media_type = DEFAULT_MEDIA_TYPE
         self.media_handlers = Handlers()
 
-        mimetypes.init()
+        if not mimetypes.inited:
+            mimetypes.init()
         self.static_media_types = mimetypes.types_map

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -49,13 +49,16 @@ class StaticRoute:
         if not prefix.startswith('/'):
             raise ValueError("prefix must start with '/'")
 
-        if not os.path.isabs(directory):
+        self._directory = os.path.normpath(directory)
+        if not os.path.isabs(self._directory):
             raise ValueError('directory must be an absolute path')
 
         if fallback_filename is None:
             self._fallback_filename = None
         else:
-            self._fallback_filename = os.path.normpath(os.path.join(directory, fallback_filename))
+            self._fallback_filename = os.path.normpath(
+                os.path.join(self._directory, fallback_filename)
+            )
             if not os.path.isfile(self._fallback_filename):
                 raise ValueError('fallback_filename is not a file')
 
@@ -66,7 +69,6 @@ class StaticRoute:
             prefix += '/'
 
         self._prefix = prefix
-        self._directory = os.path.normpath(directory)
         self._downloadable = downloadable
 
     def match(self, path):

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -55,7 +55,7 @@ class StaticRoute:
         if fallback_filename is None:
             self._fallback_filename = None
         else:
-            self._fallback_filename = os.path.join(directory, fallback_filename)
+            self._fallback_filename = os.path.normpath(os.path.join(directory, fallback_filename))
             if not os.path.isfile(self._fallback_filename):
                 raise ValueError('fallback_filename is not a file')
 
@@ -66,7 +66,7 @@ class StaticRoute:
             prefix += '/'
 
         self._prefix = prefix
-        self._directory = directory
+        self._directory = os.path.normpath(directory)
         self._downloadable = downloadable
 
     def match(self, path):

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -1,12 +1,13 @@
 import asyncio
 from collections import Counter
-import time
 import sys
+import time
 
 import falcon
 import falcon.asgi
 import falcon.util
-_WIN32 = sys.platform.startswith("win")
+
+_WIN32 = sys.platform.startswith('win')
 
 
 class Things:

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -1,10 +1,12 @@
 import asyncio
 from collections import Counter
 import time
+import sys
 
 import falcon
 import falcon.asgi
 import falcon.util
+_WIN32 = sys.platform.startswith("win")
 
 
 class Things:
@@ -67,7 +69,8 @@ class Things:
         cms = falcon.util.wrap_sync_to_async(callmesafely, threadsafe=False)
         loop = falcon.util.get_loop()
 
-        num_cms_tasks = 1000
+        # NOTE(caselit): on windows it takes more time so create less tasks
+        num_cms_tasks = 100 if _WIN32 else 1000
 
         for i in range(num_cms_tasks):
             # NOTE(kgriffs): create_task() is used here, so that the coroutines

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 import os
 import platform
 import subprocess
-import time
 import sys
+import time
 
 import pytest
 import requests
@@ -15,7 +15,7 @@ from falcon import testing
 _MODULE_DIR = os.path.abspath(os.path.dirname(__file__))
 
 _PYPY = platform.python_implementation() == 'PyPy'
-_WIN32 = sys.platform.startswith("win")
+_WIN32 = sys.platform.startswith('win')
 
 _SERVER_HOST = '127.0.0.1'
 _SIZE_1_KB = 1024

--- a/tests/asgi/test_boundedstream_asgi.py
+++ b/tests/asgi/test_boundedstream_asgi.py
@@ -13,7 +13,7 @@ from falcon import asgi, testing
     b'catsup',
     b'\xDE\xAD\xBE\xEF' * 512,
     testing.rand_string(1, 2048),
-])
+], ids=['empty', 'null', 'null-ff', 'normal', 'long', 'random'])
 @pytest.mark.parametrize('extra_body', [True, False])
 @pytest.mark.parametrize('set_content_length', [True, False])
 def test_read_all(body, extra_body, set_content_length):
@@ -155,7 +155,7 @@ def test_filelike():
     b'catsup',
     b'\xDE\xAD\xBE\xEF' * 512,
     testing.rand_string(1, 2048).encode(),
-])
+], ids=['empty', 'null', 'null-ff', 'normal', 'long', 'random'])
 @pytest.mark.parametrize('chunk_size', [1, 2, 10, 64, 100, 1000, 10000])
 def test_read_chunks(body, chunk_size):
     def stream():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import falcon
 
 
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=["asgi", "wsgi"])
 def asgi(request):
     is_asgi = request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import falcon
 
 
-@pytest.fixture(params=[True, False], ids=["asgi", "wsgi"])
+@pytest.fixture(params=[True, False], ids=['asgi', 'wsgi'])
 def asgi(request):
     is_asgi = request.param
 

--- a/tests/test_cmd_print_api.py
+++ b/tests/test_cmd_print_api.py
@@ -1,4 +1,5 @@
 import io
+from os.path import normpath
 
 import pytest
 
@@ -46,7 +47,7 @@ def test_traverse_with_verbose(app):
         get_info, options_info = options_info, get_info
 
     assert options_info.startswith('-->OPTIONS')
-    assert 'falcon/responders.py:' in options_info
+    assert '{}:'.format(normpath('falcon/responders.py')) in options_info
 
     assert get_info.startswith('-->GET')
 
@@ -54,10 +55,11 @@ def test_traverse_with_verbose(app):
     # 18 or 25 (in the case of DummyResourceAsync) in the present file.
     # Adjust the test if the said responder is relocated, or just check for
     # any number if this becomes too painful to maintain.
+    path = normpath('tests/test_cmd_print_api.py')
 
     assert (
-        get_info.endswith('tests/test_cmd_print_api.py:13') or
-        get_info.endswith('tests/test_cmd_print_api.py:20')
+        get_info.endswith('{}:14'.format(path)) or
+        get_info.endswith('{}:21'.format(path))
     )
 
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from falcon import MEDIA_TEXT, ResponseOptions
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,6 +1,7 @@
 import pytest
+from unittest.mock import MagicMock
 
-from falcon import MEDIA_TEXT
+from falcon import MEDIA_TEXT, ResponseOptions
 
 from _util import create_resp  # NOQA
 
@@ -58,3 +59,18 @@ def test_response_removed_stream_len(resp):
 
     with pytest.raises(AttributeError):
         resp.stream_len
+
+
+def test_response_option_mimetype_init(monkeypatch):
+    mock = MagicMock()
+    mock.inited = False
+    monkeypatch.setattr('falcon.response.mimetypes', mock)
+
+    ro = ResponseOptions()
+
+    assert ro.static_media_types is mock.types_map
+    mock.reset_mock()
+    mock.inited = True
+    ro = ResponseOptions()
+    assert ro.static_media_types is mock.types_map
+    mock.init.assert_not_called()

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -12,11 +12,11 @@ import falcon.testing as testing
 import _util  # NOQA
 
 
-@pytest.fixture(params=[True, False])
-def client(request):
-    app = _util.create_app(asgi=request.param)
+@pytest.fixture()
+def client(asgi):
+    app = _util.create_app(asgi=asgi)
     client = testing.TestClient(app)
-    client.asgi = request.param
+    client.asgi = asgi
     return client
 
 
@@ -136,6 +136,12 @@ def test_invalid_args_fallback_filename(client, default):
         client.app.add_static_route(prefix, directory, fallback_filename=default)
 
 
+# NOTE(caselit) depending on the system configuration mime types can have alternative names
+_MIME_ALTERNATIVE = {
+    'application/zip': ('application/zip', 'application/x-zip-compressed')
+}
+
+
 @pytest.mark.parametrize('uri_prefix, uri_path, expected_path, mtype', [
     ('/static/', '/css/test.css', '/css/test.css', 'text/css'),
     ('/static', '/css/test.css', '/css/test.css', 'text/css'),
@@ -180,8 +186,8 @@ def test_good_path(asgi, uri_prefix, uri_path, expected_path, mtype, monkeypatch
         sr(req, resp)
         body = resp.stream.read()
 
-    assert resp.content_type == mtype
-    assert body.decode() == '/var/www/statics' + expected_path
+    assert resp.content_type in _MIME_ALTERNATIVE.get(mtype, (mtype, ))
+    assert body.decode() == os.path.normpath('/var/www/statics' + expected_path)
 
 
 def test_lifo(client, monkeypatch):
@@ -192,11 +198,11 @@ def test_lifo(client, monkeypatch):
 
     response = client.simulate_request(path='/downloads/thing.zip')
     assert response.status == falcon.HTTP_200
-    assert response.text == '/opt/somesite/downloads/thing.zip'
+    assert response.text == os.path.normpath('/opt/somesite/downloads/thing.zip')
 
     response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
     assert response.status == falcon.HTTP_200
-    assert response.text == '/opt/somesite/x/thingtoo.zip'
+    assert response.text == os.path.normpath('/opt/somesite/x/thingtoo.zip')
 
 
 def test_lifo_negative(client, monkeypatch):
@@ -207,11 +213,11 @@ def test_lifo_negative(client, monkeypatch):
 
     response = client.simulate_request(path='/downloads/thing.zip')
     assert response.status == falcon.HTTP_200
-    assert response.text == '/opt/somesite/downloads/thing.zip'
+    assert response.text == os.path.normpath('/opt/somesite/downloads/thing.zip')
 
     response = client.simulate_request(path='/downloads/archive/thingtoo.zip')
     assert response.status == falcon.HTTP_200
-    assert response.text == '/opt/somesite/downloads/archive/thingtoo.zip'
+    assert response.text == os.path.normpath('/opt/somesite/downloads/archive/thingtoo.zip')
 
 
 def test_downloadable(client, monkeypatch):
@@ -243,6 +249,7 @@ def test_downloadable_not_found(client):
 @pytest.mark.parametrize('uri, default, expected, content_type', [
     ('', 'default', 'default', 'application/octet-stream'),
     ('other', 'default.html', 'default.html', 'text/html'),
+    ('zip', 'default.zip', 'default.zip', 'application/zip'),
     ('index2', 'index', 'index2', 'application/octet-stream'),
     ('absolute', '/foo/bar/index', '/foo/bar/index', 'application/octet-stream'),
     ('docs/notes/test.txt', 'index.html', 'index.html', 'text/html'),
@@ -253,13 +260,13 @@ def test_fallback_filename(asgi, uri, default, expected, content_type, downloada
                            monkeypatch):
 
     def mock_open(path, mode):
-        if default in path:
+        if os.path.normpath(default) in path:
             return io.BytesIO(path.encode())
 
         raise IOError()
 
     monkeypatch.setattr(io, 'open', mock_open)
-    monkeypatch.setattr('os.path.isfile', lambda file: default in file)
+    monkeypatch.setattr('os.path.isfile', lambda file: os.path.normpath(default) in file)
 
     sr = create_sr(
         asgi,
@@ -290,8 +297,8 @@ def test_fallback_filename(asgi, uri, default, expected, content_type, downloada
         body = resp.stream.read()
 
     assert sr.match(req.path)
-    assert body.decode() == os.path.join('/var/www/statics', expected)
-    assert resp.content_type == content_type
+    assert body.decode() == os.path.normpath(os.path.join('/var/www/statics', expected))
+    assert resp.content_type in _MIME_ALTERNATIVE.get(content_type, (content_type, ))
 
     if downloadable:
         assert os.path.basename(expected) in resp.downloadable_as
@@ -329,7 +336,7 @@ def test_e2e_fallback_filename(client, monkeypatch, strip_slash, path, fallback,
             assert response.status == falcon.HTTP_404
         else:
             assert response.status == falcon.HTTP_200
-            assert response.text == directory + expected
+            assert response.text == os.path.normpath(directory + expected)
 
     test('/static', '/opt/somesite/static/', static_exp)
     test('/assets', '/opt/somesite/assets/', assert_axp)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -364,7 +364,7 @@ def test_filesystem_traversal_fuse(client, monkeypatch):
     def suspicious_normpath(path):
         return 'assets/../../../../' + path
 
-    monkeypatch.setattr('os.path.normpath', suspicious_normpath)
     client.app.add_static_route('/static', '/etc/nginx/includes/static-data')
+    monkeypatch.setattr('os.path.normpath', suspicious_normpath)
     response = client.simulate_request(path='/static/shadow')
     assert response.status == falcon.HTTP_404


### PR DESCRIPTION
# Summary of Changes

Make the test work on windows. This mainly involves changes to the `tests` files.
The serve static constructor has been updated to use `os.path.normpath` on the `directory` and the `fallback_filename`
I've also created ids for pytest fixtures so that the logging is a bit more readable, in particular to the fixtures that tests long strings and the `asgi` fixture so that the tests read `[asgi]` and `[wsgi]` instead of true/false (maybe async/sync is better?)

# Related Issues

Closes #1656 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://github.com/falconry/falcon/blob/master/CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://pypi.org/project/towncrier/) news fragments under `docs/_newsfragments/`. (Run `towncrier --draft` to ensure it renders correctly.)

This  is still a work in progress. Currently I've fixed the test related to the path errors. There are still errors in the async part.
