### PR TITLE
fix(SSEvent): Parameter validation in the constructor is too lenient

### DIFF
--- a/falcon/asgi/structures.py
+++ b/falcon/asgi/structures.py
@@ -84,22 +84,22 @@ class SSEvent:
         #   an error to be raised from the framework when it calls serialize()
         #   after the fact.
 
-        if data and not isinstance(data, bytes):
+        if data is not None and not isinstance(data, bytes):
             raise TypeError('data must be a byte string')
 
-        if text and not isinstance(text, str):
+        if text is not None and not isinstance(text, str):
             raise TypeError('text must be a string')
 
-        if event and not isinstance(event, str):
+        if event is not None and not isinstance(event, str):
             raise TypeError('event name must be a string')
 
-        if event_id and not isinstance(event_id, str):
+        if event_id is not None and not isinstance(event_id, str):
             raise TypeError('event_id must be a string')
 
-        if comment and not isinstance(comment, str):
+        if comment is not None and not isinstance(comment, str):
             raise TypeError('comment must be a string')
 
-        if retry and not isinstance(retry, int):
+        if retry is not None and not isinstance(retry, int):
             raise TypeError('retry must be an int')
 
         self.data = data

--- a/tests/asgi/test_sse.py
+++ b/tests/asgi/test_sse.py
@@ -111,10 +111,16 @@ def test_invalid_event_values():
         SSEvent(data=12345)
 
     with pytest.raises(TypeError):
+        SSEvent(data=0)
+
+    with pytest.raises(TypeError):
         SSEvent(text=b'notbytes')
 
     with pytest.raises(TypeError):
         SSEvent(text=23455)
+
+    with pytest.raises(TypeError):
+        SSEvent(text=0)
 
     with pytest.raises(TypeError):
         SSEvent(json=set()).serialize()
@@ -126,13 +132,22 @@ def test_invalid_event_values():
         SSEvent(event=1234)
 
     with pytest.raises(TypeError):
+        SSEvent(event=0)
+
+    with pytest.raises(TypeError):
         SSEvent(event_id=b'idbytes')
 
     with pytest.raises(TypeError):
         SSEvent(event_id=52085)
 
     with pytest.raises(TypeError):
+        SSEvent(event_id=0)
+
+    with pytest.raises(TypeError):
         SSEvent(retry='5808.25')
+
+    with pytest.raises(TypeError):
+        SSEvent(retry='')
 
     with pytest.raises(TypeError):
         SSEvent(retry=5808.25)
@@ -142,6 +157,9 @@ def test_invalid_event_values():
 
     with pytest.raises(TypeError):
         SSEvent(comment=1234)
+
+    with pytest.raises(TypeError):
+        SSEvent(comment=0)
 
 
 def test_non_iterable():


### PR DESCRIPTION
# Summary of Changes

This patch modifies the SSEvent initializer so that it explicitly checks whether a parameter is None. This avoids the problem of a parameter value having the wrong type, but being evaluated as falsey and thereby bypassing the type check.

# Related Issues

#1358 