### PR TITLE
doc: Bring all reference pages up to date

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -281,6 +281,14 @@ div.contents.local.topic {
     border: none;
 }
 
+div.contents.local.topic > ul > li > p {
+    margin-bottom: 0;
+}
+
+div.contents.local.topic > ul > li > ul {
+    margin-top: 0;
+}
+
 .sphinx-tabs .sphinx-menu a.item {
     color: #c77c11 !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -313,6 +313,10 @@ div.note, pre {
     background-color: rgb(245,245,245);
 }
 
+div.note div.highlight > pre, div.admonition div.highlight > pre {
+    border: none;
+}
+
 div.note, div.admonition {
     /* Match tab radius */
     border-radius: .285714rem;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -275,3 +275,61 @@ div.body div.section > ul.simple > li > dl.simple > dd > ul {
 div.body div.toctree-wrapper.compound > ul > li.toctree-l1 > ul {
     margin-top: 0;
 }
+
+div.contents.local.topic {
+    background: none;
+    border: none;
+}
+
+.sphinx-tabs .sphinx-menu a.item {
+    color: #c77c11 !important;
+}
+
+.sphinx-tabs .sphinx-menu a.item:hover{
+    color: #f0ad4e !important;
+}
+
+.sphinx-tabs .sphinx-menu {
+    border-bottom-color: #eee !important;
+}
+
+.sphinx-tabs .sphinx-menu a.active.item {
+    border-color: #eee !important;
+}
+
+.sphinx-tab {
+    border-color: #eee !important;
+}
+
+.sphinx-tab.tab.active {
+    background-color: rgb(245,245,245);
+}
+
+.sphinx-tabs .sphinx-menu a.active.item  {
+    background-color: rgb(245,245,245) !important;
+}
+
+div.note, pre {
+    background-color: rgb(245,245,245);
+}
+
+div.note, div.admonition {
+    /* Match tab radius */
+    border-radius: .285714rem;
+    border-color: #eee;
+}
+
+div.ui.bottom.attached.sphinx-tab.tab {
+    /* Match tab radius */
+    border-bottom-left-radius: .285714rem;
+    border-bottom-right-radius: .285714rem;
+}
+
+div.highlight > pre {
+    border: 1px solid #eee;
+    border-radius: .285714rem;
+}
+
+.sphinx-tab pre {
+    border: none !important;
+}

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -3,10 +3,7 @@
 Cookies
 -------
 
-* `Getting Cookies`_
-* `Setting Cookies`_
-* `The Secure Attribute`_
-* `The SameSite Attribute`_
+.. contents:: :local:
 
 .. _getting-cookies:
 
@@ -25,45 +22,49 @@ need a collection of all the cookies in the request.
     :class:`falcon.asgi.Request` implements the same cookie methods and
     properties as :class:`falcon.Request`.
 
-Here's an example showing how to get cookies from a WSGI request:
+Here's an example showing how to get cookies from a request:
 
-.. code:: python
+.. tabs::
 
-    class Resource:
-        def on_get(self, req, resp):
+    .. tab:: WSGI
 
-            # Get a dict of name/value cookie pairs.
-            cookies = req.cookies
+        .. code:: python
 
-            my_cookie_values = req.get_cookie_values('my_cookie')
+            class Resource:
+                def on_get(self, req, resp):
 
-            if my_cookie_values:
-                # NOTE: If there are multiple values set for the cookie, you
-                #   will need to choose how to handle the additional values.
-                v = my_cookie_values[0]
+                    # Get a dict of name/value cookie pairs.
+                    cookies = req.cookies
 
-                # ...
+                    my_cookie_values = req.get_cookie_values('my_cookie')
 
-The ASGI version is similar:
+                    if my_cookie_values:
+                        # NOTE: If there are multiple values set for the cookie, you
+                        #   will need to choose how to handle the additional values.
+                        v = my_cookie_values[0]
 
-.. code:: python
+                        # ...
 
-    class Resource:
-        async def on_get(self, req, resp):
+    .. tab:: ASGI
 
-            # Get a dict of name/value cookie pairs.
-            cookies = req.cookies
+        .. code:: python
 
-            # NOTE: Since get_cookie_values() is synchronous, it does
-            #   not need to be await'd.
-            my_cookie_values = req.get_cookie_values('my_cookie')
+            class Resource:
+                async def on_get(self, req, resp):
 
-            if my_cookie_values:
-                # NOTE: If there are multiple values set for the cookie, you
-                #   will need to choose how to handle the additional values.
-                v = my_cookie_values[0]
+                    # Get a dict of name/value cookie pairs.
+                    cookies = req.cookies
 
-                # ...
+                    # NOTE: Since get_cookie_values() is synchronous, it does
+                    #   not need to be await'd.
+                    my_cookie_values = req.get_cookie_values('my_cookie')
+
+                    if my_cookie_values:
+                        # NOTE: If there are multiple values set for the cookie, you
+                        #   will need to choose how to handle the additional values.
+                        v = my_cookie_values[0]
+
+                        # ...
 
 .. _setting-cookies:
 

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -91,23 +91,18 @@ Simple example:
 
 .. code:: python
 
-    class Resource:
-        def on_get(self, req, resp):
-
-            # Set the cookie 'my_cookie' to the value 'my cookie value'
-            resp.set_cookie('my_cookie', 'my cookie value')
+    # Set the cookie 'my_cookie' to the value 'my cookie value'
+    resp.set_cookie('my_cookie', 'my cookie value')
 
 
 You can of course also set the domain, path and lifetime of the cookie.
 
 .. code:: python
 
-    class Resource:
-        def on_get(self, req, resp):
-            # Set the maximum age of the cookie to 10 minutes (600 seconds)
-            #   and the cookie's domain to 'example.com'
-            resp.set_cookie('my_cookie', 'my cookie value',
-                            max_age=600, domain='example.com')
+    # Set the maximum age of the cookie to 10 minutes (600 seconds)
+    #   and the cookie's domain to 'example.com'
+    resp.set_cookie('my_cookie', 'my cookie value',
+                    max_age=600, domain='example.com')
 
 
 You can also instruct the client to remove a cookie with the
@@ -115,12 +110,14 @@ You can also instruct the client to remove a cookie with the
 
 .. code:: python
 
-    class Resource:
-        def on_get(self, req, resp):
-            resp.set_cookie('bad_cookie', ':(')
+    # Set a cookie in middleware or in a previous request.
+    resp.set_cookie('my_cookie', 'my cookie value')
 
-            # Clear the bad cookie
-            resp.unset_cookie('bad_cookie')
+    # -- snip --
+
+    # Clear the cookie for the current request and instruct the user agent
+    #   to expire its own copy of the cookie (if any).
+    resp.unset_cookie('my_cookie')
 
 .. _cookie-secure-attribute:
 

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -20,17 +20,47 @@ Cookies can be read from a request either via the
 :py:meth:`~.falcon.Request.get_cookie_values` method should be used unless you
 need a collection of all the cookies in the request.
 
+.. note::
+
+    :class:`falcon.asgi.Request` implements the same cookie methods and
+    properties as :class:`falcon.Request`.
+
+Here's an example showing how to get cookies from a WSGI request:
+
 .. code:: python
 
     class Resource:
         def on_get(self, req, resp):
 
+            # Get a dict of name/value cookie pairs.
             cookies = req.cookies
 
             my_cookie_values = req.get_cookie_values('my_cookie')
+
             if my_cookie_values:
                 # NOTE: If there are multiple values set for the cookie, you
-                # will need to choose how to handle the additional values.
+                #   will need to choose how to handle the additional values.
+                v = my_cookie_values[0]
+
+                # ...
+
+The ASGI version is similar:
+
+.. code:: python
+
+    class Resource:
+        async def on_get(self, req, resp):
+
+            # Get a dict of name/value cookie pairs.
+            cookies = req.cookies
+
+            # NOTE: Since get_cookie_values() is synchronous, it does
+            #   not need to be await'd.
+            my_cookie_values = req.get_cookie_values('my_cookie')
+
+            if my_cookie_values:
+                # NOTE: If there are multiple values set for the cookie, you
+                #   will need to choose how to handle the additional values.
                 v = my_cookie_values[0]
 
                 # ...
@@ -47,6 +77,14 @@ One of these methods should be used instead of
 :py:meth:`~falcon.Response.set_header`. With :py:meth:`~falcon.Response.set_header` you
 cannot set multiple headers with the same name (which is how multiple cookies
 are sent to the client).
+
+.. note::
+
+    :class:`falcon.asgi.Request` implements the same cookie methods and
+    properties as :class:`falcon.Request`. The ASGI versions of
+    :meth:`~falcon.asgi.Response.set_cookie` and
+    :meth:`~falcon.asgi.Response.append_header`
+    are synchronous, so they do not need to be ``await``'d.
 
 Simple example:
 
@@ -66,7 +104,7 @@ You can of course also set the domain, path and lifetime of the cookie.
     class Resource:
         def on_get(self, req, resp):
             # Set the maximum age of the cookie to 10 minutes (600 seconds)
-            # and the cookie's domain to 'example.com'
+            #   and the cookie's domain to 'example.com'
             resp.set_cookie('my_cookie', 'my cookie value',
                             max_age=600, domain='example.com')
 

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -43,8 +43,6 @@ Here's an example showing how to get cookies from a request:
                         #   will need to choose how to handle the additional values.
                         v = my_cookie_values[0]
 
-                        # ...
-
     .. tab:: ASGI
 
         .. code:: python
@@ -63,8 +61,6 @@ Here's an example showing how to get cookies from a request:
                         # NOTE: If there are multiple values set for the cookie, you
                         #   will need to choose how to handle the additional values.
                         v = my_cookie_values[0]
-
-                        # ...
 
 .. _setting-cookies:
 

--- a/docs/api/cors.rst
+++ b/docs/api/cors.rst
@@ -10,7 +10,7 @@ browsers to prevent unauthorized requests between different domains.
 When implementing
 a web API, it is common to have to also implement a CORS policy. Therefore,
 Falcon provides an easy way to enable a simple CORS policy via a flag passed
-to :any:`falcon.App`.
+to :class:`falcon.App` or :class:`falcon.asgi.App`.
 
 By default, Falcon's built-in CORS support is disabled, so that any cross-origin
 requests will be blocked by the browser. Passing ``cors_enable=True`` will
@@ -25,10 +25,22 @@ sensitive resources.
 Usage
 -----
 
-.. code:: python
+.. tabs::
 
-    import falcon
+    .. tab:: WSGI
 
-    # Enable a simple CORS policy for all responses
-    app = falcon.App(cors_enable=True)
+        .. code:: python
 
+            import falcon
+
+            # Enable a simple CORS policy for all responses
+            app = falcon.App(cors_enable=True)
+
+    .. tab:: ASGI
+
+        .. code:: python
+
+            import falcon.asgi
+
+            # Enable a simple CORS policy for all responses
+            app = falcon.asgi.App(cors_enable=True)

--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -3,9 +3,7 @@
 Error Handling
 ==============
 
-* `Base Class`_
-* `Mixins`_
-* `Predefined Errors`_
+.. contents:: :local:
 
 When it comes to error handling, you can always directly set the error
 status, appropriate response headers, and error body using the ``resp``
@@ -48,21 +46,45 @@ To customize what data is passed to the serializer, subclass
             result['acceptable'] = self._acceptable
             return result
 
-All classes are available directly in the ``falcon`` package namespace::
+All classes are available directly in the ``falcon`` package namespace:
 
-    import falcon
+.. tabs::
 
-    class MessageResource:
-        def on_get(self, req, resp):
+    .. tab:: WSGI
 
-            # -- snip --
+        .. code:: python
 
-            raise falcon.HTTPBadRequest(
-                title="TTL Out of Range",
-                description="The message's TTL must be between 60 and 300 seconds, inclusive."
-            )
+            import falcon
 
-            # -- snip --
+            class MessageResource:
+                def on_get(self, req, resp):
+
+                    # -- snip --
+
+                    raise falcon.HTTPBadRequest(
+                        title="TTL Out of Range",
+                        description="The message's TTL must be between 60 and 300 seconds, inclusive."
+                    )
+
+                    # -- snip --
+
+    .. tab:: ASGI
+
+        .. code:: python
+
+            import falcon
+
+            class MessageResource:
+                async def on_get(self, req, resp):
+
+                    # -- snip --
+
+                    raise falcon.HTTPBadRequest(
+                        title="TTL Out of Range",
+                        description="The message's TTL must be between 60 and 300 seconds, inclusive."
+                    )
+
+                    # -- snip --
 
 Note also that any exception (not just instances of
 :class:`~.HTTPError`) can be caught, logged, and otherwise handled

--- a/docs/api/errors.rst
+++ b/docs/api/errors.rst
@@ -55,14 +55,14 @@ All classes are available directly in the ``falcon`` package namespace::
     class MessageResource:
         def on_get(self, req, resp):
 
-            # ...
+            # -- snip --
 
             raise falcon.HTTPBadRequest(
                 title="TTL Out of Range",
                 description="The message's TTL must be between 60 and 300 seconds, inclusive."
             )
 
-            # ...
+            # -- snip --
 
 Note also that any exception (not just instances of
 :class:`~.HTTPError`) can be caught, logged, and otherwise handled

--- a/docs/api/multipart.rst
+++ b/docs/api/multipart.rst
@@ -3,9 +3,7 @@
 Multipart Forms
 ===============
 
-* `Body Part Type`_
-* `Parsing Options`_
-* `Parsing Errors`_
+.. contents:: :local:
 
 Falcon features easy and efficient access to submitted multipart forms by using
 :class:`falcon.media.MultipartFormHandler` to handle the

--- a/docs/api/multipart.rst
+++ b/docs/api/multipart.rst
@@ -8,12 +8,12 @@ Multipart Forms
 Falcon features easy and efficient access to submitted multipart forms by using
 :class:`falcon.media.MultipartFormHandler` to handle the
 ``multipart/form-data`` :ref:`media <media>` type. This handler is enabled by
-default, allowing you to use ``req.media`` to iterate over the
+default, allowing you to use ``req.get_media()`` to iterate over the
 :class:`body parts <falcon.media.multipart.BodyPart>` in a form:
 
 .. code:: python
 
-    for part in req.media:
+    for part in req.get_media():
         if part.content_type == 'application/json':
             # TODO: Body part is a JSON document, do something useful with it
             resp.media = part.media

--- a/docs/api/request_and_response.rst
+++ b/docs/api/request_and_response.rst
@@ -1,5 +1,5 @@
-Requests & Responses
-====================
+Request & Response
+==================
 
 Similar to other frameworks, Falcon employs the inversion of control (IoC)
 pattern to coordinate with app methods in order to respond to HTTP requests.

--- a/docs/api/request_and_response_asgi.rst
+++ b/docs/api/request_and_response_asgi.rst
@@ -1,7 +1,7 @@
 .. _request_asgi:
 
-ASGI Requests & Responses
-=========================
+ASGI Request & Response
+=======================
 
 * `Request`_
 * `Response`_

--- a/docs/api/request_and_response_wsgi.rst
+++ b/docs/api/request_and_response_wsgi.rst
@@ -1,7 +1,7 @@
 .. _request:
 
-WSGI Requests & Responses
-=========================
+WSGI Request & Response
+=======================
 
 * `Request`_
 * `Response`_

--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -3,14 +3,7 @@
 Routing
 =======
 
-* `Default Behavior`_
-* `Default Router`_
-* `Field Converters`_
-* `Built-in Converters`_
-* `Custom Converters`_
-* `Custom Routers`_
-* `Routing Utilities`_
-* `Custom HTTP Methods`_
+.. contents:: :local:
 
 Falcon routes incoming requests to resources based on a set of URI
 templates. If the path requested by the client matches the template for
@@ -19,35 +12,78 @@ for processing.
 
 Here's a quick example to show how all the pieces fit together:
 
-.. code:: python
+.. tabs::
 
-    import json
+    .. tab:: WSGI
 
-    import falcon
+        .. code:: python
 
-    class ImagesResource:
+            import json
 
-        def on_get(self, req, resp):
-            doc = {
-                'images': [
-                    {
-                        'href': '/images/1eaf6ef1-7f2d-4ecc-a8d5-6e8adba7cc0e.png'
+            import falcon
+
+
+            class ImagesResource:
+
+                def on_get(self, req, resp):
+                    doc = {
+                        'images': [
+                            {
+                                'href': '/images/1eaf6ef1-7f2d-4ecc-a8d5-6e8adba7cc0e.png'
+                            }
+                        ]
                     }
-                ]
-            }
 
-            # Create a JSON representation of the resource
-            resp.body = json.dumps(doc, ensure_ascii=False)
+                    # Create a JSON representation of the resource; this could
+                    #   also be done automatically by assigning to resp.media
+                    resp.body = json.dumps(doc, ensure_ascii=False)
 
-            # The following line can be omitted because 200 is the default
-            # status returned by the framework, but it is included here to
-            # illustrate how this may be overridden as needed.
-            resp.status = falcon.HTTP_200
+                    # The following line can be omitted because 200 is the default
+                    # status returned by the framework, but it is included here to
+                    # illustrate how this may be overridden as needed.
+                    resp.status = falcon.HTTP_200
 
-    app = application = falcon.App()
 
-    images = ImagesResource()
-    app.add_route('/images', images)
+            app = falcon.App()
+
+            images = ImagesResource()
+            app.add_route('/images', images)
+
+    .. tab:: ASGI
+
+        .. code:: python
+
+            import json
+
+            import falcon
+            import falcon.asgi
+
+
+            class ImagesResource:
+
+                async def on_get(self, req, resp):
+                    doc = {
+                        'images': [
+                            {
+                                'href': '/images/1eaf6ef1-7f2d-4ecc-a8d5-6e8adba7cc0e.png'
+                            }
+                        ]
+                    }
+
+                    # Create a JSON representation of the resource; this could
+                    #   also be done automatically by assigning to resp.media
+                    resp.body = json.dumps(doc, ensure_ascii=False)
+
+                    # The following line can be omitted because 200 is the default
+                    # status returned by the framework, but it is included here to
+                    # illustrate how this may be overridden as needed.
+                    resp.status = falcon.HTTP_200
+
+
+            app = falcon.asgi.App()
+
+            images = ImagesResource()
+            app.add_route('/images', images)
 
 If no route matches the request, control then passes to a default
 responder that simply raises an instance of
@@ -144,12 +180,29 @@ example, given the following template::
 
     /user/{name}
 
-A PUT request to "/user/kgriffs" would be routed to:
+A PUT request to ``'/user/kgriffs'`` would cause the framework to invoke
+the ``on_put()`` responder method on the route's resource class, passing
+``'kgriffs'`` via an additional `name` argument defined by the responder:
 
-.. code:: python
+.. tabs::
 
-    def on_put(self, req, resp, name):
-        pass
+    .. tab:: WSGI
+
+        .. code:: python
+
+            # Template fields correspond to named arguments or keyword
+            #   arguments, following the usual req and resp args.
+            def on_put(self, req, resp, name):
+                pass
+
+    .. tab:: ASGI
+
+        .. code:: python
+
+            # Template fields correspond to named arguments or keyword
+            #   arguments, following the usual req and resp args.
+            async def on_put(self, req, resp, name):
+                pass
 
 Because field names correspond to argument names in responder
 methods, they must be valid Python identifiers.
@@ -245,7 +298,7 @@ Custom Routers
 --------------
 
 A custom routing engine may be specified when instantiating
-:py:meth:`falcon.App`. For example:
+:py:meth:`falcon.App` or :py:meth:`falcon.asgi.App`. For example:
 
 .. code:: python
 
@@ -339,9 +392,9 @@ be used by custom routing engines.
 Custom HTTP Methods
 -------------------
 
-While not advised, some applications need to support non-standard HTTP methods,
-such as FOO or BAR, in addition to the standard HTTP methods like GET and PUT.
-To support custom HTTP methods, use one of the following methods:
+While not normally advised, some applications may need to support non-standard
+HTTP methods, in addition to the standard HTTP methods like GET and PUT. To
+support custom HTTP methods, use one of the following methods:
 
 - Ideally, if you don't use hooks in your application, you can easily add the
   custom methods in your application setup by overriding the value of
@@ -358,7 +411,22 @@ To support custom HTTP methods, use one of the following methods:
 
 
 Once you have used the appropriate method, your custom methods should be active.
-You then can define request methods like any other HTTP method, such as::
+You then can define request methods like any other HTTP method:
 
-    def on_foo(self, req, resp):
-        ...
+.. tabs::
+
+    .. tab:: WSGI
+
+        .. code:: python
+
+            # Handle the custom FOO method
+            def on_foo(self, req, resp):
+                pass
+
+    .. tab:: ASGI
+
+        .. code:: python
+
+            # Handle the custom FOO method
+            async def on_foo(self, req, resp):
+                pass

--- a/docs/api/status.rst
+++ b/docs/api/status.rst
@@ -29,10 +29,10 @@ Or, using the more verbose name:
 Using these constants helps avoid typos and cuts down on the number of
 string objects that must be created when preparing responses.
 
-Falcon also provides a generic ``HTTPStatus`` class. Raise this class from a
-hook, middleware, or a responder to stop handling the request and skip to the
-response handling. It takes status, additional headers and body as input
-arguments.
+Falcon also provides a generic :class:`~.HTTPStatus` class. Simply raise an
+instance of this class from any hook, middleware, or a responder to stop
+handling the request and skip to the response handling. It takes status,
+additional headers and body as input arguments.
 
 HTTPStatus
 ----------

--- a/docs/api/status.rst
+++ b/docs/api/status.rst
@@ -3,12 +3,7 @@
 Status Codes
 ============
 
-* `HTTPStatus`_
-* `1xx Informational`_
-* `2xx Success`_
-* `3xx Redirection`_
-* `4xx Client Error`_
-* `5xx Server Error`_
+.. contents:: :local:
 
 Falcon provides a list of constants for common
 `HTTP response status codes <http://httpstatus.es>`_.
@@ -27,7 +22,11 @@ Or, using the more verbose name:
     resp.status = falcon.HTTP_CONFLICT
 
 Using these constants helps avoid typos and cuts down on the number of
-string objects that must be created when preparing responses.
+string objects that must be created when preparing responses. However,
+starting with Falcon version 3.0, an LRU is used to enable efficient use
+of :class:`http.HTTPStatus` and bare ``int`` codes as well (currently only
+implemented for the ASGI interface; see also:
+:attr:`~falcon.asgi.Response.status`).
 
 Falcon also provides a generic :class:`~.HTTPStatus` class. Simply raise an
 instance of this class from any hook, middleware, or a responder to stop

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -3,10 +3,7 @@
 Testing Helpers
 ===============
 
-* `General Helpers`_
-* `Simulating Requests`_
-    * `Main Interface`_
-    * `Low-Level Utils`_
+.. contents:: :local:
 
 .. automodule:: falcon.testing
     :noindex:
@@ -45,6 +42,9 @@ Main Interface
 .. autoclass:: Cookie
 .. autoclass:: TestClient
 .. autofunction:: capture_responder_args
+.. autofunction:: capture_responder_args_async
+.. autofunction:: set_resp_defaults
+.. autofunction:: set_resp_defaults_async
 
 Low-Level Utils
 ~~~~~~~~~~~~~~~

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -3,11 +3,7 @@
 Utilities
 =========
 
-* `URI`_
-* `Date and Time`_
-* `HTTP Status`_
-* `Async`_
-* `Other`_
+.. contents:: :local:
 
 URI
 ---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,6 +63,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
 
+    'sphinx_tabs.tabs',
+
     # Falcon-specific extensions
     'ext.rfc',
     'ext.doorway',

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -267,7 +267,7 @@ same resource class:
             pass
 
 
-    # ...
+    # -- snip --
 
 
     resource = MyResource()
@@ -384,7 +384,7 @@ order to handle all three routes:
             resp.data = b'{"message": "pong"}'
 
 
-    # ...
+    # -- snip --
 
 
     app = falcon.App()
@@ -423,14 +423,15 @@ around:
 .. code:: python
 
     def authorize(req, resp, resource, params):
-        # Check authentication/authorization
-        # ...
+        # TODO: Check authentication/authorization
+
+        # -- snip --
 
         req.context.role = 'root'
         req.context.scopes = ('storage', 'things')
         req.context.uid = 0
 
-    # ...
+    # -- snip --
 
     @falcon.before(authorize)
     def on_post(self, req, resp):
@@ -535,13 +536,11 @@ installed by default, thus making the POSTed form available as
 
     import falcon
 
-    # ...
 
     class MyResource:
         def on_post(self, req, resp):
-            form = req.media
             # TODO: Handle the submitted URL-encoded form
-            # ...
+            form = req.media
 
             # NOTE: Falcon chooses the right media handler automatically, but
             #   if we wanted to differentiate from, for instance, JSON, we
@@ -596,9 +595,10 @@ method, making it compatible with ``boto3``\'s
 .. code:: python
 
     import boto3
-    s3 = boto3.client('s3')
 
-    # ...
+    # -- snip --
+
+    s3 = boto3.client('s3')
 
     for part in req.media:
         if part.name == 'myfile':
@@ -745,7 +745,7 @@ types:
     class ResponseWithDictContext(falcon.Response):
         context_type = dict
 
-    # ...
+    # -- snip --
 
     app = falcon.App(request_type=RequestWithDictContext,
                      response_type=ResponseWithDictContext)
@@ -894,15 +894,18 @@ Then, within ``SomeResource``:
     # Read from the DB
     result = self._engine.execute(some_table.select())
     for row in result:
-        # ....
+        # TODO: Do something with each row
+
     result.close()
 
-    # ...
+    # -- snip --
 
     # Write to the DB within a transaction
     with self._engine.begin() as connection:
         r1 = connection.execute(some_table.select())
-        # ...
+
+        # -- snip --
+
         connection.execute(
             some_table.insert(),
             col1=7,

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -1332,7 +1332,7 @@ And then attach the hook to the ``on_post()`` responder:
 
     @falcon.before(validate_image_type)
     def on_post(self, req, resp):
-        # ...
+        pass
 
 Now, before every call to that responder, Falcon will first invoke
 ``validate_image_type()``. There isn't anything special about this
@@ -1366,8 +1366,7 @@ by simply decorating the class:
 
     @falcon.before(extract_project_id)
     class Message:
-
-        # ...
+        pass
 
 Similar logic can be applied globally with middleware.
 (See also: :ref:`falcon.middleware <middleware>`)

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -24,14 +24,14 @@ package namespace::
     class MessageResource:
         def on_get(self, req, resp):
 
-            # ...
+            # -- snip --
 
             raise falcon.HTTPBadRequest(
                 title='TTL Out of Range',
                 description='The message's TTL must be between 60 and 300 seconds, inclusive.'
             )
 
-            # ...
+            # -- snip --
 
 """
 

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -9,7 +9,7 @@ from falcon.vendor import mimeparse
 
 
 class Handlers(UserDict):
-    """A dictionary like object that manages internet media type handlers."""
+    """A :class:`dict`-like object that manages Internet media type handlers."""
     def __init__(self, initial=None):
         handlers = initial or {
             'application/json': JSONHandler(),

--- a/falcon/media/validators/jsonschema.py
+++ b/falcon/media/validators/jsonschema.py
@@ -47,16 +47,47 @@ def validate(req_schema=None, resp_schema=None, is_async=False):
             function is declared using ``async def``.
 
     Example:
-        .. code:: python
 
-            from falcon.media.validators import jsonschema
+        .. tabs::
 
-            # -- snip --
+            .. tab:: WSGI
 
-            @jsonschema.validate(my_post_schema)
-            def on_post(self, req, resp):
+                .. code:: python
 
-            # -- snip --
+                    from falcon.media.validators import jsonschema
+
+                    # -- snip --
+
+                    @jsonschema.validate(my_post_schema)
+                    def on_post(self, req, resp):
+
+                    # -- snip --
+
+            .. tab:: ASGI
+
+                .. code:: python
+
+                    from falcon.media.validators import jsonschema
+
+                    # -- snip --
+
+                    @jsonschema.validate(my_post_schema)
+                    async def on_post(self, req, resp):
+
+                    # -- snip --
+
+            .. tab:: ASGI (Cythonized App)
+
+                .. code:: python
+
+                    from falcon.media.validators import jsonschema
+
+                    # -- snip --
+
+                    @jsonschema.validate(my_post_schema, is_async=True)
+                    async def on_post(self, req, resp):
+
+                    # -- snip --
 
     """
 

--- a/falcon/testing/__init__.py
+++ b/falcon/testing/__init__.py
@@ -78,6 +78,7 @@ The testing framework supports both unittest and pytest::
 from falcon.testing.client import *  # NOQA
 from falcon.testing.helpers import *  # NOQA
 from falcon.testing.resource import capture_responder_args, set_resp_defaults  # NOQA
+from falcon.testing.resource import capture_responder_args_async, set_resp_defaults_async  # NOQA
 from falcon.testing.resource import SimpleTestResource, SimpleTestResourceAsync  # NOQA
 from falcon.testing.srmock import StartResponseMock  # NOQA
 from falcon.testing.test_case import TestCase  # NOQA

--- a/falcon/testing/resource.py
+++ b/falcon/testing/resource.py
@@ -65,7 +65,7 @@ def capture_responder_args(req, resp, resource, params):
 
 
 async def capture_responder_args_async(req, resp, resource, params):
-    """An asynchronous version of ``capture_responder_args()``."""
+    """An asynchronous version of :meth:`~falcon.testing.capture_responder_args`."""
 
     resource.captured_req = req
     resource.captured_resp = resp
@@ -82,7 +82,14 @@ async def capture_responder_args_async(req, resp, resource, params):
 
 
 def set_resp_defaults(req, resp, resource, params):
-    """Before hook for setting default response properties."""
+    """Before hook for setting default response properties.
+
+    This hook simply sets the the response body, status,
+    and headers to the `_default_status`,
+    `_default_body`, and `_default_headers` attributes
+    that are assumed to be defined on the resource
+    object.
+    """
 
     if resource._default_status is not None:
         resp.status = resource._default_status
@@ -95,7 +102,7 @@ def set_resp_defaults(req, resp, resource, params):
 
 
 async def set_resp_defaults_async(req, resp, resource, params):
-    """Wraps capture_responder_args in a coroutine."""
+    """Wraps :meth:`~falcon.testing.set_resp_defaults` in a coroutine."""
     set_resp_defaults(req, resp, resource, params)
 
 

--- a/falcon/testing/test_case.py
+++ b/falcon/testing/test_case.py
@@ -30,25 +30,26 @@ from falcon.testing.client import Result  # NOQA - hoist for backwards compat
 
 
 class TestCase(unittest.TestCase, TestClient):
-    """Extends :py:mod:`unittest` to support WSGI functional testing.
+    """Extends :py:mod:`unittest` to support WSGI/ASGI functional testing.
 
     Note:
         If available, uses :py:mod:`testtools` in lieu of
         :py:mod:`unittest`.
 
     This base class provides some extra plumbing for unittest-style
-    test cases, to help simulate WSGI calls without having to spin up
-    an actual web server. Various simulation methods are derived
-    from :py:class:`falcon.testing.TestClient`.
+    test cases, to help simulate WSGI or ASGI requests without having
+    to spin up an actual web server. Various simulation methods are
+    derived from :py:class:`falcon.testing.TestClient`.
 
     Simply inherit from this class in your test case classes instead of
     :py:class:`unittest.TestCase` or :py:class:`testtools.TestCase`.
 
     Attributes:
         app (object): A WSGI or ASGI application to target when simulating
-            requests (default: ``falcon.App()``). When testing your
+            requests (defaults to ``falcon.App()``). When testing your
             application, you will need to set this to your own instance
-            of ``falcon.App`` or ``falcon.asgi.App``. For example::
+            of :class:`falcon.App` or :class:`falcon.asgi.App`. For
+            example::
 
                 from falcon import testing
                 import myapp

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -232,7 +232,7 @@ class ETag(str):
                     resp.status = falcon.HTTP_304
                     return
 
-            # ...
+            # -- snip --
 
             resp.etag = content_etag
             resp.status = falcon.HTTP_200

--- a/requirements/docs
+++ b/requirements/docs
@@ -6,3 +6,4 @@ pygments
 pygments-style-github
 sphinx>=1.4.4,!=1.7.3
 sphinx_rtd_theme
+sphinx-tabs


### PR DESCRIPTION
This PR includes a number of updates to the reference pages in the docs to bring them up to date with ASGI and other code changes since 2.0. 

Outstanding 3.0 doc updates not covered by this PR:
* ASGI tutorial
* Final multipart docs
* WebSocket docs (if that feature does not get postponed to 3.1)