### PR TITLE
Set SameSite=Lax when un-setting cookies

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -499,6 +499,10 @@ class Response:
         # thus removing it from future request objects.
         self._cookies[name]['expires'] = -1
 
+        # NOTE(CaselIT): Set SameSite to Lax to avoid setting invalid cookies.
+        # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#Fixing_common_warnings  # noqa: E501
+        self._cookies[name]['samesite'] = 'Lax'
+
     def get_header(self, name, default=None):
         """Retrieve the raw string value for the given header.
 

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -151,6 +151,7 @@ def test_response_complex_case(client):
     cookie = result.cookies['bad']
     assert cookie.value == ''  # An unset cookie has an empty value
     assert cookie.domain is None
+    assert cookie.same_site == 'Lax'
 
     assert cookie.expires < datetime.utcnow()
 
@@ -233,7 +234,7 @@ def test_response_unset_cookie(client):
     len(morsels) == 1
 
     bad_cookie = morsels[0]
-    bad_cookie['expires'] == -1
+    assert bad_cookie['expires'] == -1
 
     output = bad_cookie.OutputString()
     assert 'bad=;' in output or 'bad="";' in output


### PR DESCRIPTION
# Summary of Changes

Set the cookie same site to `Lax` when un-setting cookies.
This avoids warning / invalid cookies https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#Fixing_common_warnings

# Related Issues
Closes #1721

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
