### PR TITLE
chore(Travis): temporarily disable the broken s390x gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,13 @@ matrix:
           env: TOXENV=py38
         - python: 3.8
           env: TOXENV=py38_cython
-        - python: 3.8
-          # NOTE(vytas): Big-endian architecture
-          arch: s390x
-          dist: bionic
-          os: linux
-          env: TOXENV=py38_cython
+        # TODO(vytas): Re-enable once issues are fixed on the Travis side.
+        # - python: 3.8
+        #   # NOTE(vytas): Big-endian architecture
+        #   arch: s390x
+        #   dist: bionic
+        #   os: linux
+        #   env: TOXENV=py38_cython
         - python: 3.8
           env: TOXENV=py38_smoke
         - python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ matrix:
         - python: 3.8
           # NOTE(vytas): Big-endian architecture
           arch: s390x
+          dist: bionic
           os: linux
           env: TOXENV=py38_cython
         - python: 3.8


### PR DESCRIPTION
Our `s390x` gate stopped working on Travis, probably because of: https://travis-ci.community/t/s390-xenial-builds-fail-with-an-error-occurred-while-generating-the-build-script/9039

However, it seems that unfortunately all distributions are affected; `s390x` is plainly broken on Travis at the time of writing. Let's disable the gate until it's fixed.