### PR TITLE
refactor(asgi.Request): Change the media property to an alias of get_media()

### DIFF
--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -262,6 +262,13 @@ class Request(falcon.request.Request):
             the body of the request, if any.
 
             See also: :class:`falcon.asgi.BoundedStream`
+        media (object): An awaitable property that acts as an alias for
+            :meth:`~.get_media`. This can be used to ease the porting of a
+            a WSGI app to ASGI, although the ``await`` keyword must still be
+            added when referencing the property::
+
+                deserialized_media = await req.media
+
         expect (str): Value of the Expect header, or ``None`` if the
             header is missing.
         range (tuple of int): A 2-member ``tuple`` parsed from the value of the
@@ -681,13 +688,6 @@ class Request(falcon.request.Request):
 
         return netloc_value
 
-    @property
-    def media(self):
-        raise errors.UnsupportedError(
-            'The media property is not supported for ASGI requests. '
-            'Please use the Request.get_media() coroutine function instead.'
-        )
-
     async def get_media(self):
         """Returns a deserialized form of the request stream.
 
@@ -731,6 +731,8 @@ class Request(falcon.request.Request):
             await self.stream.exhaust()
 
         return self._media
+
+    media = property(get_media)
 
     @property
     def if_match(self):

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -331,8 +331,6 @@ class Request:
 
                 doc = json.load(req.bounded_stream)
 
-        expect (str): Value of the Expect header, or ``None`` if the
-            header is missing.
         media (object): Returns a deserialized form of the request stream.
             When called, it will attempt to deserialize the request stream
             using the Content-Type header as well as the media-type handlers
@@ -344,6 +342,9 @@ class Request:
                 This operation will consume the request stream the first time
                 it's called and cache the results. Follow-up calls will just
                 retrieve a cached version of the object.
+
+        expect (str): Value of the Expect header, or ``None`` if the
+            header is missing.
 
         range (tuple of int): A 2-member ``tuple`` parsed from the value of the
             Range header.

--- a/tests/asgi/test_request_asgi.py
+++ b/tests/asgi/test_request_asgi.py
@@ -1,6 +1,6 @@
 import pytest
 
-from falcon import testing, UnsupportedError
+from falcon import testing
 
 
 def test_missing_server_in_scope():
@@ -13,9 +13,3 @@ def test_log_error_not_supported():
     req = testing.create_asgi_req()
     with pytest.raises(NotImplementedError):
         req.log_error('Boink')
-
-
-def test_media_prop_not_supported():
-    req = testing.create_asgi_req()
-    with pytest.raises(UnsupportedError):
-        req.media

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -154,7 +154,10 @@ def test_deserialization_raises(asgi):
             resp.media = {}
 
         async def on_post(self, req, resp):
-            await req.get_media()
+            # NOTE(kgriffs): In this one case we use the property
+            #   instead of get_media(), in order to test that the
+            #   alias works as expected.
+            await req.media
 
     app.add_route('/', ResourceAsync() if asgi else Resource())
 


### PR DESCRIPTION
# Summary of Changes

This patch adds back support for the media property to help make the ASGI
and WSGI interfaces as similar as possible.

# Related Issues

#1358 