### PR TITLE
fix(asgi.BoundedStream): Mixing iteration and read() can lead to subtle errors

### DIFF
--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -58,6 +58,12 @@ class UnsupportedError(RuntimeError):
     """The method or operation is not supported."""
 
 
+# NOTE(kgriffs): This inherits from ValueError to be consistent with the type
+#   raised by Python's built-in file-like objects.
+class OperationNotAllowed(ValueError):
+    """The requested operation is not allowed."""
+
+
 class HTTPBadRequest(HTTPError):
     """400 Bad Request.
 


### PR DESCRIPTION
# Summary of Changes

This patch does three things to make BoundedStream more robust and debuggable:

1. Disallow re-iteration over the stream when an iteration is already in progress.
2. Yield anything in the buffer first, before awaiting additional body events,
   when iterating over a stream that was partially read before the iteration
   began.
3. Introduce a custom subclass of ValueError, OperationNotAllowed, that
   can be raised to give the developer a more obvious hint as to what
   went wrong.

# Related Issues

#1358 
