### PR TITLE
docs: Fix no blank line after initial paragraph in attr description

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -259,7 +259,7 @@ dl.field-list.simple dd ul li p:not(:first-child) {
 }
 
 dl.attribute > dd > p {
-    margin: 0;
+    margin: 0 0 1em 0;
 }
 
 /* NOTE(kgriffs): Fix spacing issue with embedded Note blocks, and make


### PR DESCRIPTION
# Summary of Changes

Fix the paragraphs in attr descriptions running together.

# Related Issues

N/A
