### PR TITLE
[POC] Adopt pep517 + try compile with cython

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    # Skip cython when using pypy
+    "cython; python_implementation == 'CPython'"
+]
+build-backend = "setuptools.build_meta"
+
 [tool.towncrier]
     package = "falcon"
     package_dir = ""

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import glob
-import importlib
 import io
 import os
 from os import path
@@ -10,8 +9,12 @@ from setuptools import Extension, find_packages, setup
 
 MYDIR = path.abspath(os.path.dirname(__file__))
 
-VERSION = importlib.import_module('falcon.version')
-VERSION = VERSION.__version__
+with open(path.join(path.dirname(__file__), 'falcon', 'version.py')) as v_file:
+    VERSION = (
+        re.compile(r""".*__version__ = ["'](.*?)['"]""", re.S)
+        .match(v_file.read())
+        .group(1)
+    )
 
 REQUIRES = []
 
@@ -30,7 +33,39 @@ else:
     except ImportError:
         CYTHON = False
 
-if CYTHON:
+
+class BuildFailed(Exception):
+    pass
+
+
+def getCythonOptions():
+    # from sqlalchemy setup.py
+    from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+    ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
+    if sys.platform == 'win32':
+        # Work around issue https://github.com/pypa/setuptools/issues/1902
+        ext_errors += (IOError, TypeError)
+
+    class ve_build_ext(build_ext):
+        # This class allows Cython building to fail.
+
+        def run(self):
+            try:
+                super().run()
+            except DistutilsPlatformError:
+                raise BuildFailed()
+
+        def build_extension(self, ext):
+            try:
+                super().build_extension(ext)
+            except ext_errors as e:
+                raise BuildFailed() from e
+            except ValueError as e:
+                # this can happen on Windows 64 bit, see Python issue 7511
+                if "'path'" in str(e):
+                    raise BuildFailed() from e
+                raise
+
     def list_modules(dirname, pattern):
         filenames = glob.glob(path.join(dirname, pattern))
 
@@ -89,11 +124,8 @@ if CYTHON:
     for ext_mod in ext_modules:
         ext_mod.cython_directives = {'language_level': '3'}
 
-    cmdclass = {'build_ext': build_ext}
-
-else:
-    cmdclass = {}
-    ext_modules = []
+    cmdclass = {'build_ext': ve_build_ext}
+    return cmdclass, ext_modules
 
 
 def load_description():
@@ -131,51 +163,84 @@ def load_description():
     return ''.join(description_lines)
 
 
-setup(
-    name='falcon',
-    version=VERSION,
-    description='An unladen web framework for building APIs and app backends.',
-    long_description=load_description(),
-    long_description_content_type='text/x-rst',
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Environment :: Web Environment',
-        'Natural Language :: English',
-        'Intended Audience :: Developers',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft :: Windows',
-        'Operating System :: POSIX',
-        'Topic :: Internet :: WWW/HTTP :: WSGI',
-        'Topic :: Software Development :: Libraries :: Application Frameworks',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-    ],
-    keywords='wsgi web api framework rest http cloud',
-    author='Kurt Griffiths',
-    author_email='mail@kgriffs.com',
-    url='https://falconframework.org',
-    license='Apache 2.0',
-    packages=find_packages(exclude=['tests']),
-    include_package_data=True,
-    zip_safe=False,
-    python_requires='>=3.5',
-    install_requires=REQUIRES,
-    cmdclass=cmdclass,
-    ext_modules=ext_modules,
-    tests_require=['testtools', 'requests', 'pyyaml', 'pytest', 'pytest-runner'],
-    entry_points={
-        'console_scripts': [
-            'falcon-bench = falcon.cmd.bench:main',
-            'falcon-inspect-app = falcon.cmd.inspect_app:main',
-            'falcon-print-routes = falcon.cmd.inspect_app:route_main',
-        ]
-    }
-)
+def run_setup(CYTHON):
+    if CYTHON:
+        cmdclass, ext_modules = getCythonOptions()
+    else:
+        cmdclass, ext_modules = {}, []
+
+    setup(
+        name='falcon',
+        version=VERSION,
+        description='An unladen web framework for building APIs and app backends.',
+        long_description=load_description(),
+        long_description_content_type='text/x-rst',
+        classifiers=[
+            'Development Status :: 5 - Production/Stable',
+            'Environment :: Web Environment',
+            'Natural Language :: English',
+            'Intended Audience :: Developers',
+            'Intended Audience :: System Administrators',
+            'License :: OSI Approved :: Apache Software License',
+            'Operating System :: MacOS :: MacOS X',
+            'Operating System :: Microsoft :: Windows',
+            'Operating System :: POSIX',
+            'Topic :: Internet :: WWW/HTTP :: WSGI',
+            'Topic :: Software Development :: Libraries :: Application Frameworks',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: Implementation :: CPython',
+            'Programming Language :: Python :: Implementation :: PyPy',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
+        ],
+        keywords='wsgi web api framework rest http cloud',
+        author='Kurt Griffiths',
+        author_email='mail@kgriffs.com',
+        url='https://falconframework.org',
+        license='Apache 2.0',
+        packages=find_packages(exclude=['tests']),
+        include_package_data=True,
+        zip_safe=False,
+        python_requires='>=3.5',
+        install_requires=REQUIRES,
+        cmdclass=cmdclass,
+        ext_modules=ext_modules,
+        tests_require=['testtools', 'requests', 'pyyaml', 'pytest', 'pytest-runner'],
+        entry_points={
+            'console_scripts': [
+                'falcon-bench = falcon.cmd.bench:main',
+                'falcon-inspect-app = falcon.cmd.inspect_app:main',
+                'falcon-print-routes = falcon.cmd.inspect_app:route_main',
+            ]
+        }
+    )
+
+
+def status_msgs(*msgs):
+    print('*' * 75, *msgs, '*' * 75, sep='\n')
+
+
+if not CYTHON:
+    run_setup(False)
+    if not PYPY:
+        status_msgs('Cython compilation not supported in this environment')
+else:
+    try:
+        run_setup(True)
+    except BuildFailed as exc:
+        status_msgs(
+            exc.__cause__,
+            'Cython compilation could not be compiled, speedups are not enabled.',
+            'Failure information, if any, is above.',
+            'Retrying the build without the C extension now.'
+        )
+
+        run_setup(False)
+
+        status_msgs(
+            'Cython compilation could not be compiled, speedups are not enabled.',
+            'Plain-Python build succeeded.'
+        )


### PR DESCRIPTION
# Summary of Changes

This is just a WIP POC to see if something like this could work.

Add support for pep517 using the setuptools backend. This is based on https://github.com/pypa/setuptools/issues/1698 since currently no documentation exists.
Since we now use pep517 we have cython available during a normal install, so `setuy.py` has been updated to try to compile using cython and then falling back to a normal install. This logic is based mostly on [SQLAlchemy `setup.py](https://github.com/sqlalchemy/sqlalchemy/blob/c7d3ca0da477451885158a923aa9ee7e49794541/setup.py)

# Related Issues

#1683

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
