### PR TITLE
feat(asgi): support the ASGI WebSocket connection scope

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,17 +143,20 @@ and to debug edge cases in large-scale deployments.
 Features
 --------
 
--  Highly-optimized, extensible code base
--  Intuitive routing via URI templates and REST-inspired resource
-   classes
--  Easy access to headers and bodies through request and response
-   classes
--  DRY request processing via middleware components and hooks
--  Idiomatic HTTP error responses
--  Straightforward exception handling
--  Snappy unit testing through WSGI/ASGI helpers and mocks
--  CPython 3.5+ and PyPy 3.5+ support
--  ~20% speed boost under CPython when Cython is available
+- ASGI and WSGI Support
+- WebSocket Support
+- Strict adherence to RFCs
+- Highly-optimized, extensible code base
+- Intuitive routing via URI templates and REST-inspired resource
+  classes
+- Easy access to headers and bodies through request and response
+  classes
+- DRY request processing via middleware components and hooks
+- Idiomatic HTTP error responses
+- Straightforward exception handling
+- Snappy testing through WSGI/ASGI helpers and mocks
+- CPython 3.5+ and PyPy 3.5+ support
+- ~20% speed boost under CPython when Cython is available
 
 Who's Using Falcon?
 -------------------

--- a/docs/_newsfragments/321.newandimproved.rst
+++ b/docs/_newsfragments/321.newandimproved.rst
@@ -1,0 +1,1 @@
+ASGI+WebSocket support was added to the framework via :class:`falcon.asgi.App` and :class:`falcon.asgi.WebSocket`.

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -328,6 +328,7 @@ div.note, div.admonition {
     /* Match tab radius */
     border-radius: .285714rem;
     border-color: #eee;
+    padding-bottom: 1em;
 }
 
 div.ui.bottom.attached.sphinx-tab.tab {
@@ -344,4 +345,3 @@ div.highlight > pre {
 .sphinx-tab pre {
     border: none !important;
 }
-

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -6,6 +6,7 @@ Framework Reference
 
    app
    request_and_response
+   websocket
    cookies
    status
    errors

--- a/docs/api/media.rst
+++ b/docs/api/media.rst
@@ -13,9 +13,9 @@ specified on your :any:`falcon.App`.
 
 .. note::
 
-    To avoid unnecessary overhead, Falcon will only process request media
-    the first time the media property is referenced. Once it has been
-    referenced, it'll use the cached result for subsequent interactions.
+    WebSocket media is handled differently from regular HTTP requests. For
+    information regarding WebSocket media handlers, please
+    see: :ref:`ws_media_handlers`.
 
 Usage
 -----
@@ -78,7 +78,9 @@ do the heavy lifting for you.
 
     Once :meth:`falcon.Request.get_media()` or
     :meth:`falcon.asgi.Request.get_media()` is called on a request, it will
-    consume the request's body stream.
+    consume the request's body stream. To avoid unnecessary overhead, Falcon
+    will only process request media the first time it is referenced. Subsequent
+    interactions will use a cached object.
 
 Validating Media
 ----------------

--- a/docs/api/middleware.rst
+++ b/docs/api/middleware.rst
@@ -174,6 +174,41 @@ defined below.
                             otherwise False.
                     """
 
+                async def process_request_ws(self, req, ws):
+                    """Process a WebSocket handshake request before routing it.
+
+                    Note:
+                        Because Falcon routes each request based on req.path, a
+                        request can be effectively re-routed by setting that
+                        attribute to a new value from within process_request().
+
+                    Args:
+                        req: Request object that will eventually be
+                            passed into an on_websocket() responder method.
+                        ws: The WebSocket object that will be passed into
+                            on_websocket() after routing.
+                    """
+
+                async def process_resource_ws(self, req, ws, resource, params):
+                    """Process a WebSocket handshake request after routing.
+
+                    Note:
+                        This method is only called when the request matches
+                        a route to a resource.
+
+                    Args:
+                        req: Request object that will be passed to the
+                            routed responder.
+                        ws: WebSocket object that will be passed to the
+                            routed responder.
+                        resource: Resource object to which the request was
+                            routed.
+                        params: A dict-like object representing any additional
+                            params derived from the route's URI template fields,
+                            that will be passed to the resource's responder
+                            method as keyword arguments.
+                    """
+
 It is also possible to implement a middleware component that is compatible
 with both ASGI and WSGI apps. This is done by applying an `*_async` postfix
 to distinguish the two different versions of each middleware method, as in

--- a/docs/api/request_and_response.rst
+++ b/docs/api/request_and_response.rst
@@ -1,3 +1,5 @@
+.. _rr:
+
 Request & Response
 ==================
 

--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -5,7 +5,7 @@ Routing
 
 .. contents:: :local:
 
-Falcon routes incoming requests to resources based on a set of URI
+Falcon routes incoming requests (including :ref:`WebSocket handshakes <ws>`) to resources based on a set of URI
 templates. If the path requested by the client matches the template for
 a given route, the request is then passed on to the associated resource
 for processing.
@@ -85,17 +85,18 @@ Here's a quick example to show how all the pieces fit together:
             images = ImagesResource()
             app.add_route('/images', images)
 
-If no route matches the request, control then passes to a default
-responder that simply raises an instance of
-:class:`~.HTTPRouteNotFound`. By default, this error will be
-rendered as a 404 response, but this behavior can be modified by
-adding a custom error handler (see also
+If no route matches the request, control then passes to a default responder that
+simply raises an instance of :class:`~.HTTPRouteNotFound`. By default, this
+error will be rendered as a 404 response for a regular HTTP request, and a 403
+response with a 3404 close code for a :ref:`WebSocket <ws>` handshake. This
+behavior can be modified by adding a custom error handler (see also
 :ref:`this FAQ topic <faq_override_404_500_handlers>`).
 
-On the other hand, if a route is matched but the resource does not
-implement a responder for the requested HTTP method, the framework
-invokes a default responder that raises an instance of
-:class:`~.HTTPMethodNotAllowed`.
+On the other hand, if a route is matched but the resource does not implement a
+responder for the requested HTTP method, the framework invokes a default
+responder that raises an instance of :class:`~.HTTPMethodNotAllowed`. This class
+will be rendered by default as a 405 response for a regular HTTP request, and a
+403 response with a 3405 close code for a :ref:`WebSocket <ws>` handshake.
 
 Default Behavior
 ----------------

--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -24,6 +24,8 @@ Main Interface
    :members:
 .. autoclass:: ResultBodyStream
    :members:
+.. autoclass:: ASGIWebSocketSimulator
+   :members:
 .. autoclass:: Cookie
    :members:
 
@@ -57,6 +59,7 @@ Low-Level Utils
    :members:
 .. autofunction:: create_environ
 .. autofunction:: create_scope
+.. autofunction:: create_scope_ws
 .. autofunction:: create_req
 .. autofunction:: create_asgi_req
 .. autofunction:: closed_wsgi_iterable

--- a/docs/api/websocket.rst
+++ b/docs/api/websocket.rst
@@ -1,0 +1,435 @@
+.. _ws:
+
+WebSocket (ASGI Only)
+=====================
+
+.. contents:: :local:
+
+Falcon builds upon the
+`ASGI WebSocket Specification <https://asgi.readthedocs.io/en/latest/specs/www.html#websocket>`_
+to provide a simple, no-nonsense WebSocket server implementation.
+
+With support for both
+`WebSocket <https://tools.ietf.org/html/rfc6455>`_ and
+`Server-Sent Events <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events>`_ (SSE), Falcon facilitates real-time, event-oriented communication between an ASGI
+application and a web browser, mobile app, or other client application.
+
+.. note::
+
+    See also :attr:`falcon.asgi.Response.sse` to learn more about Falcon's
+    Server-Sent Event (SSE) support,
+
+Usage
+-----
+
+With Falcon you can easily add WebSocket support to any route in your ASGI
+app, simply by implementing an ``on_websocket()`` responder in the
+resource class for that route. As with regular
+HTTP requests, WebSocket flows can be augmented with middleware
+components and media handlers.
+
+When a WebSocket handshake arrives (via a standard HTTP request), Falcon will
+first route it as usual to a specific resource class instance. Along the way,
+the following middleware methods will be invoked, if implemented on any
+middleware objects configured for the app:
+
+.. code:: python
+
+    class SomeMiddleware:
+        async def process_request_ws(self, req, ws):
+            """Process a WebSocket handshake request before routing it.
+
+            Note:
+                Because Falcon routes each request based on req.path, a
+                request can be effectively re-routed by setting that
+                attribute to a new value from within process_request().
+
+            Args:
+                req: Request object that will eventually be
+                    passed into an on_websocket() responder method.
+                ws: The WebSocket object that will be passed into
+                    on_websocket() after routing.
+            """
+
+        async def process_resource_ws(self, req, ws, resource, params):
+            """Process a WebSocket handshake request after routing.
+
+            Note:
+                This method is only called when the request matches
+                a route to a resource.
+
+            Args:
+                req: Request object that will be passed to the
+                    routed responder.
+                ws: WebSocket object that will be passed to the
+                    routed responder.
+                resource: Resource object to which the request was
+                    routed.
+                params: A dict-like object representing any additional
+                    params derived from the route's URI template fields,
+                    that will be passed to the resource's responder
+                    method as keyword arguments.
+            """
+
+If a route is found for the requested path, the framework will then check for
+a responder coroutine named ``on_websocket()`` on the target resource. If the
+responder is found, it is invoked in a similar manner to a regular
+``on_get()`` responder, except that a :class:`falcon.asgi.WebSocket` object
+is passed in, instead of an object of type :class:`falcon.asgi.Response`.
+
+For example, given a route that includes an ``account_id`` path parameter, the
+framework would expect an ``on_websocket()`` responder similar to this:
+
+.. code:: python
+
+    async def on_websocket(self, req: Request, ws: WebSocket, account_id: str):
+        pass
+
+If no route matches the path requested in the WebSocket handshake, control then
+passes to a default responder that simply raises an instance of
+:class:`~.HTTPRouteNotFound`. By default, this error will be rendered as a 403
+response with a 3404 close code. This behavior can be modified by adding a
+custom error handler (see also: :meth:`~falcon.asgi.App.add_error_handler`).
+
+Similarly, if a route exists but the target resource does not implement an
+``on_websocket()`` responder, the framework invokes a default responder that
+raises an instance of :class:`~.HTTPMethodNotAllowed`. This class will be
+rendered by default as a 403 response with a 3405 close code.
+
+.. _ws_media_handlers:
+
+Media Handlers
+--------------
+
+By default, :meth:`~.falcon.asgi.WebSocket.send_media` and
+:meth:`~.falcon.asgi.WebSocket.receive_media` will serialize to (and
+deserialize from) JSON for a TEXT payload, and to/from MessagePack
+for a BINARY payload (see also: :ref:`bimh`).
+
+.. note::
+
+    In order to use the default MessagePack handler, the extra ``msgpack``
+    package (version 0.5.2 or higher) must be installed in addition
+    to ``falcon`` from PyPI:
+
+    .. code::
+
+        $ pip install msgpack
+
+WebSocket media handling can be customized by using
+:attr:`falcon.asgi.App.ws_options` to specify an alternative handler for
+one or both payload types, as in the following example.
+
+.. code:: python
+
+    # Let's say we want to use a faster JSON library. You could also use this
+    #   pattern to add serialization support for custom types that aren't
+    #   normally JSON-serializable out of the box.
+    class RapidJSONHandler(falcon.media.TextBaseHandlerWS):
+        def serialize(self, media: object) -> str:
+            return rapidjson.dumps(media, ensure_ascii=False)
+
+        # The raw TEXT payload will be passed as a Unicode string
+        def deserialize(self, payload: str) -> object:
+            return rapidjson.loads(payload)
+
+
+    # And/or for binary mode we want to use CBOR:
+    class CBORHandler(media.BinaryBaseHandlerWS):
+        def serialize(self, media: object) -> bytes:
+            return cbor2.dumps(media)
+
+        # The raw BINARY payload will be passed as a byte string
+        def deserialize(self, payload: bytes) -> object:
+            return cbor2.loads(payload)
+
+    app = falcon.asgi.App()
+
+    # Expected to (de)serialize from/to str
+    json_handler = RapidJSONHandler()
+    app.ws_options.media_handlers[falcon.WebSocketPayloadType.TEXT] = json_handler
+
+    # Expected to (de)serialize from/to bytes, bytearray, or memoryview
+    cbor_handler = ProtocolBuffersHandler()
+    app.ws_options.media_handlers[falcon.WebSocketPayloadType.BINARY] = cbor_handler
+
+The ``falcon`` module defines the following :py:class:`~enum.Enum` values for
+specifying the WebSocket payload type:
+
+.. code:: python
+
+    falcon.WebSocketPayloadType.TEXT
+    falcon.WebSocketPayloadType.BINARY
+
+Extended Example
+----------------
+
+Here is a more comprehensive (albeit rather contrived) example that illustrates
+some of the different ways an application can interact with a WebSocket
+connection. This example also introduces some common WebSocket errors raised
+by the framework.
+
+.. code:: python
+
+    import falcon.asgi
+    import falcon.media
+
+
+    class SomeResource:
+
+        # Get a paginated list of events via a regular HTTP request.
+        #
+        #   For small-scale, all-in-one apps, it may make sense to support
+        #   both a regular HTTP interface and one based on WebSocket
+        #   side-by-side in the same deployment. However, these two
+        #   interaction models have very different performance characteristics,
+        #   and so larger scale-out deployments may wish to specifically
+        #   designate instance groups for one type of traffic vs. the
+        #   other (although the actual applications may still be capable
+        #   of handling both modes).
+        #
+        async def on_get(self, req: Request, account_id: str):
+            pass
+
+        # Push event stream to client. Note that the framework will pass
+        #   parameters defined in the URI template as with HTTP method
+        #   responders.
+        async def on_websocket(self, req: Request, ws: WebSocket, account_id: str):
+
+            # The HTTP request used to initiate the WebSocket handshake can be
+            #   examined as needed.
+            some_header_value = req.get_header('Some-Header')
+
+            # Reject it?
+            if some_condition:
+                # If close() is called before accept() the code kwarg is
+                #   ignored, if present, and the server returns a 403
+                #   HTTP response without upgrading the connection.
+                await ws.close()
+                return
+
+            # Examine subprotocols advertised by the client. Here let's just
+            #   assume we only support wamp, so if the client doesn't advertise
+            #   it we reject the connection.
+            if 'wamp' not in ws.subprotocols:
+                # If close() is not called explicitly, the framework will
+                #   take care of it automatically with the default code (1000).
+                return
+
+            # If, after examining the connection info, you would like to accept
+            #   it, simply call accept() as follows:
+            try:
+                await ws.accept(subprotocol='wamp')
+            except WebSocketDisconnected:
+                return
+
+            # Simply start sending messages to the client if this is an event
+            #   feed endpoint.
+            while True:
+                try:
+                    event = await my_next_event()
+
+                    # Send an instance of str as a WebSocket TEXT (0x01) payload
+                    await ws.send_text(event)
+
+                    # Send an instance of bytes, bytearray, or memoryview as a
+                    #   WebSocket BINARY (0x02) payload.
+                    await ws.send_data(event)
+
+                    # Or if you want it to be serialized to JSON (by default; can
+                    #   be customized via app.ws_options.media_handlers):
+                    await ws.send_media(event)  # Defaults to WebSocketPayloadType.TEXT
+                except WebSocketDisconnected:
+                    # Do any necessary cleanup, then bail out
+                    return
+
+            # ...or loop like this to implement a simple request-response protocol
+            while True:
+                try:
+                    # Use this if you expect a WebSocket TEXT (0x01) payload,
+                    #   decoded from UTF-8 to a Unicode string.
+                    payload_str = await ws.receive_text()
+
+                    # Or if you are expecting a WebSocket BINARY (0x02) payload,
+                    #   in which case you will end up with a byte string result:
+                    payload_bytes = await ws.receive_data()
+
+                    # Or if you want to get a serialized media object (defaults to
+                    #   JSON deserialization of text payloads, and MessagePack
+                    #   deserialization for BINARY payloads, but this can be
+                    #   customized via app.ws_options.media_handlers).
+                    media_object = await ws.receive_media()
+
+                except WebSocketDisconnected:
+                    # Do any necessary cleanup, then bail out
+                    return
+                except TypeError:
+                    # The received message payload was not of the expected
+                    #   type (e.g., got BINARY when TEXT was expected).
+                    pass
+                except json.JSONDecodeError:
+                    # The default media deserializer uses the json standard
+                    #   library, so you might see this error raised as well.
+                    pass
+
+                # At any time, you may decide to close the websocket. If the
+                #   socket is already closed, this call does nothing (it will
+                #   not raise an error.)
+                if we_are_so_done_with_this_conversation():
+                    # https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+                    await ws.close(code=1000)
+                    return
+
+                try:
+                    # Here we are sending as a binary (0x02) payload type, which
+                    #   will go find the handler configured for that (defaults to
+                    #   MessagePack which assumes you've also installed that
+                    #   package, but this can be customized as mentioned above.')
+                    await ws.send_media(
+                        {'event': 'message'},
+                        payload_type=WebSocketPayloadType.BINARY,
+                    )
+
+                except WebSocketDisconnected:
+                    # Do any necessary cleanup, then bail out. If ws.close() was
+                    #   not already called by the app, the framework will take
+                    #   care of it.
+
+                    # NOTE: If you do not handle this exception, it will be
+                    #   bubbled up to a default error handler that simply
+                    #   logs the message as a warning and then closes the
+                    #   server side of the connection. This handler can be
+                    #   overwritten as with any other error handler for the app.
+
+                    # NOTE: If the error handler accepts an 'ws' kwarg, the framework
+                    #   will pass in the falcon.asgi.WebSocket instance.
+
+                    return
+
+            # ...or run a couple of different loops in parallel to support
+            #  independent bidirectional message streams.
+
+            messages = collections.deque()
+
+            async def sink():
+                while True:
+                    try:
+                        message = await ws.receive_text()
+                    except falcon.WebSocketDisconnected:
+                        break
+
+                    messages.append(message)
+
+            sink_task = falcon.create_task(sink())
+
+            while not sink_task.done():
+                while ws.ready and not messages and not sink_task.done():
+                    await asyncio.sleep(0)
+
+                try:
+                    await ws.send_text(messages.popleft())
+                except falcon.WebSocketDisconnected:
+                    break
+
+            sink_task.cancel()
+            try:
+                await sink_task
+            except asyncio.CancelledError:
+                pass
+
+
+    class SomeMiddleware:
+        async def process_request_ws(self, req: Request, ws: WebSocket):
+            # This will be called for the HTTP request that initiates the
+            #   WebSocket handshake before routing.
+            pass
+
+        async def process_resource_ws(self, req: Request, ws: WebSocket, resource, params):
+            # This will be called for the HTTP request that initiates the
+            #   WebSocket handshake after routing (if a route matches the
+            #   request).
+            pass
+
+
+    app = falcon.asgi.App(middleware=SomeMiddleware())
+    app.add_route('/{account_id}/messages', SomeResource())
+
+Testing
+-------
+
+Falcon's testing framework includes support for simulating WebSocket connections
+with the :class:`falcon.testing.ASGIConductor` class, as demonstrated in the
+following example.
+
+.. code:: python
+
+    # This context manages the ASGI app lifecycle, including lifespan events
+    async with testing.ASGIConductor(some_app) as c:
+        async def post_events():
+            for i in range(100):
+                await c.simulate_post('/events', json={'id': i}):
+                await asyncio.sleep(0.01)
+
+        async def get_events_ws():
+            # Simulate a WebSocket connection
+            async with c.simulate_ws('/events') as ws:
+                while some_condition:
+                    message = await ws.receive_text()
+
+        asyncio.gather(post_events(), get_events_ws())
+
+See also: :meth:`~falcon.testing.ASGIConductor.simulate_ws`.
+
+Reference
+---------
+
+WebSocket Class
+~~~~~~~~~~~~~~~
+
+The framework passes an instance of the following class into
+the ``on_websocket()`` responder. Conceptually, this class takes the place of the
+:class:`falcon.asgi.Response` class for WebSocket connections.
+
+.. autoclass:: falcon.asgi.WebSocket
+    :members:
+
+.. _bimh:
+
+Built-in Media Handlers
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: falcon.media.TextBaseHandlerWS
+    :members:
+
+.. autoclass:: falcon.media.BinaryBaseHandlerWS
+    :members:
+
+.. autoclass:: falcon.media.JSONHandlerWS
+    :no-members:
+
+.. autoclass:: falcon.media.MessagePackHandlerWS
+    :no-members:
+
+Error Types
+~~~~~~~~~~~
+
+.. autoclass:: falcon.WebSocketDisconnected
+    :members:
+
+.. autoclass:: falcon.WebSocketPathNotFound
+    :no-members:
+
+.. autoclass:: falcon.WebSocketHandlerNotFound
+    :no-members:
+
+.. autoclass:: falcon.WebSocketServerError
+    :no-members:
+
+.. autoclass:: falcon.PayloadTypeError
+    :no-members:
+
+Options
+~~~~~~~
+
+.. autoclass:: falcon.asgi.WebSocketOptions
+    :members:

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -57,17 +57,20 @@ and to debug edge cases in large-scale deployments.
 Features
 --------
 
+- :ref:`ASGI and WSGI <app>` Support
+- :ref:`WebSocket <ws>` Support
+- Strict adherence to RFCs
 - Highly-optimized, extensible code base
-- Intuitive routing via URI templates and REST-inspired resource
+- Intuitive :ref:`routing <routing>` via URI templates and REST-inspired resource
   classes
-- Easy access to headers and bodies through request and response
+- Easy access to headers and bodies through :ref:`request and response <rr>`
   classes
-- DRY request processing via middleware components and hooks
-- Idiomatic HTTP error responses
+- DRY request processing via :ref:`middleware <middleware>` components and hooks
+- Idiomatic :ref:`HTTP error <errors>` responses
 - Straightforward exception handling
-- Snappy unit testing through WSGI helpers and mocks
-- Supports Python 3.5+
-- Compatible with PyPy
+- Snappy :ref:`testing <testing>` through WSGI/ASGI helpers and mocks
+- CPython 3.5+ and PyPy 3.5+ support
+- ~20% speed boost under CPython when Cython is available
 
 About Apache 2.0
 ----------------

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -193,7 +193,11 @@ class App:
                  '_error_handlers', '_router', '_sinks',
                  '_serialize_error', 'req_options', 'resp_options',
                  '_middleware', '_independent_middleware', '_router_search',
-                 '_static_routes', '_cors_enable', '_unprepared_middleware')
+                 '_static_routes', '_cors_enable', '_unprepared_middleware',
+
+                 # NOTE(kgriffs): WebSocket is currently only supported for
+                 #   ASGI apps, but we may add support for WSGI at some point.
+                 '_middleware_ws')
 
     def __init__(self, media_type=DEFAULT_MEDIA_TYPE,
                  request_type=Request, response_type=Response,
@@ -815,7 +819,7 @@ class App:
         """
 
         path = req.path
-        method = req.method
+        method = 'WEBSOCKET' if req.is_websocket else req.method
         uri_template = None
 
         route = self._router_search(path, req=req)

--- a/falcon/asgi/__init__.py
+++ b/falcon/asgi/__init__.py
@@ -37,3 +37,4 @@ from .structures import SSEvent  # NOQA
 from .request import Request  # NOQA
 from .response import Response  # NOQA
 from .stream import BoundedStream  # NOQA
+from .ws import WebSocket, WebSocketOptions  # NOQA

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -19,9 +19,14 @@ from inspect import isasyncgenfunction, iscoroutinefunction
 import traceback
 
 import falcon.app
-from falcon.app_helpers import prepare_middleware
-from falcon.asgi_spec import EventType
-from falcon.errors import CompatibilityError, UnsupportedError, UnsupportedScopeError
+from falcon.app_helpers import prepare_middleware, prepare_middleware_ws
+from falcon.asgi_spec import EventType, WSCloseCode
+from falcon.errors import (
+    CompatibilityError,
+    UnsupportedError,
+    UnsupportedScopeError,
+    WebSocketDisconnected,
+)
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
 from falcon.media.multipart import MultipartFormHandler
@@ -32,12 +37,14 @@ from .multipart import MultipartForm
 from .request import Request
 from .response import Response
 from .structures import SSEvent
+from .ws import WebSocket, WebSocketOptions
 
-# TODO(vytas): Clean up these foul workarounds when we drop Python 3.5 support.
-MultipartFormHandler._ASGI_MULTIPART_FORM = MultipartForm  # type: ignore
 
 __all__ = ['App']
 
+
+# TODO(vytas): Clean up these foul workarounds when we drop Python 3.5 support.
+MultipartFormHandler._ASGI_MULTIPART_FORM = MultipartForm  # type: ignore
 
 _EVT_RESP_EOF = {'type': EventType.HTTP_RESPONSE_BODY}
 
@@ -52,6 +59,8 @@ _TYPELESS_STATUS_CODES = frozenset([
     204,
     304,
 ])
+
+_FALLBACK_WS_ERROR_CODE = 3011
 
 
 class App(falcon.app.App):
@@ -169,7 +178,7 @@ class App(falcon.app.App):
                             resp: Response object that will be passed to the
                                 responder.
                             resource: Resource object to which the request was
-                                routed. May be None if no route was found for
+                                routed. May be ``None`` if no route was found for
                                 the request.
                             params: A dict-like object representing any
                                 additional params derived from the route's URI
@@ -185,7 +194,7 @@ class App(falcon.app.App):
                             req: Request object.
                             resp: Response object.
                             resource: Resource object to which the request was
-                                routed. May be None if no route was found
+                                routed. May be ``None`` if no route was found
                                 for the request.
                             req_succeeded: True if no exceptions were raised
                                 while the framework processed and routed the
@@ -228,6 +237,8 @@ class App(falcon.app.App):
             requests. (See also: :py:class:`~.RequestOptions`)
         resp_options: A set of behavioral options related to outgoing
             responses. (See also: :py:class:`~.ResponseOptions`)
+        ws_options: A set of behavioral options related to WebSocket
+            connections. (See also: :py:class:`~.WebSocketOptions`)
         router_options: Configuration options for the router. If a
             custom router is in use, and it does not expose any
             configurable options, referencing this attribute will raise
@@ -248,6 +259,10 @@ class App(falcon.app.App):
 
     def __init__(self, *args, request_type=Request, response_type=Response, **kwargs):
         super().__init__(*args, request_type=request_type, response_type=response_type, **kwargs)
+
+        self.ws_options = WebSocketOptions()
+
+        self.add_error_handler(WebSocketDisconnected, self._ws_disconnected_error_handler)
 
     async def __call__(self, scope, receive, send):  # noqa: C901
         try:
@@ -291,6 +306,30 @@ class App(falcon.app.App):
                     )
 
                 await self._call_lifespan_handlers(spec_version, scope, receive, send)
+                return
+
+            elif scope_type == 'websocket':
+                try:
+                    spec_version = asgi_info['spec_version']
+                except KeyError:
+                    spec_version = '2.0'
+
+                if not spec_version.startswith('2.'):
+                    raise UnsupportedScopeError(
+                        'Only versions 2.x of the ASGI "websocket" scope are supported.'
+                    )
+
+                try:
+                    http_version = scope['http_version']
+                except KeyError:
+                    http_version = '1.1'
+
+                if http_version not in {'1.1', '2', '3'}:
+                    raise UnsupportedError(
+                        f'The ASGI "websocket" scope does not support HTTP version {http_version}.'
+                    )
+
+                await self._handle_websocket(spec_version, scope, receive, send)
                 return
 
             # NOTE(kgriffs): According to the ASGI spec: "Applications should
@@ -650,7 +689,7 @@ class App(falcon.app.App):
         by ``custom_handle_404()``, not by ``custom_handle_not_found()``, because
         ``custom_handle_404()`` was registered more recently.
 
-        .. Note::
+        Note:
 
             By default, the framework installs three handlers, one for
             :class:`~.HTTPError`, one for :class:`~.HTTPStatus`, and one for
@@ -658,19 +697,45 @@ class App(falcon.app.App):
             exceptions to the WSGI server. These can be overridden by adding a
             custom error handler method for the exception type in question.
 
+            When a generic unhandled exception is raised while
+            handling a :ref:`WebSocket <ws>` connection, the default handler will
+            close the connection with the standard close code ``1011`` (Internal
+            Error). If your ASGI server does not support this code, the
+            framework will use code ``3011`` instead; or you can customize
+            it via the
+            :attr:`~falcon.asgi.WebSocketOptions.error_close_code`
+            property of :attr:`~.ws_options`.
+
+            On the other hand, if a ``on_websocket()`` handler raises an
+            instance of :class:`~falcon.HTTPError`, the default error handler
+            will close the :ref:`WebSocket <ws>` connection with a framework
+            close code derived by adding ``3000`` to the HTTP status code (e.g.,
+            ``3404``)
+
         Args:
             exception (type or iterable of types): When handling a request,
                 whenever an error occurs that is an instance of the specified
                 type(s), the associated handler will be called. Either a single
                 type or an iterable of types may be specified.
-            handler (callable): A coroutine function taking the form
-                ``async func(req, resp, ex, params)``.
 
-                If not specified explicitly, the handler will default to
-                ``exception.handle``, where ``exception`` is the error
-                type specified above, and ``handle`` is a static method
-                (i.e., decorated with ``@staticmethod``) that accepts
-                the same params just described. For example::
+        Keyword Args:
+            handler (callable): A coroutine function taking the
+                form::
+
+                    async func(req, resp, ex, params, ws=None):
+                        pass
+
+                In the case of a WebSocket connection, the `resp` argument
+                will be ``None``, while the `ws` keyword argument
+                will receive the :class:`~falcon.asgi.WebSocket` object
+                representing the connection.
+
+                If the `handler` keyword argument is not provided to
+                :meth:`~.add_error_handler`, the handler will default to
+                ``exception.handle``, where ``exception`` is the error type
+                specified above, and ``handle`` is a static method (i.e.,
+                decorated with ``@staticmethod``) that accepts the params
+                just described. For example::
 
                     class CustomException(CustomBaseException):
 
@@ -680,8 +745,9 @@ class App(falcon.app.App):
                             # Convert to an instance of falcon.HTTPError
                             raise falcon.HTTPError(falcon.HTTP_792)
 
-                If an iterable of exception types is specified instead of
-                a single type, the handler must be explicitly specified.
+                Note, however, that if an iterable of exception types is
+                specified instead of a single type, the handler must be
+                explicitly specified using the `handler` keyword argument.
         """
 
         if handler is None:
@@ -767,7 +833,59 @@ class App(falcon.app.App):
                 await send({'type': EventType.LIFESPAN_SHUTDOWN_COMPLETE})
                 return
 
+    async def _handle_websocket(self, ver, scope, receive, send):
+        first_event = await receive()
+        if first_event['type'] != EventType.WS_CONNECT:
+            # The handshake was abandoned or this is a message we don't
+            #   support, so bail out.
+            await send({
+                'type': EventType.WS_CLOSE,
+                'code': WSCloseCode.SERVER_ERROR
+            })
+            return
+
+        req = self._request_type(scope, receive, options=self.req_options)
+
+        web_socket = WebSocket(
+            ver,
+            scope,
+            receive,
+            send,
+            self.ws_options.media_handlers,
+            self.ws_options.max_receive_queue,
+        )
+
+        on_websocket = None
+        params = {}
+
+        request_mw, resource_mw = self._middleware_ws
+
+        try:
+            for process_request_ws in request_mw:
+                await process_request_ws(req, web_socket)
+
+            on_websocket, params, resource, req.uri_template = self._get_responder(req)
+
+            # NOTE(kgriffs): If the request did not match any
+            # route, a default responder is returned and the
+            # resource is None. In that case, we skip the
+            # resource middleware methods. Resource will also be
+            # None when a middleware method already set
+            # resp.complete to True.
+            if resource:
+                for process_resource_ws in resource_mw:
+                    await process_resource_ws(req, web_socket, resource, params)
+
+            await on_websocket(req, web_socket, **params)
+            await web_socket.close()
+
+        except Exception as ex:
+            if not await self._handle_exception(req, None, ex, params, ws=web_socket):
+                raise
+
     def _prepare_middleware(self, middleware=None, independent_middleware=False):
+        self._middleware_ws = prepare_middleware_ws(middleware)
+
         return prepare_middleware(
             middleware=middleware,
             independent_middleware=independent_middleware,
@@ -777,24 +895,48 @@ class App(falcon.app.App):
     async def _http_status_handler(self, req, resp, status, params):
         self._compose_status_response(req, resp, status)
 
-    async def _http_error_handler(self, req, resp, error, params):
-        self._compose_error_response(req, resp, error)
+    async def _http_error_handler(self, req, resp, error, params, ws=None):
+        if resp:
+            self._compose_error_response(req, resp, error)
 
-    async def _python_error_handler(self, req, resp, error, params):
-        falcon._logger.error('Unhandled exception in ASGI app', exc_info=error)
-        self._compose_error_response(req, resp, falcon.HTTPInternalServerError())
+        if ws:
+            falcon._logger.error(
+                '[FALCON] WebSocket handshake rejected due to raised HTTP error: %s',
+                error
+            )
 
-    async def _handle_exception(self, req, resp, ex, params):
+            code = 3000 + falcon.util.http_status_to_code(error.status)
+            await ws.close(code)
+
+    async def _python_error_handler(self, req, resp, error, params, ws=None):
+        falcon._logger.error('[FALCON] Unhandled exception in ASGI app', exc_info=error)
+
+        if resp:
+            self._compose_error_response(req, resp, falcon.HTTPInternalServerError())
+
+        if ws:
+            await self._ws_cleanup_on_error(ws)
+
+    async def _ws_disconnected_error_handler(self, req, resp, error, params, ws):
+        falcon._logger.debug('[FALCON] WebSocket client disconnected with code %i', error.code)
+        await self._ws_cleanup_on_error(ws)
+
+    async def _handle_exception(self, req, resp, ex, params, ws=None):
         """Handle an exception raised from mw or a responder.
 
         Args:
             ex: Exception to handle
-            req: Current request object to pass to the handler
-                registered for the given exception type
-            resp: Current response object to pass to the handler
-                registered for the given exception type
+            req: Current request object to pass to the handler registered for
+                the given exception type
+            resp: Current response object to pass to the handler registered for
+                the given exception type. Will be ``None`` in the case of a
+                WebSocket request.
             params: Responder params to pass to the handler
                 registered for the given exception type
+
+        Keyword Args:
+            ws: WebSocket instance in the case that the error was raised while
+                handling a WebSocket connection.
 
         Returns:
             bool: ``True`` if a handler was found and called for the
@@ -802,11 +944,19 @@ class App(falcon.app.App):
         """
         err_handler = self._find_error_handler(ex)
 
-        # NOTE(caselit): Reset body, data and media before calling the handler
-        resp.body = resp.data = resp.media = None
+        if resp:
+            # NOTE(caselit): Reset body, data and media before calling the handler
+            resp.body = resp.data = resp.media = None
+
         if err_handler is not None:
             try:
-                await err_handler(req, resp, ex, params)
+                kwargs = {}
+
+                if ws and 'ws' in falcon.util.get_argnames(err_handler):
+                    kwargs['ws'] = ws
+
+                await err_handler(req, resp, ex, params, **kwargs)
+
             except HTTPStatus as status:
                 self._compose_status_response(req, resp, status)
             except HTTPError as error:
@@ -819,3 +969,24 @@ class App(falcon.app.App):
         # would have matched one of the corresponding default
         # handlers.
         return False
+
+    async def _ws_cleanup_on_error(self, ws):
+        # NOTE(kgriffs): Attempt to close cleanly on our end
+        try:
+            await ws.close(self.ws_options.error_close_code)
+        except Exception as ex:
+            # NOTE(kgriffs): This can be raised by Daphne. We also
+            #   may raise it ourselves for errors codes < 1000, but in that
+            #   case we just include this string in the exception message
+            #   to make it easier to verify test coverage of the following.
+            if 'invalid close code' in str(ex).lower():
+                await ws.close(_FALLBACK_WS_ERROR_CODE)
+            else:
+                falcon._logger.warning(
+                    (
+                        '[FALCON] Attempt to close web connection cleanly '
+                        'failed due to raised error.'
+                    ),
+                    exc_info=True
+                )
+                raise

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -406,10 +406,16 @@ class Response(falcon.response.Response):
         if media_type is not None and 'content-type' not in headers:
             headers['content-type'] = media_type
 
-        items = [(n.encode(), v.encode()) for n, v in headers.items()]
+        try:
+            items = [(n.encode('ascii'), v.encode('ascii')) for n, v in headers.items()]
+        except UnicodeEncodeError as ex:
+            raise ValueError(
+                'The modern series of HTTP standards require that header names and values '
+                f'use only ASCII characters: {ex}'
+            )
 
         if self._extra_headers:
-            items += [(n.encode(), v.encode()) for n, v in self._extra_headers]
+            items += [(n.encode('ascii'), v.encode('ascii')) for n, v in self._extra_headers]
 
         # NOTE(kgriffs): It is important to append these after self._extra_headers
         #   in case the latter contains Set-Cookie headers that should be
@@ -423,6 +429,6 @@ class Response(falcon.response.Response):
             #
             # Even without the .split("\\r\\n"), the below
             # is still ~17% faster, so don't use .output()
-            items += [(b'set-cookie', c.OutputString().encode())
+            items += [(b'set-cookie', c.OutputString().encode('ascii'))
                       for c in self._cookies.values()]
         return items

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -1,0 +1,671 @@
+import asyncio
+import collections
+from enum import Enum
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Deque,
+    Dict,
+    Iterable,
+    Mapping,
+    Optional,
+    Union,
+)
+
+import falcon
+from falcon import errors, media
+from falcon.asgi_spec import EventType, WSCloseCode
+from falcon.constants import WebSocketPayloadType
+
+
+_WebSocketState = Enum('_WebSocketState', 'HANDSHAKE ACCEPTED CLOSED')
+
+
+__all__ = ['WebSocket']
+
+
+class WebSocket:
+    """Represents a single WebSocket connection with a client.
+
+    Attributes:
+        ready (bool): ``True`` if the WebSocket connection has been
+            accepted and the client is still connected, ``False`` otherwise.
+        unaccepted (bool)): ``True`` if the WebSocket connection has not yet
+            been accepted, ``False`` otherwise.
+        closed (bool): ``True`` if the WebSocket connection has been closed
+            by the server or the client has disconnected.
+        subprotocols (tuple[str]): The list of subprotocol strings advertised
+            by the client, or an empty tuple if no subprotocols were
+            specified.
+        supports_accept_headers (bool): ``True`` if the ASGI server hosting
+            the app supports sending headers when accepting the WebSocket
+            connection, ``False`` otherwise.
+
+    """
+
+    __slots__ = (
+        '_asgi_receive',
+        '_asgi_send',
+        '_buffered_receiver',
+        '_close_code',
+        '_supports_accept_headers',
+        '_mh_bin_deserialize',
+        '_mh_bin_serialize',
+        '_mh_text_deserialize',
+        '_mh_text_serialize',
+        '_state',
+        'subprotocols',
+    )
+
+    def __init__(
+        self,
+        ver: str,
+        scope: dict,
+        receive: Callable[[], Awaitable[dict]],
+        send: Callable[[dict], Awaitable],
+        media_handlers: Mapping[
+            WebSocketPayloadType,
+            Union[media.BinaryBaseHandlerWS, media.TextBaseHandlerWS]
+        ],
+        max_receive_queue: int,
+    ):
+        self._supports_accept_headers = (ver != '2.0')
+
+        # NOTE(kgriffs): Normalize the iterable to a stable tuple; note that
+        #   ordering is significant, and so we preserve it here.
+        self.subprotocols = tuple(scope.get('subprotocols', []))
+
+        # TODO(kgriffs): Should we make the use of _BufferedReceiver
+        #   configurable? For example, if the developer knows that
+        #   they will be interleaving receives and sends, then they
+        #   will be able to find out about the 'websocket.disconnect'
+        #   event via one of their receive() calls, and there is no
+        #   need for the added overhead.
+        #
+        #   On the other hand, using _BufferedReceiver may still be
+        #   useful in the case of a server that does not have any
+        #   back pressure handling (even though _BufferedReceiver
+        #   only provides somewhat unsophisticated back pressure
+        #   mitigation, it is probably better than nothing).
+        self._buffered_receiver = _BufferedReceiver(receive, max_receive_queue)
+        self._asgi_receive = self._buffered_receiver.receive
+        self._asgi_send = send
+
+        mh_text = media_handlers[WebSocketPayloadType.TEXT]
+        self._mh_text_serialize = mh_text.serialize
+        self._mh_text_deserialize = mh_text.deserialize
+
+        mh_bin = media_handlers[WebSocketPayloadType.BINARY]
+        self._mh_bin_serialize = mh_bin.serialize
+        self._mh_bin_deserialize = mh_bin.deserialize
+
+        self._state = _WebSocketState.HANDSHAKE
+        self._close_code = None  # type: Optional[int]
+
+    @property
+    def unaccepted(self) -> bool:
+        return self._state == _WebSocketState.HANDSHAKE
+
+    @property
+    def closed(self) -> bool:
+        return (
+            self._state == _WebSocketState.CLOSED or
+            self._buffered_receiver.client_disconnected
+        )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self._state == _WebSocketState.ACCEPTED and
+            not self._buffered_receiver.client_disconnected
+        )
+
+    @property
+    def supports_accept_headers(self) -> bool:
+        return self._supports_accept_headers
+
+    async def accept(
+        self,
+        subprotocol: Optional[str] = None,
+        headers: Optional[Union[Iterable[Iterable[str]], Mapping[str, str]]] = None
+    ):
+        """Accept the incoming WebSocket connection.
+
+        If, after examining the connection's attributes (headers, advertised
+        subprotocols, etc.) the request should be accepted, the responder must
+        first await this coroutine method to finalize the WebSocket handshake.
+        Alternatively, the responder may deny the connection request by awaiting
+        the :meth:`~.close` method.
+
+        Keyword Arguments:
+            subprotocol (str): The subprotocol the app wishes to accept,
+                out of the list of protocols that the client suggested. If
+                more than one of the suggested protocols is acceptable,
+                the first one in the list from the client should be
+                selected (see also: :attr:`~.subprotocols`).
+
+                When left unspecified, a Sec-WebSocket-Protocol header will
+                not be included in the response to the client. The
+                client may choose to abandon the connection in this case,
+                if it does not receive an explicit protocol selection.
+
+            headers (Iterable[[str, str]]): An iterable of ``[name: str, value: str]``
+                two-item iterables, representing a collection of HTTP headers to
+                include in the handshake response. Both *name* and *value* must
+                be of type ``str`` and contain only US-ASCII characters.
+
+                Alternatively, a dict-like object may be passed that implements
+                an ``items()`` method.
+
+                Note:
+                    This argument is only supported for ASGI servers that
+                    implement spec version 2.1 or better. If an app needs to
+                    be compatible with multiple ASGI servers, it can
+                    reference the :attr:`~.supports_accept_headers` property to
+                    determine if the hosting server supports this feature.
+
+        """
+
+        if self.closed:
+            raise errors.OperationNotAllowed(
+                'accept() may not be called on a closed WebSocket connection'
+            )
+
+        if self._state != _WebSocketState.HANDSHAKE:
+            raise errors.OperationNotAllowed(
+                'accept() may only be called once on an open WebSocket connection'
+            )
+
+        event: Dict[str, Any] = {
+            'type': EventType.WS_ACCEPT,
+        }
+
+        if subprotocol is not None:
+            if not isinstance(subprotocol, str):
+                raise ValueError('WebSocket subprotocol must be a string')
+
+            event['subprotocol'] = subprotocol
+
+        if headers:
+            if not self._supports_accept_headers:
+                raise errors.OperationNotAllowed(
+                    'The ASGI server that is running this app '
+                    'does not support accept headers.'
+                )
+
+            header_items = getattr(headers, 'items', None)
+
+            if callable(header_items):
+                headers = header_items()
+
+            event['headers'] = parsed_headers = [
+                (name.lower().encode('ascii'), value.encode('ascii'))
+                for name, value in headers  # type: ignore
+            ]
+
+            for name, __ in parsed_headers:
+                if name == b'sec-websocket-protocol':
+                    raise ValueError(
+                        'Per the ASGI spec, the headers iterable must not '
+                        'contain "sec-websocket-protocol". Instead, the '
+                        'subprotocol argument can be used to indicate the '
+                        'accepted protocol.'
+                    )
+
+        await self._send(event)
+        self._state = _WebSocketState.ACCEPTED
+
+        self._buffered_receiver.start()
+
+        # NOTE(kgriffs): We have to buffer received events so that we
+        #   will know when a disconnect happens and we can alert the app
+        #   via falcon.errors.WebSocketDisconnected so that the app knows
+        #   it should bail out if it is just emitting a series of messages
+        #   without ever reading any from the client.
+        #
+        # TODO(kgriffs): Bring this use case to the attention of the
+        #   ASGI spec committee and see if they can't come up with a better
+        #   way to deal with this.
+
+    async def close(self, code: Optional[int] = None) -> None:
+        """Close the WebSocket connection.
+
+        This coroutine method sends a WebSocket ``CloseEvent`` to the client and
+        then proceeds to actually close the connection.
+
+        The responder can also use this method to deny a connection request
+        simply by awaiting it instead of :meth:`~.accept`. In this case,
+        the client will receive an HTTP 403 response to the handshake.
+
+        Keyword Arguments:
+            code (int): The close code to use for the `CloseEvent` (default
+                1000). See also: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+
+        """
+
+        # NOTE(kgriffs): Do this first to be sure we clean things up
+        #   in the case that we are going to raise an error next.
+        await self._buffered_receiver.stop()
+
+        if code is None:
+            code = WSCloseCode.NORMAL
+        elif not isinstance(code, int):
+            raise ValueError('code must be an int')
+        elif code < 1000:
+            raise ValueError('Invalid close code. The value must be >= 1000')
+        elif (1015 <= code <= 1999 or 1004 <= code <= 1006):
+            raise ValueError('Invalid close code. Only unreserved codes may be used.')
+
+        # NOTE(kgriffs): Only do this after we validate the code, to avoid
+        #   masking errors.
+        if self.closed:
+            return
+
+        await self._asgi_send({
+            'type': EventType.WS_CLOSE,
+            'code': code,
+        })
+
+        self._state = _WebSocketState.CLOSED
+        self._close_code = code
+
+    async def send_media(
+        self,
+        media: object,
+        payload_type: WebSocketPayloadType = WebSocketPayloadType.TEXT
+    ) -> None:
+        """Send a serializable object to the client.
+
+        The payload type determines the media handler that will be used
+        to serialize the given object (see also: :ref:`ws_media_handlers`).
+
+        Arguments:
+            media (object): The object to send.
+
+        Keyword Arguments:
+            payload_type (falcon.WebSocketPayloadType): The payload type to
+                use for the message (default ``falcon.WebSocketPayloadType.TEXT``).
+
+                Must be one of:
+
+                .. code:: python
+
+                    falcon.WebSocketPayloadType.TEXT
+                    falcon.WebSocketPayloadType.BINARY
+        """
+
+        self._require_accepted()
+
+        if payload_type is WebSocketPayloadType.TEXT:
+            await self._send({
+                'type': EventType.WS_SEND,
+                'text': self._mh_text_serialize(media),
+            })
+        else:
+            await self._send({
+                'type': EventType.WS_SEND,
+                'bytes': self._mh_bin_serialize(media),
+            })
+
+    async def send_text(self, payload: str) -> None:
+        """Send a message to the client with a Unicode string payload.
+
+        Arguments:
+            payload (str): The string to send.
+        """
+
+        self._require_accepted()
+
+        # NOTE(kgriffs): We have to check ourselves because some ASGI
+        #   servers are not very strict which can lead to hard-to-debug
+        #   errors.
+        if not isinstance(payload, str):
+            raise TypeError('payload must be a string')
+
+        await self._send({
+            'type': EventType.WS_SEND,
+            'text': payload,
+        })
+
+    async def send_data(self, payload: Union[bytes, bytearray, memoryview]) -> None:
+        """Send a message to the client with a binary data payload.
+
+        Arguments:
+            payload (Union[bytes, bytearray, memoryview]): The binary data to send.
+        """
+
+        # NOTE(kgriffs): We have to check ourselves because some ASGI
+        #   servers are not very strict which can lead to hard-to-debug
+        #   errors.
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError('payload must be a byte string')
+
+        self._require_accepted()
+
+        await self._send({
+            'type': EventType.WS_SEND,
+            'bytes': bytes(payload),
+        })
+
+    async def receive_text(self) -> str:
+        """Receive a message from the client with a Unicode string payload.
+
+        Awaiting this coroutine will block until a message is available or
+        the WebSocket is disconnected.
+        """
+
+        self._require_accepted()
+
+        event = await self._receive()
+
+        # PERF(kgriffs): When we normally expect the key to be
+        #   present, this pattern is faster than get()
+        try:
+            text = event['text']
+        except KeyError:
+            text = None
+
+        # NOTE(kgriffs): Even if the key is present, it may be None
+        if text is None:
+            raise errors.PayloadTypeError('Missing TEXT (0x01) payload')
+
+        return text
+
+    async def receive_data(self) -> bytes:
+        """Receive a message from the client with a binary data payload.
+
+        Awaiting this coroutine will block until a message is available or
+        the WebSocket is disconnected.
+        """
+
+        self._require_accepted()
+
+        event = await self._receive()
+
+        # PERF(kgriffs): When we normally expect the key to be
+        #   present, EAFP is faster than get()
+        try:
+            data = event['bytes']
+        except KeyError:
+            data = None
+
+        # NOTE(kgriffs): Even if the key is present, it may be None
+        if data is None:
+            raise errors.PayloadTypeError('Missing BINARY (0x02) payload')
+
+        return data
+
+    async def receive_media(self) -> object:
+        """Receive a deserialized object from the client.
+
+        The incoming payload type determines the media handler that will be used
+        to deserialize the object (see also: :ref:`ws_media_handlers`).
+        """
+
+        self._require_accepted()
+
+        event = await self._receive()
+
+        # NOTE(kgriffs): Most likely case is going to be JSON via text
+        #   payload, so try that first.
+        text = event.get('text')
+        if text is not None:
+            return self._mh_text_deserialize(text)
+
+        # PERF(kgriffs): At this point there better be a 'bytes' key, so
+        #   use EAFP this time.
+        try:
+            data = event['bytes']
+        except KeyError:
+            data = None
+
+        # NOTE(kgriffs): Even if the key is present, it may be None
+        if data is None:
+            raise errors.PayloadTypeError(
+                'Message did not contain either a TEXT (0x01) or BINARY (0x02) payload'
+            )
+
+        return self._mh_bin_deserialize(data)
+
+    async def _send(self, msg: dict):
+        if self._buffered_receiver.client_disconnected:
+            self._state = _WebSocketState.CLOSED
+            self._close_code = self._buffered_receiver.client_disconnected_code
+            raise errors.WebSocketDisconnected(self._close_code)
+
+        try:
+            await self._asgi_send(msg)
+        except Exception as ex:
+            # NOTE(kgriffs): If uvicorn or any other server using the
+            #   the "websockets" library that allows exceptions to bubble up,
+            #   we will have an error raised on client disconnect.
+            #
+            #   Daphne, on the other hand, does not raise an error but just
+            #   eats the message. This approach is actually more in keeping
+            #   with the ASGI spec, but poses its own challenges.
+
+            translated_ex = self._translate_webserver_error(ex)
+            if translated_ex:
+                raise translated_ex
+
+            # NOTE(kgriffs): Re-raise other errors directly so that we don't
+            #   obscure the traceback.
+            raise
+
+    async def _receive(self) -> dict:
+        event = await self._asgi_receive()
+
+        event_type = event['type']
+
+        if event_type != EventType.WS_RECEIVE:
+            # NOTE(kgriffs): Based on the ASGI spec, there are no other
+            #   event types that should be emitted by the protocol server,
+            #   but we sanity-check it here just in case.
+            assert event_type == EventType.WS_DISCONNECT
+
+            self._state = _WebSocketState.CLOSED
+            self._close_code = event.get('code', WSCloseCode.NORMAL)
+            raise errors.WebSocketDisconnected(self._close_code)
+
+        return event
+
+    def _require_accepted(self):
+        if self._state == _WebSocketState.HANDSHAKE:
+            raise errors.OperationNotAllowed('WebSocket connection has not yet been accepted')
+        elif self._state == _WebSocketState.CLOSED:
+            raise errors.WebSocketDisconnected(self._close_code)
+
+    def _translate_webserver_error(self, ex):
+        s = str(ex)
+
+        # NOTE(kgriffs): uvicorn or any other server using the "websockets"
+        #   package that allows exceptions to bubble up
+        if 'code = 1000 (OK)' in s:
+            return errors.WebSocketDisconnected(WSCloseCode.NORMAL)
+
+        # NOTE(kgriffs): Autobahn (used by Daphne) raises a generic exception
+        #   with this message
+        if 'protocol accepted must be from the list' in s:
+            return ValueError('WebSocket subprotocol must be from the list sent by the client')
+
+        return None
+
+
+class WebSocketOptions:
+    """Defines a set of configurable WebSocket options.
+
+    An instance of this class is exposed via :attr:`falcon.asgi.App.ws_options`
+    for configuring certain :py:class:`~.WebSocket` behaviors.
+
+    Attributes:
+        error_close_code (int): The WebSocket close code to use when an
+            unhandled error is raised while handling a WebSocket connection
+            (default ``1011``). For a list of valid close codes and ranges,
+            see also: https://tools.ietf.org/html/rfc6455#section-7.4
+        media_handlers (dict): A dict-like object for configuring media handlers
+            according to the WebSocket payload type (TEXT vs. BINARY) of a
+            given message. See also: :ref:`ws_media_handlers`.
+    """
+
+    __slots__ = ['error_close_code', 'max_receive_queue', 'media_handlers']
+
+    def __init__(self):
+        self.media_handlers = {
+            WebSocketPayloadType.TEXT: media.JSONHandlerWS(),
+            WebSocketPayloadType.BINARY: media.MessagePackHandlerWS(),
+        }
+
+        # Internal Error
+        #
+        #   See also: https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent
+        #
+        self.error_close_code = WSCloseCode.SERVER_ERROR
+
+        # NOTE(kgriffs): The websockets library itself will buffer, so we keep
+        #   this value fairly small to reduce memory usage by default. On the
+        #   other hand, AFAICT, autobahn-based servers such as Daphne do not
+        #   limit the received message queue length, and so in that case they
+        #   don't properly deal with back pressure and it may make sense to
+        #   increase this value.
+        #
+        #   For now, we leave this as undocumented since the default should
+        #   be generally sufficient. If we find this is not the case, we can
+        #   surface documentation at that time.
+        #
+        #   See also:
+        #       * https://websockets.readthedocs.io/en/stable/design.html#buffers
+        #       * https://websockets.readthedocs.io/en/stable/deployment.html#buffers
+        #
+        self.max_receive_queue = 4
+
+
+class _BufferedReceiver:
+    """Buffer incoming WebSocket messages.
+
+    This class is used internally to monitor the WebSocket status (so that we
+    can detect when it is disconnected), as well as to ensure at least
+    a minimum amount of back pressure when the application can't keep up with
+    the incoming event stream.
+    """
+
+    __slots__ = [
+        '_asgi_receive',
+        '_loop',
+        '_max_queue',
+        '_messages',
+        '_pop_message_waiter',
+        '_pump_task',
+        '_put_message_waiter',
+        'client_disconnected',
+        'client_disconnected_code',
+    ]
+
+    def __init__(self, asgi_receive: Callable[[], Awaitable[dict]], max_queue: int):
+        self._asgi_receive = asgi_receive
+        self._max_queue = max_queue
+
+        self._loop = falcon.get_running_loop()
+
+        self._messages: Deque[dict] = collections.deque()
+        self._pop_message_waiter = None
+        self._put_message_waiter = None
+
+        self._pump_task = None
+
+        self.client_disconnected = False
+        self.client_disconnected_code = None
+
+    def start(self):
+        if not self._pump_task:
+            self._pump_task = falcon.create_task(self._pump())
+
+    async def stop(self):
+        if not self._pump_task:
+            return
+
+        self._pump_task.cancel()
+        try:
+            await self._pump_task
+        except asyncio.CancelledError:
+            pass
+
+        self._pump_task = None
+
+    async def receive(self):
+        # NOTE(kgriffs): Since this class is only used internally, we
+        #   use an assertion to mitigate against framework bugs.
+        #
+        #   receive() may not be called again while another coroutine
+        #   is already waiting for the next message.
+        assert not self._pop_message_waiter
+
+        # NOTE(kgriffs): Wait for a message if none are available. This pattern
+        #   was borrowed from the websockets.protocol module.
+        while not self._messages:
+            # -------------------------------------------------------------------------------------
+            # NOTE(kgriffs): The pattern below was borrowed from the websockets.protocol
+            #   module under the BSD 3-Clause "New" or "Revised" License.
+            #
+            #   Ref: https://github.com/aaugustin/websockets/blob/master/src/websockets/protocol.py
+            #
+            # -------------------------------------------------------------------------------------
+
+            # PERF(kgriffs): Using a bare future like this seems to be
+            #   slightly more efficient vs. something like asyncio.Event
+            pop_message_waiter = self._loop.create_future()
+            self._pop_message_waiter = pop_message_waiter
+
+            try:
+                await asyncio.wait(
+                    [pop_message_waiter, self._pump_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                self._pop_message_waiter = None
+
+            if not pop_message_waiter.done():
+                # NOTE(kgriffs): asyncio.wait(...) exited because
+                #   self._pump_task completed before receiving a
+                #   new message.
+                pop_message_waiter.cancel()
+                return {
+                    'type': EventType.WS_DISCONNECT,
+                }
+
+        message = self._messages.popleft()
+
+        # Notify _pump()
+        if self._put_message_waiter is not None:
+            self._put_message_waiter.set_result(None)
+            self._put_message_waiter = None
+
+        return message
+
+    async def _pump(self):
+        while not self.client_disconnected:
+            received_event = await self._asgi_receive()
+            if received_event['type'] == EventType.WS_DISCONNECT:
+                self.client_disconnected = True
+                self.client_disconnected_code = received_event.get('code', WSCloseCode.NORMAL)
+
+            # -------------------------------------------------------------------------------------
+            # NOTE(kgriffs): The pattern below was borrowed from the websockets.protocol
+            #   module under the BSD 3-Clause "New" or "Revised" License.
+            #
+            #   Ref: https://github.com/aaugustin/websockets/blob/master/src/websockets/protocol.py
+            #
+            # -------------------------------------------------------------------------------------
+            while len(self._messages) >= self._max_queue:
+                self._put_message_waiter = self._loop.create_future()
+                try:
+                    await self._put_message_waiter
+                finally:
+                    self._put_message_waiter = None
+
+            self._messages.append(received_event)
+
+            # Notify receive()
+            if self._pop_message_waiter is not None:
+                self._pop_message_waiter.set_result(None)
+                self._pop_message_waiter = None

--- a/falcon/asgi_spec.py
+++ b/falcon/asgi_spec.py
@@ -16,6 +16,8 @@
 
 
 class EventType:
+    """Standard ASGI event type strings."""
+
     HTTP_REQUEST = 'http.request'
     HTTP_RESPONSE_START = 'http.response.start'
     HTTP_RESPONSE_BODY = 'http.response.body'
@@ -28,8 +30,31 @@ class EventType:
     LIFESPAN_SHUTDOWN_COMPLETE = 'lifespan.shutdown.complete'
     LIFESPAN_SHUTDOWN_FAILED = 'lifespan.shutdown.failed'
 
+    WS_CONNECT = 'websocket.connect'
+    WS_ACCEPT = 'websocket.accept'
+    WS_RECEIVE = 'websocket.receive'
+    WS_SEND = 'websocket.send'
+    WS_DISCONNECT = 'websocket.disconnect'
+    WS_CLOSE = 'websocket.close'
+
 
 class ScopeType:
+    """Standard ASGI event type strings."""
+
     HTTP = 'http'
     WS = 'websocket'
     LIFESPAN = 'lifespan'
+
+
+#
+class WSCloseCode:
+    """WebSocket close codes used by the Falcon ASGI framework.
+
+    See also: https://tools.ietf.org/html/rfc6455#section-7.4
+    """
+
+    NORMAL = 1000
+    SERVER_ERROR = 1011
+    FORBIDDEN = 3403
+    PATH_NOT_FOUND = 3404
+    HANDLER_NOT_FOUND = 3405

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -1,3 +1,4 @@
+from enum import Enum
 import os
 
 # RFC 7231, 5789 methods
@@ -38,7 +39,16 @@ FALCON_CUSTOM_HTTP_METHODS = [
     if method.strip() != ''
 ]
 
-COMBINED_METHODS = HTTP_METHODS + WEBDAV_METHODS + FALCON_CUSTOM_HTTP_METHODS
+_META_METHODS = [
+    'WEBSOCKET',
+]
+
+COMBINED_METHODS = (
+    HTTP_METHODS +
+    WEBDAV_METHODS +
+    FALCON_CUSTOM_HTTP_METHODS +
+    _META_METHODS
+)
 
 # NOTE(kgriffs): According to RFC 7159, most JSON parsers assume
 # UTF-8 and so it is the recommended default charset going forward,
@@ -110,3 +120,6 @@ SINGLETON_HEADERS = frozenset([
 # NOTE(kgriffs): Special singleton to be used internally whenever using
 #   None would be ambiguous.
 _UNSET = object()
+
+WebSocketPayloadType = Enum('WebSocketPayloadType', 'TEXT BINARY')
+"""Enum representing the two possible WebSocket payload types."""

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -69,6 +69,49 @@ class DelimiterError(IOError):
     """The read operation did not find the requested stream delimiter."""
 
 
+class PayloadTypeError(TypeError):
+    """The WebSocket message payload was not of the expected type."""
+
+
+class WebSocketDisconnected(RuntimeError):
+    """The websocket connection is lost.
+
+    This error is raised when attempting to perform an operation on the
+    WebSocket and it is determined that either the client has closed the
+    connection, the server closed the connection, or the socket has otherwise
+    been lost.
+
+    Keyword Args:
+        code (int): The WebSocket close code, as per the WebSocket spec
+            (default ``1000``).
+
+    Attributes:
+        code (int): The WebSocket close code, as per the WebSocket spec.
+    """
+
+    def __init__(self, code: int = None):
+        self.code = code or 1000  # Default to "Normal Closure"
+
+
+class WebSocketPathNotFound(WebSocketDisconnected):
+    """No route could be found for the requested path.
+
+    A simulated WebSocket connection was attempted but the path specified in
+    the handshake request did not match any of the app's routes.
+    """
+    pass
+
+
+class WebSocketHandlerNotFound(WebSocketDisconnected):
+    """The routed resource does not contain an ``on_websocket()`` handler."""
+    pass
+
+
+class WebSocketServerError(WebSocketDisconnected):
+    """The server encountered an unexpected error."""
+    pass
+
+
 class HTTPBadRequest(HTTPError):
     """400 Bad Request.
 

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -455,7 +455,7 @@ class HTTPMethodNotAllowed(HTTPError):
             resource (e.g., ``['GET', 'POST', 'HEAD']``).
 
             Note:
-                The existing valuessss of the Allow in headers will be
+                If previously set, the Allow response header will be
                 overridden by this value.
 
     Keyword Args:

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -124,6 +124,8 @@ class HTTPError(Exception):
     def __repr__(self):
         return '<%s: %s>' % (self.__class__.__name__, self.status)
 
+    __str__ = __repr__
+
     @property  # type: ignore
     @deprecated(
         'has_representation is deprecated and is currently unused by falcon',

--- a/falcon/media/__init__.py
+++ b/falcon/media/__init__.py
@@ -1,16 +1,20 @@
-from .base import BaseHandler
+from .base import BaseHandler, BinaryBaseHandlerWS, TextBaseHandlerWS
 from .handlers import Handlers
-from .json import JSONHandler
-from .msgpack import MessagePackHandler
+from .json import JSONHandler, JSONHandlerWS
+from .msgpack import MessagePackHandler, MessagePackHandlerWS
 from .multipart import MultipartFormHandler
 from .urlencoded import URLEncodedFormHandler
 
 
 __all__ = [
     'BaseHandler',
+    'BinaryBaseHandlerWS',
+    'TextBaseHandlerWS',
     'Handlers',
     'JSONHandler',
+    'JSONHandlerWS',
     'MessagePackHandler',
+    'MessagePackHandlerWS',
     'MultipartFormHandler',
     'URLEncodedFormHandler',
 ]

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -1,5 +1,6 @@
 import abc
 import io
+from typing import Union
 
 
 class BaseHandler(metaclass=abc.ABCMeta):
@@ -112,3 +113,77 @@ class BaseHandler(metaclass=abc.ABCMeta):
     consume the whole stream, but the deserialized media object is complete and
     does not involve further streaming.
     """
+
+
+class TextBaseHandlerWS(metaclass=abc.ABCMeta):
+    """Abstract Base Class for a WebSocket TEXT media handler."""
+
+    def serialize(self, media: object) -> str:
+        """Serialize the media object to a Unicode string.
+
+        By default, this method raises an instance of
+        :py:class:`NotImplementedError`. Therefore, it must be
+        overridden if the child class wishes to support
+        serialization to TEXT (0x01) message payloads.
+
+        Args:
+            media (object): A serializable object.
+
+        Returns:
+            str: The resulting serialized string from the input object.
+        """
+        raise NotImplementedError()
+
+    def deserialize(self, payload: str) -> object:
+        """Deserialize TEXT payloads from a Unicode string.
+
+        By default, this method raises an instance of
+        :py:class:`NotImplementedError`. Therefore, it must be
+        overridden if the child class wishes to support
+        deserialization from TEXT (0x01) message payloads.
+
+        Args:
+            payload (str): Message payload to deserialize.
+
+        Returns:
+            object: A deserialized object.
+        """
+        raise NotImplementedError()
+
+
+class BinaryBaseHandlerWS(metaclass=abc.ABCMeta):
+    """Abstract Base Class for a WebSocket BINARY media handler."""
+
+    def serialize(self, media: object) -> Union[bytes, bytearray, memoryview]:
+        """Serialize the media object to a byte string.
+
+        By default, this method raises an instance of
+        :py:class:`NotImplementedError`. Therefore, it must be
+        overridden if the child class wishes to support
+        serialization to BINARY (0x02) message payloads.
+
+        Args:
+            media (object): A serializable object.
+
+        Returns:
+            bytes: The resulting serialized byte string from the input
+            object. May be an instance of :class:`bytes`,
+            :class:`bytearray`, or :class:`memoryview`.
+        """
+        raise NotImplementedError()
+
+    def deserialize(self, payload: bytes) -> object:
+        """Deserialize BINARY payloads from a byte string.
+
+        By default, this method raises an instance of
+        :py:class:`NotImplementedError`. Therefore, it must be
+        overridden if the child class wishes to support
+        deserialization from BINARY (0x02) message payloads.
+
+        Args:
+            payload (bytes): Message payload to deserialize.
+
+        Returns:
+            object: A deserialized object.
+        """
+        raise NotImplementedError()

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -1,7 +1,7 @@
 from functools import partial
 
 from falcon import errors
-from falcon.media import BaseHandler
+from falcon.media.base import BaseHandler, TextBaseHandlerWS
 from falcon.util import json
 
 
@@ -110,3 +110,72 @@ class JSONHandler(BaseHandler):
             return result.encode('utf-8')
 
         return result
+
+
+class JSONHandlerWS(TextBaseHandlerWS):
+    """WebSocket media handler for de(serializing) JSON to/from TEXT payloads.
+
+    This handler uses Python's standard :py:mod:`json` library by default, but
+    can be easily configured to use any of a number of third-party JSON
+    libraries, depending on your needs. For example, you can often
+    realize a significant performance boost under CPython by using an
+    alternative library. Good options in this respect include `orjson`,
+    `python-rapidjson`, and `mujson`.
+
+    Note:
+        If you are deploying to PyPy, we recommend sticking with the standard
+        library's JSON implementation, since it will be faster in most cases
+        as compared to a third-party library.
+
+    Overriding the default JSON implementation is simply a matter of specifying
+    the desired ``dumps`` and ``loads`` functions::
+
+        import falcon
+        from falcon import media
+
+        import rapidjson
+
+        json_handler = media.JSONHandlerWS(
+            dumps=rapidjson.dumps,
+            loads=rapidjson.loads,
+        )
+
+        app = falcon.asgi.App()
+        app.ws_options.media_handlers[falcon.WebSocketPayloadType.TEXT] = json_handler
+
+    By default, ``ensure_ascii`` is passed to the ``json.dumps`` function.
+    If you override the ``dumps`` function, you will need to explicitly set
+    ``ensure_ascii`` to ``False`` in order to enable the serialization of
+    Unicode characters to UTF-8. This is easily done by using
+    ``functools.partial`` to apply the desired keyword argument. In fact, you
+    can use this same technique to customize any option supported by the
+    ``dumps`` and ``loads`` functions::
+
+        from functools import partial
+
+        from falcon import media
+        import rapidjson
+
+        json_handler = media.JSONHandlerWS(
+            dumps=partial(
+                rapidjson.dumps,
+                ensure_ascii=False, sort_keys=True
+            ),
+        )
+
+    Keyword Arguments:
+        dumps (func): Function to use when serializing JSON.
+        loads (func): Function to use when deserializing JSON.
+    """
+
+    __slots__ = ['dumps', 'loads']
+
+    def __init__(self, dumps=None, loads=None):
+        self.dumps = dumps or partial(json.dumps, ensure_ascii=False)
+        self.loads = loads or json.loads
+
+    def serialize(self, media: object) -> str:
+        return self.dumps(media)
+
+    def deserialize(self, payload: str) -> object:
+        return self.loads(payload)

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import  # NOTE(kgriffs): Work around a Cython bug
 
+from typing import Union
+
 from falcon import errors
-from falcon.media import BaseHandler
+from falcon.media.base import BaseHandler, BinaryBaseHandlerWS
 
 
 class MessagePackHandler(BaseHandler):
@@ -59,3 +61,40 @@ class MessagePackHandler(BaseHandler):
 
     async def serialize_async(self, media, content_type):
         return self.packer.pack(media)
+
+
+class MessagePackHandlerWS(BinaryBaseHandlerWS):
+    """WebSocket media handler for de(serializing) MessagePack to/from BINARY payloads.
+
+    This handler uses ``msgpack.unpackb()`` and ``msgpack.packb()``. The
+    MessagePack ``bin`` type is used to distinguish between Unicode strings
+    (of type ``str``) and byte strings (of type ``bytes``).
+
+    Note:
+        This handler requires the extra ``msgpack`` package (version 0.5.2
+        or higher), which must be installed in addition to ``falcon`` from
+        PyPI:
+
+        .. code::
+
+            $ pip install msgpack
+    """
+
+    __slots__ = ['msgpack', 'packer']
+
+    def __init__(self):
+        import msgpack
+
+        self.msgpack = msgpack
+        self.packer = msgpack.Packer(
+            autoreset=True,
+            use_bin_type=True,
+        )
+
+    def serialize(self, media: object) -> Union[bytes, bytearray, memoryview]:
+        return self.packer.pack(media)
+
+    def deserialize(self, payload: bytes) -> object:
+        # NOTE(jmvrbanac): Using unpackb since we would need to manage
+        # a buffer for Unpacker() which wouldn't gain us much.
+        return self.msgpack.unpackb(payload, raw=False)

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -424,6 +424,7 @@ class Request:
         'stream',
         'uri_template',
         '_media',
+        'is_websocket',
     )
 
     _cookies = None
@@ -437,6 +438,8 @@ class Request:
     _wsgi_input_type_known = False
 
     def __init__(self, env, options=None):
+        self.is_websocket = False
+
         self.env = env
         self.options = options if options else RequestOptions()
 

--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -141,7 +141,10 @@ def set_default_responders(method_map, asgi=False):
     """
 
     # Attach a resource for unsupported HTTP methods
-    allowed_methods = sorted(list(method_map.keys()))
+    allowed_methods = [
+        m for m in sorted(list(method_map.keys()))
+        if m not in constants._META_METHODS
+    ]
 
     if 'OPTIONS' not in method_map:
         # OPTIONS itself is intentionally excluded from the Allow header
@@ -152,5 +155,5 @@ def set_default_responders(method_map, asgi=False):
     na_responder = responders.create_method_not_allowed(allowed_methods, asgi=asgi)
 
     for method in constants.COMBINED_METHODS:
-        if method not in allowed_methods:
+        if method not in method_map:
             method_map[method] = na_responder

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -787,7 +787,9 @@ class ASGIConductor:
     This class provides more control over the lifecycle of a simulated
     request as compared to :class:`~.TestClient`. In addition, the conductor's
     asynchronous interface affords interleaved requests and the testing of
-    streaming protocols such as server-sent events (SSE) and WebSocket.
+    streaming protocols such as
+    :attr:`Server-Sent Events (SSE) <falcon.asgi.Response.sse>`
+    and :ref:`WebSocket <ws>`.
 
     :class:`~.ASGIConductor` is implemented as a context manager. Upon
     entering and exiting the context, the appropriate ASGI lifespan events
@@ -914,7 +916,10 @@ class ASGIConductor:
     def simulate_get_stream(self, path='/', **kwargs):
         """Simulate a GET request to an ASGI application with a streamed response.
 
-        This method returns a context manager that can be used to obtain
+        (See also: :py:meth:`falcon.testing.simulate_get` for a list of
+        supported keyword arguments.)
+
+        This method returns an async context manager that can be used to obtain
         a managed :class:`~.StreamedResult` instance. Exiting the context
         will automatically finalize the result object, causing the request
         event emitter to begin emitting 'http.disconnect' events and then
@@ -941,6 +946,34 @@ class ASGIConductor:
         kwargs['_stream_result'] = True
 
         return _AsyncContextManager(self.simulate_request('GET', path, **kwargs))
+
+    def simulate_ws(self, path='/', **kwargs):
+        """Simulate a WebSocket connection to an ASGI application.
+
+        All keyword arguments are passed through to
+        :py:meth:`falcon.testing.create_scope_ws`.
+
+        This method returns an async context manager that can be used to obtain
+        a managed :class:`falcon.testing.ASGIWebSocketSimulator` instance.
+        Exiting the context will simulate a close on the WebSocket (if not
+        already closed) and await the completion of the task that is
+        running the simulated ASGI request.
+
+        In the following example, a series of WebSocket TEXT events are
+        received from the ASGI app::
+
+            async with conductor.simulate_ws('/events') as ws:
+                while some_condition:
+                    message = await ws.receive_text()
+
+        """
+
+        scope = helpers.create_scope_ws(path=path, **kwargs)
+        ws = helpers.ASGIWebSocketSimulator()
+
+        task_req = create_task(self.app(scope, ws._emit, ws._collect))
+
+        return _WSContextManager(ws, task_req)
 
     async def simulate_head(self, path='/', **kwargs) -> _ResultBase:
         """Simulate a HEAD request to an ASGI application.
@@ -1854,6 +1887,41 @@ class _AsyncContextManager:
     async def __aexit__(self, exc_type, exc, tb):
         await self._obj.finalize()
         self._obj = None
+
+
+class _WSContextManager:
+    def __init__(self, ws, task_req):
+        self._ws = ws
+        self._task_req = task_req
+
+    async def __aenter__(self):
+        ready_waiter = create_task(self._ws.wait_ready())
+
+        # NOTE(kgriffs): Wait on both so that in the case that the request
+        #   task raises an error, we don't just end up masking it with an
+        #   asyncio.TimeoutError.
+        await asyncio.wait(
+            [ready_waiter, self._task_req],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if ready_waiter.done():
+            await ready_waiter
+        else:
+            # NOTE(kgriffs): Retrieve the exception, if any
+            await self._task_req
+
+            # NOTE(kgriffs): This should complete gracefully (without a
+            #   timeout). It may raise WebSocketDisconnected, but that
+            #   is expected and desired for "normal" reasons that the
+            #   request task finished without accepting the connection.
+            await ready_waiter
+
+        return self._ws
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self._ws.close()
+        await self._task_req
 
 
 def _prepare_sim_args(

--- a/requirements/tests
+++ b/requirements/tests
@@ -10,8 +10,12 @@ httpx; python_version >= '3.6'
 uvicorn; python_version >= '3.6'
 aiofiles; python_version >= '3.6'
 daphne; python_version >= '3.6'
+httpx; python_version >= '3.6'
+uvicorn; python_version >= '3.6'
+websockets; python_version >= '3.6'
 
 # Handler Specific
+cbor2
 msgpack
 mujson
 ujson

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -6,6 +6,7 @@ import time
 
 import falcon
 import falcon.asgi
+import falcon.errors
 import falcon.util
 
 SSE_TEST_MAX_DELAY_SEC = 1
@@ -102,6 +103,12 @@ class Bucket:
         resp.body = await req.stream.read()
 
 
+class Feed:
+    async def on_websocket(self, req, ws, feed_id):
+        await ws.accept()
+        await ws.send_text(feed_id)
+
+
 class Events:
     async def on_get(self, req, resp):
         async def emit():
@@ -112,6 +119,81 @@ class Events:
                 s += (SSE_TEST_MAX_DELAY_SEC / 4)
 
         resp.sse = emit()
+
+    async def on_websocket(self, req, ws):  # noqa: C901
+        recv_command = req.get_header('X-Command') == 'recv'
+        send_mismatched = req.get_header('X-Mismatch') == 'send'
+        recv_mismatched = req.get_header('X-Mismatch') == 'recv'
+
+        mismatch_type = req.get_header('X-Mismatch-Type', default='text')
+
+        raise_error = req.get_header('X-Raise-Error')
+
+        close = req.get_header('X-Close')
+        close_code = req.get_header('X-Close-Code')
+        if close_code:
+            close_code = int(close_code)
+
+        accept = req.get_header('X-Accept', default='accept')
+
+        if accept == 'accept':
+            subprotocol = req.get_header('X-Subprotocol')
+
+            if subprotocol == '*':
+                subprotocol = ws.subprotocols[0]
+
+            if subprotocol:
+                await ws.accept(subprotocol)
+            else:
+                await ws.accept()
+        elif accept == 'reject':
+            if close:
+                await ws.close()
+            return
+
+        if send_mismatched:
+            if mismatch_type == 'text':
+                await ws.send_text(b'fizzbuzz')
+            else:
+                await ws.send_data('fizzbuzz')
+
+        if recv_mismatched:
+            if mismatch_type == 'text':
+                await ws.receive_text()
+            else:
+                await ws.receive_data()
+
+        start = time.time()
+        while time.time() - start < 1:
+            try:
+                msg = None
+
+                if recv_command:
+                    msg = await ws.receive_media()
+                else:
+                    msg = None
+
+                await ws.send_text('hello world')
+                print('on_websocket:send_text')
+
+                if msg and msg['command'] == 'echo':
+                    await ws.send_text(msg['echo'])
+
+                await ws.send_data(b'hello\x00world')
+                await asyncio.sleep(0.2)
+            except falcon.errors.WebSocketDisconnected:
+                print('on_websocket:WebSocketDisconnected')
+                raise
+
+            if raise_error == 'generic':
+                raise Exception('Test: Generic Unhandled Error')
+            elif raise_error == 'http':
+                raise falcon.HTTPBadRequest()
+
+        if close:
+            # NOTE(kgriffs): Tests that the default is used
+            #   when close_code is None.
+            await ws.close(close_code)
 
 
 class Multipart:
@@ -156,9 +238,24 @@ def create_app():
     app.add_route('/bucket', Bucket())
     app.add_route('/events', Events())
     app.add_route('/forms', Multipart())
+    app.add_route('/feeds/{feed_id}', Feed())
 
     lifespan_handler = LifespanHandler()
     app.add_middleware(lifespan_handler)
+
+    async def _on_ws_error(req, resp, error, params, ws=None):
+        if not ws:
+            raise
+
+        if ws.unaccepted:
+            await ws.accept()
+
+        if not ws.closed:
+            await ws.send_text(error.__class__.__name__)
+            await ws.close()
+
+    app.add_error_handler(falcon.errors.OperationNotAllowed, _on_ws_error)
+    app.add_error_handler(ValueError, _on_ws_error)
 
     return app
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 import hashlib
 import os
@@ -10,6 +11,8 @@ import time
 import pytest
 import requests
 import requests.exceptions
+import websockets
+import websockets.exceptions
 
 from falcon import testing
 from . import _asgi_test_app
@@ -135,6 +138,226 @@ class TestASGIServer:
             )
 
 
+class TestWebSocket:
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('explicit_close', [True, False])
+    @pytest.mark.parametrize('close_code', [None, 4321])
+    async def test_hello(self, explicit_close, close_code, server_url_events_ws):
+        echo_expected = 'Check 1 - \U0001f600'
+
+        extra_headers = {'X-Command': 'recv'}
+
+        if explicit_close:
+            extra_headers['X-Close'] = 'True'
+
+        if close_code:
+            extra_headers['X-Close-Code'] = str(close_code)
+
+        async with websockets.connect(
+            server_url_events_ws,
+            extra_headers=extra_headers,
+        ) as ws:
+            got_message = False
+
+            while True:
+                try:
+                    # TODO: Why is this failing to decode on the other side? (raises an error)
+                    # TODO: Why does this cause Daphne to hang?
+                    await ws.send(f'{{"command": "echo", "echo": "{echo_expected}"}}')
+
+                    message_text = await ws.recv()
+                    message_echo = await ws.recv()
+                    message_binary = await ws.recv()
+                except websockets.exceptions.ConnectionClosed as ex:
+                    if explicit_close and close_code:
+                        assert ex.code == close_code
+                    else:
+                        assert ex.code == 1000
+
+                    break
+
+                got_message = True
+                assert message_text == 'hello world'
+                assert message_echo == echo_expected
+                assert message_binary == b'hello\x00world'
+
+            assert got_message
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('explicit_close', [True, False])
+    @pytest.mark.parametrize('close_code', [None, 4040])
+    async def test_rejected(self, explicit_close, close_code, server_url_events_ws):
+        extra_headers = {'X-Accept': 'reject'}
+        if explicit_close:
+            extra_headers['X-Close'] = 'True'
+
+        if close_code:
+            extra_headers['X-Close-Code'] = str(close_code)
+
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.connect(server_url_events_ws, extra_headers=extra_headers):
+                pass
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_missing_responder(self, server_url_events_ws):
+        server_url_events_ws += '/404'
+
+        with pytest.raises(websockets.exceptions.InvalidStatusCode) as exc_info:
+            async with websockets.connect(server_url_events_ws):
+                pass
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('subprotocol, expected', [
+        ('*', 'amqp'),
+        ('wamp', 'wamp'),
+    ])
+    async def test_select_subprotocol_known(self, subprotocol, expected, server_url_events_ws):
+        extra_headers = {
+            'X-Subprotocol': subprotocol
+        }
+        async with websockets.connect(
+            server_url_events_ws,
+            extra_headers=extra_headers,
+            subprotocols=['amqp', 'wamp'],
+        ) as ws:
+            assert ws.subprotocol == expected
+
+    @pytest.mark.asyncio
+    async def test_select_subprotocol_unknown(self, server_url_events_ws):
+        extra_headers = {
+            'X-Subprotocol': 'xmpp'
+        }
+
+        try:
+            async with websockets.connect(
+                server_url_events_ws,
+                extra_headers=extra_headers,
+                subprotocols=['amqp', 'wamp'],
+            ):
+                pass
+
+            # NOTE(kgriffs): Taking the approach of asserting inside
+            #   except clauses is a little bit cleaner in this case vs.
+            #   multiple pytest.raises(), so we fail the test if no
+            #   error is raised as expected.
+            pytest.fail('no error raised')
+
+        # Uvicorn
+        except websockets.exceptions.NegotiationError as ex:
+            assert 'unsupported subprotocol: xmpp' in str(ex)
+
+        # Daphne
+        except websockets.exceptions.InvalidMessage:
+            pass
+
+    # NOTE(kgriffs): When executing this test under pytest with the -s
+    #   argument, one should be able to see the message
+    #   "on_websocket:WebSocketDisconnected" printed to the console. I have
+    #   tried to capture this output and check it in the test below,
+    #   but the usual ways of capturing stdout/stderr with pytest do
+    #   not work.
+    @pytest.mark.asyncio
+    async def test_disconnecting_client_early(self, server_url_events_ws):
+        ws = await websockets.connect(server_url_events_ws, extra_headers={'X-Close': 'True'})
+        await asyncio.sleep(0.2)
+
+        message_text = await ws.recv()
+        assert message_text == 'hello world'
+
+        message_binary = await ws.recv()
+        assert message_binary == b'hello\x00world'
+
+        await ws.close()
+        print('closed')
+
+        # NOTE(kgriffs): Let the app continue to attempt to send us
+        #   messages after the close.
+        await asyncio.sleep(1)
+
+    @pytest.mark.asyncio
+    async def test_send_before_accept(self, server_url_events_ws):
+        extra_headers = {'x-accept': 'skip'}
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            message = await ws.recv()
+            assert message == 'OperationNotAllowed'
+
+    @pytest.mark.asyncio
+    async def test_recv_before_accept(self, server_url_events_ws):
+        extra_headers = {'x-accept': 'skip', 'x-command': 'recv'}
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            message = await ws.recv()
+            assert message == 'OperationNotAllowed'
+
+    @pytest.mark.asyncio
+    async def test_invalid_close_code(self, server_url_events_ws):
+        extra_headers = {'x-close': 'True', 'x-close-code': 42}
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            start = time.time()
+
+            while True:
+                message = await asyncio.wait_for(ws.recv(), timeout=1)
+                if message == 'ValueError':
+                    break
+
+                elapsed = time.time() - start
+                assert elapsed < 2
+
+    @pytest.mark.asyncio
+    async def test_close_code_on_unhandled_error(self, server_url_events_ws):
+        extra_headers = {'x-raise-error': 'generic'}
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            await ws.wait_closed()
+
+        assert ws.close_code in {3011, 1011}
+
+    @pytest.mark.asyncio
+    async def test_close_code_on_unhandled_http_error(self, server_url_events_ws):
+        extra_headers = {'x-raise-error': 'http'}
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            await ws.wait_closed()
+
+        assert ws.close_code == 3400
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('mismatch', ['send', 'recv'])
+    @pytest.mark.parametrize('mismatch_type', ['text', 'data'])
+    async def test_type_mismatch(self, mismatch, mismatch_type, server_url_events_ws):
+        extra_headers = {
+            'X-Mismatch': mismatch,
+            'X-Mismatch-Type': mismatch_type,
+        }
+
+        async with websockets.connect(server_url_events_ws, extra_headers=extra_headers) as ws:
+            if mismatch == 'recv':
+                if mismatch_type == 'text':
+                    await ws.send(b'hello')
+                else:
+                    await ws.send('hello')
+
+            await ws.wait_closed()
+
+        assert ws.close_code in {3011, 1011}
+
+    @pytest.mark.asyncio
+    async def test_passing_path_params(self, server_base_url_ws):
+        expected_feed_id = '1ee7'
+        url = f'{server_base_url_ws}feeds/{expected_feed_id}'
+
+        async with websockets.connect(url) as ws:
+            feed_id = await ws.recv()
+            assert feed_id == expected_feed_id
+
+
 @contextmanager
 def _run_server_isolated(process_factory, host, port):
     # NOTE(kgriffs): We have to use subprocess because uvicorn has a tendency
@@ -206,6 +429,8 @@ uvicorn.run('_asgi_test_app:application', host='{host}', port={port})
         '--host', host,
         '--port', str(port),
 
+        '--interface', 'asgi3',
+
         '_asgi_test_app:application'
     )
 
@@ -273,3 +498,13 @@ def server_base_url(request):
 
     else:
         pytest.fail('Could not start server')
+
+
+@pytest.fixture
+def server_base_url_ws(server_base_url):
+    return server_base_url.replace('http', 'ws')
+
+
+@pytest.fixture
+def server_url_events_ws(server_base_url_ws):
+    return server_base_url_ws + 'events'

--- a/tests/asgi/test_scope.py
+++ b/tests/asgi/test_scope.py
@@ -50,7 +50,7 @@ def test_supported_asgi_version(version, supported):
             _call_with_scope(scope)
 
 
-@pytest.mark.parametrize('scope_type', ['websocket', 'tubes', 'http3', 'htt'])
+@pytest.mark.parametrize('scope_type', ['tubes', 'http3', 'htt'])
 def test_unsupported_scope_type(scope_type):
     scope = testing.create_scope()
     scope['type'] = scope_type

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -1,0 +1,1041 @@
+import asyncio
+from collections import deque
+import os
+
+import cbor2
+import pytest
+import rapidjson
+
+import falcon
+from falcon import media, testing
+from falcon.asgi import App
+from falcon.asgi.ws import _WebSocketState as ServerWebSocketState
+from falcon.testing.helpers import _WebSocketState as ClientWebSocketState
+
+
+# NOTE(kgriffs): We do not use codes defined in the framework because we
+#   want to verify that the correct value is being used.
+class CloseCode:
+    NORMAL = 1000
+    SERVER_ERROR = 1011
+    FORBIDDEN = 3403
+    NOT_FOUND = 3404
+
+
+class EventType:
+    WS_CONNECT = 'websocket.connect'
+    WS_ACCEPT = 'websocket.accept'
+    WS_RECEIVE = 'websocket.receive'
+    WS_SEND = 'websocket.send'
+    WS_DISCONNECT = 'websocket.disconnect'
+    WS_CLOSE = 'websocket.close'
+
+
+@pytest.fixture
+def conductor():
+    app = falcon.asgi.App()
+    return testing.ASGIConductor(app)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('path', ['/ws/yes', '/ws/no'])
+async def test_ws_not_accepted(path, conductor):
+    class SomeResource:
+        def __init__(self):
+            self.called = False
+            self.caught_unsupported_error = False
+            self.caught_receive_not_allowed = False
+            self.caught_operation_not_allowed = False
+
+        async def on_websocket(self, req, ws, explicit):
+            try:
+                req.stream
+            except falcon.UnsupportedError:
+                self.caught_unsupported_error = True
+
+            self.called = True
+
+            try:
+                await ws.receive_text()
+            except falcon.OperationNotAllowed:
+                self.caught_receive_not_allowed = True
+
+            if explicit == 'yes':
+                await ws.close()
+
+                # NOTE(kgriffs): This verifies that closing
+                #   an already-closed WebSocket is a no-op.
+                await ws.close()
+
+                try:
+                    await ws.accept()
+                except falcon.OperationNotAllowed:
+                    self.caught_operation_not_allowed = True
+
+    resource = SomeResource()
+    conductor.app.add_route('/ws/{explicit}', resource)
+
+    # NOTE(kgriffs): declaring the 'c' variable is not strictly necessary
+    #   because it is just 'conductor', but it probably wastes fewer brain
+    #   cycles to just use the same pattern whether or not the conductor
+    #   object is pre-instantiated.
+    async with conductor as c:
+        assert c is conductor
+
+        with pytest.raises(falcon.WebSocketDisconnected) as exc_info:
+            async with c.simulate_ws(path):
+                pass
+
+        assert resource.called
+        assert resource.caught_receive_not_allowed
+        assert resource.caught_unsupported_error
+        assert exc_info.value.code == CloseCode.FORBIDDEN
+
+        if 'yes' in path:
+            assert resource.caught_operation_not_allowed
+
+
+@pytest.mark.asyncio
+async def test_echo():  # noqa: C901
+    class Resource:
+        def __init__(self):
+            self.caught_operation_not_allowed = False
+
+        async def on_websocket(self, req, ws, p1, p2, injected):
+            # NOTE(kgriffs): Normally the receiver task is not started
+            #   until the websocket is started. But here we start it
+            #   first in order to simulate a potential race condition
+            #   that ASGIWebSocketSimulator._emit() guards against,
+            #   in case it ever arises due to the way the target ASGI
+            #   app may be implemented.
+            ws._buffered_receiver.start()
+
+            await asyncio.sleep(0)
+
+            if ws.unaccepted:
+                await ws.accept()
+
+            try:
+                await ws.accept()
+            except falcon.OperationNotAllowed:
+                self.caught_operation_not_allowed = True
+
+            if ws.ready:
+                await ws.send_text(f'{p1}:{p2}:{req.context.message}:{injected}')
+
+            messages = deque()
+            sink_task = falcon.create_task(self._sink(ws, messages))
+
+            while not sink_task.done():
+                if not messages:
+                    await asyncio.sleep(0)
+                    continue
+
+                try:
+                    await ws.send_text(messages.popleft())
+                except falcon.WebSocketDisconnected:
+                    break
+
+            sink_task.cancel()
+            try:
+                await sink_task
+            except asyncio.CancelledError:
+                pass
+
+        async def _sink(self, ws, messages):
+            while True:
+                # NOTE(kgriffs): Throttle slightly to allow messages to
+                #   fill up the buffer.
+                await asyncio.sleep(0.001)
+
+                try:
+                    message = await ws.receive_text()
+                except falcon.WebSocketDisconnected:
+                    break
+
+                if message != 'ignore':
+                    messages.append(message)
+
+    class MiddlewareA:
+        async def process_resource_ws(self, req, ws, resource, params):
+            assert isinstance(resource, Resource)
+            assert isinstance(ws, falcon.asgi.WebSocket)
+            params['injected'] = '42'
+
+    class MiddlewareB:
+        async def process_request_ws(self, req, ws):
+            assert isinstance(ws, falcon.asgi.WebSocket)
+            req.context.message = 'hello'
+
+    resource = Resource()
+
+    # NOTE(kgriffs): The two methods are split across different middleware
+    #   classes so that we can test code paths that check for the existence
+    #   of one WebSocket middleware method vs the other, and also so that
+    #   we can make sure both the kwarg and the add_middlware() paths
+    #   succeed.
+    app = App(middleware=MiddlewareA())
+    app.add_middleware(MiddlewareB())
+
+    app.add_route('/{p1}/{p2}', resource)
+
+    async with testing.ASGIConductor(app) as c:
+        async with c.simulate_ws('/v1/v2', headers={}) as ws:
+            assert (await ws.receive_text()) == 'v1:v2:hello:42'
+
+            for i in range(10):
+                message = str(i) or ''  # Test round-tripping the empty string as well
+
+                for i in range(100):
+                    await ws.send_text('ignore')
+
+                # NOTE(kgriffs): Cause the buffered receive() on the
+                #   server side to wait occasionally on a new message.
+                await asyncio.sleep(0.001)
+
+                await ws.send_text(message)
+                assert (await ws.receive_text()) == message
+
+            await ws.close()
+
+            assert ws.closed
+            assert ws.close_code == CloseCode.NORMAL
+
+    assert resource.caught_operation_not_allowed
+
+
+@pytest.mark.asyncio
+async def test_path_not_found(conductor):
+    async with conductor as c:
+        with pytest.raises(falcon.WebSocketDisconnected) as exc_info:
+            async with c.simulate_ws():
+                pass
+
+        assert exc_info.value.code == CloseCode.NOT_FOUND
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('clear_error_handlers', [True, False])
+async def test_responder_raises_unhandled_error(clear_error_handlers, conductor):
+    class SomeResource:
+        def __init__(self):
+            self.called = False
+
+        async def on_websocket(self, req, ws, generic_error):
+            self.called = True
+
+            if generic_error == 'true':
+                raise Exception('Oh snap!')
+
+            # NOTE(kgriffs): This may not make a lot of sense to do, but the
+            #   framework will try to do something reasonable with it by
+            #   rejecting the WebSocket handshake and setting the close code
+            #   to 3000 + falcon.util.http_status_to_code(error.status)
+            raise falcon.HTTPUnprocessableEntity()
+
+    resource = SomeResource()
+    conductor.app.add_route('/{generic_error}', resource)
+
+    if clear_error_handlers:
+        # NOTE(kgriffs): This is required in order to cover a certain branch condition.
+        conductor.app._error_handlers.clear()
+
+        async with conductor as c:
+            with pytest.raises(Exception) as exc_info:
+                async with c.simulate_ws('/true'):
+                    pass
+
+            assert resource.called
+            assert str(exc_info.value) == 'Oh snap!'
+
+            resource.called = False
+
+            with pytest.raises(falcon.HTTPUnprocessableEntity):
+                async with c.simulate_ws('/false'):
+                    pass
+
+            assert resource.called
+    else:
+        async with conductor as c:
+            with pytest.raises(falcon.WebSocketServerError) as exc_info:
+                async with c.simulate_ws('/true'):
+                    pass
+
+            assert resource.called
+            assert exc_info.value.code == 1011
+
+            resource.called = False
+
+            with pytest.raises(falcon.WebSocketDisconnected) as exc_info:
+                async with c.simulate_ws('/false'):
+                    pass
+
+            assert resource.called
+            assert exc_info.value.code == 3422
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('direction', ['send', 'receive'])
+@pytest.mark.parametrize('explicit_close_client', [True, False])
+@pytest.mark.parametrize('explicit_close_server', [True, False])
+async def test_client_disconnect_early(  # noqa: C901
+    direction,
+    explicit_close_client,
+    explicit_close_server,
+    conductor,
+):
+    sample_data = os.urandom(64 * 1024)
+
+    class Resource:
+        def __init__(self):
+            self.data_received = asyncio.Event()
+            self.times_called = 0
+            self.data = None
+            self.ws_ready = None
+            self.ws_state = None
+            self.ws_closed = None
+            self.ws_client_close_code = None
+
+        async def on_websocket(self, req, ws):
+            self.times_called += 1
+
+            await ws.accept()
+
+            while True:
+                try:
+                    if direction == 'send':
+                        await ws.send_data(sample_data)
+
+                        if explicit_close_server:
+                            await ws.close(4099)
+                    else:
+                        self.data = await ws.receive_data()
+
+                        if explicit_close_server:
+                            # NOTE(kgriffs): We call ws.receive_data() again here in order
+                            #   to test coverage of the logic that handles the case
+                            #   of a closed connection while waiting on more data.
+                            recv_task = falcon.create_task(ws.receive_data())
+                            await asyncio.sleep(0)  # Ensure recv_task() has a chance to get ahead
+                            await asyncio.wait([recv_task, ws.close(4099)])
+
+                        self.data_received.set()
+
+                except falcon.WebSocketDisconnected as ex:
+                    self.ws_ready = ws.ready
+                    self.ws_client_close_code = ex.code
+                    self.ws_state = ws._state
+                    self.ws_closed = ws.closed
+                    break
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    disconnect_raised = False
+
+    async with conductor as c:
+        try:
+            async with c.simulate_ws('/') as ws:
+                if direction == 'send':
+                    received_data = await ws.receive_data()
+                    assert received_data == sample_data
+                else:
+                    await ws.send_data(sample_data)
+                    await resource.data_received.wait()
+                    assert resource.data == sample_data
+
+                if explicit_close_client:
+                    await ws.close(4042)
+
+        except falcon.WebSocketDisconnected as ex:
+            disconnect_raised = True
+            assert explicit_close_server
+            assert ex.code == 4099
+
+        if direction == 'send' and explicit_close_server:
+            assert disconnect_raised
+
+        code_expected = CloseCode.NORMAL
+
+        if explicit_close_server:
+            code_expected = 4099
+        elif explicit_close_client:
+            code_expected = 4042
+
+        assert resource.ws_client_close_code == code_expected
+        assert ws.close_code == code_expected
+
+    assert resource.times_called == 1
+    assert resource.ws_state == ServerWebSocketState.CLOSED
+    assert resource.ws_closed
+    assert resource.ws_ready is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('custom_text', [True, False])
+@pytest.mark.parametrize('custom_data', [True, False])
+async def test_media(custom_text, custom_data, conductor):  # NOQA: C901
+    sample_doc = {
+        'answer': 42,
+        'runes': b'\xe1\x9a\xa0\xe1\x9b\x87\xe1\x9a\xbb'.decode(),
+        'ascii': 'hello world'
+    }
+
+    sample_doc_bin = sample_doc.copy()
+    sample_doc_bin['bits'] = os.urandom(32)
+    sample_doc_bin['array'] = [0, 1, 2]
+
+    class Resource:
+        def __init__(self):
+            self.finished = asyncio.Event()
+            self.docs_received = []
+            self.deserialize_error_count = 0
+
+        async def on_websocket(self, req, ws):
+            try:
+                await ws.accept()
+
+                await ws.send_media(sample_doc)
+                self.docs_received.append(await ws.receive_media())
+                await ws.send_media(sample_doc, falcon.WebSocketPayloadType.TEXT)
+                self.docs_received.append(await ws.receive_media())
+
+                await ws.send_media(sample_doc_bin, falcon.WebSocketPayloadType.BINARY)
+                self.docs_received.append(await ws.receive_media())
+
+                for __ in range(3):
+                    try:
+                        await ws.receive_media()
+                    except (ValueError):
+                        self.deserialize_error_count += 1
+            finally:
+                self.finished.set()
+
+    app = conductor.app
+
+    resource = Resource()
+    app.add_route('/', resource)
+
+    if custom_text:
+        # Let's say we want to use a faster JSON library. You could also use this
+        #   pattern to add serialization support for custom types that aren't
+        #   normally JSON-serializable out of the box.
+        class RapidJSONHandler(media.TextBaseHandlerWS):
+            def serialize(self, media: object) -> str:
+                return rapidjson.dumps(media, ensure_ascii=False)
+
+            # The raw TEXT payload will be passed as a Unicode string
+            def deserialize(self, payload: str) -> object:
+                return rapidjson.loads(payload)
+
+        app.ws_options.media_handlers[falcon.WebSocketPayloadType.TEXT] = RapidJSONHandler()
+
+    if custom_data:
+        class CBORHandler(media.BinaryBaseHandlerWS):
+            def serialize(self, media: object) -> bytes:
+                return cbor2.dumps(media)
+
+            # The raw BINARY payload will be passed as a byte string
+            def deserialize(self, payload: bytes) -> object:
+                return cbor2.loads(payload)
+
+        app.ws_options.media_handlers[falcon.WebSocketPayloadType.BINARY] = CBORHandler()
+
+    async with conductor as c:
+        async with c.simulate_ws() as ws:
+            for __ in range(2):
+                doc = await ws.receive_json()
+                await ws.send_json(doc)
+
+            if custom_data:
+                data = await ws.receive_data()
+                cbor2.loads(data)  # NOT(kgriffs): Validate serialization format
+                await ws.send_data(data)
+            else:
+                doc = await ws.receive_msgpack()
+                await ws.send_msgpack(doc)
+
+            # NOTE(kgriffs): The first one will work, but we include it to
+            #    ensure we aren't getting any false-positives.
+            await ws.send_text('"DEADBEEF"')
+            await ws.send_text('DEADBEEF')
+            await ws.send_data(b'\xDE\xAD\xBE\xEF')
+
+            await resource.finished.wait()
+
+    assert resource.deserialize_error_count == 2
+
+    assert len(resource.docs_received) == 3
+    assert resource.docs_received[0] == sample_doc
+
+    expected = [sample_doc, sample_doc, sample_doc_bin]
+    for doc, doc_expected in zip(resource.docs_received, expected):
+        assert doc == doc_expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('sample_data', [b'123', b'', b'\xe1\x9a\xa0\xe1', b'\0'])
+async def test_send_receive_data(sample_data, conductor):
+    class Resource:
+        def __init__(self):
+            self.error_count = 0
+
+        async def on_websocket(self, req, ws):
+            await ws.accept()
+
+            await ws.send_data(await ws.receive_data())
+            await ws.send_data(bytearray(await ws.receive_data()))
+            await ws.send_data(memoryview(await ws.receive_data()))
+
+            for c in (ws.receive_data, ws.receive_media):
+                for __ in range(2):
+                    try:
+                        await c()
+                    except falcon.PayloadTypeError:
+                        self.error_count += 1
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        async with c.simulate_ws() as ws:
+            await ws.send_data(sample_data)
+            await ws.send_data(bytearray(sample_data))
+            await ws.send_data(memoryview(sample_data))
+
+            for __ in range(2):
+                ws._collected_client_events.append({'type': EventType.WS_RECEIVE})
+                ws._collected_client_events.append({'type': EventType.WS_RECEIVE, 'bytes': None})
+
+            for __ in range(3):
+                assert (await ws.receive_data()) == sample_data
+
+    assert resource.error_count == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('subprotocols', [
+    ['SIS508'],
+    ('DEADBEEF', 'SIS508'),
+    [],
+    None,
+])
+async def test_subprotocol(subprotocols, conductor):
+    class Resource:
+        def __init__(self):
+            self.test_complete = asyncio.Event()
+
+        async def on_websocket(self, req, ws):
+            subs = ws.subprotocols
+            assert isinstance(subs, tuple)
+
+            selected = subs[0] if subs else None
+            await ws.accept(subprotocol=selected)
+
+            await self.test_complete.wait()
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        async with c.simulate_ws(subprotocols=subprotocols) as ws:
+            try:
+                if not subprotocols:
+                    assert ws.subprotocol is None
+                else:
+                    assert ws.subprotocol == subprotocols[0]
+            finally:
+                resource.test_complete.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('headers', [
+    None,
+    [],
+    iter([]),
+    iter([iter(['X-Name', 'Value']), ('NAME', 'Value'), ('NAME', 'Value')]),
+    (['X-Name', 'Value'], ('NAME', 'Value'), ('NAME', 'Value')),
+    {'NAME': 'value'},
+    {'NAME': 'value', 'NameToo': 'ValueToo'},
+])
+async def test_accept_with_headers(headers, conductor):
+    class Resource:
+        def __init__(self):
+            self.test_complete = asyncio.Event()
+
+        async def on_websocket(self, req, ws):
+            await ws.accept(headers=headers)
+            await self.test_complete.wait()
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        async with c.simulate_ws() as ws:
+            try:
+                if not headers:
+                    assert ws.headers is None
+                else:
+                    headers_in = headers
+                    if isinstance(headers, dict):
+                        headers_in = headers.items()
+
+                    for (name_in, value_in), (name_out, value_out) in zip(headers_in, ws.headers):
+                        name_out = name_out.decode()
+                        value_out = value_out.decode()
+
+                        assert name_out.islower()
+                        assert name_in.lower() == name_out
+                        assert value_in == value_out
+
+            finally:
+                resource.test_complete.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('headers', [
+    [['sec-websocket-protocol', 'SIS508']],
+    [['non-ascii', b'\xe1\x9a\xa0\xe1\x9b\x87\xe1\x9a\xbb'.decode()]],
+    {b'\xe1\x9a\xa0\xe1\x9b\x87\xe1\x9a\xbb'.decode(): 'non-ascii'}
+])
+async def test_accept_with_bad_headers(headers, conductor):
+    class Resource:
+        def __init__(self):
+            self.raised_error = None
+
+        async def on_websocket(self, req, ws):
+            try:
+                assert ws.supports_accept_headers
+                await ws.accept(headers=headers)
+            except Exception as ex:
+                self.raised_error = ex
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        try:
+            async with c.simulate_ws():
+                pass
+        except falcon.WebSocketDisconnected:
+            pass
+
+    assert isinstance(resource.raised_error, ValueError)
+
+
+@pytest.mark.asyncio
+async def test_accept_with_headers_not_supported(conductor):
+    class Resource:
+        def __init__(self):
+            self.raised_error = None
+
+        async def on_websocket(self, req, ws):
+            try:
+                assert not ws.supports_accept_headers
+                await ws.accept(headers={'name': 'value'})
+            except Exception as ex:
+                self.raised_error = ex
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        try:
+            async with c.simulate_ws(spec_version='2.0'):
+                pass
+        except falcon.WebSocketDisconnected:
+            pass
+
+    assert isinstance(resource.raised_error, falcon.OperationNotAllowed)
+
+
+@pytest.mark.asyncio
+async def test_missing_ws_handler(conductor):
+    class Resource:
+        async def on_get(self, req, resp):
+            pass
+
+    conductor.app.add_route('/', Resource())
+
+    async with conductor as c:
+        with pytest.raises(falcon.WebSocketHandlerNotFound):
+            async with c.simulate_ws():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_unexpected_param(conductor):
+    class Resource:
+        async def on_websocket(self, req, ws):
+            pass
+
+    conductor.app.add_route('/{id}', Resource())
+
+    async with conductor as c:
+        with pytest.raises(falcon.WebSocketServerError):
+            async with c.simulate_ws('/DEADBEEF'):
+                pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('subprotocol', [
+    b'DEADBEEF',
+    ['SIS508'],
+    [],
+    tuple(),
+    {},
+
+    'OK',  # control
+])
+async def test_subprotocol_bad_type(subprotocol, conductor):
+    class Resource:
+        def __init__(self):
+            self.test_complete = asyncio.Event()
+
+        async def on_websocket(self, req, ws):
+            await ws.accept(subprotocol=subprotocol)
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        if isinstance(subprotocol, str):
+            async with c.simulate_ws():
+                pass
+        else:
+            with pytest.raises(falcon.WebSocketServerError):
+                async with c.simulate_ws():
+                    pass
+
+
+@pytest.mark.asyncio
+async def test_send_receive_wrong_type(conductor):
+    class Resource:
+        def __init__(self):
+            self.error_count = 0
+
+        async def on_websocket(self, req, ws):
+            await ws.accept()
+
+            try:
+                await ws.receive_data()
+            except falcon.PayloadTypeError:
+                self.error_count += 1
+
+            try:
+                await ws.receive_text()
+            except falcon.PayloadTypeError:
+                self.error_count += 1
+
+            try:
+                await ws.send_text(b'')
+            except TypeError:
+                self.error_count += 1
+
+            try:
+                await ws.send_data('')
+            except TypeError:
+                self.error_count += 1
+
+            await ws.send_text('text')
+            await ws.send_data(b'data')
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        async with c.simulate_ws() as ws:
+            with pytest.raises(TypeError):
+                await ws.send_text(b'')
+
+            with pytest.raises(TypeError):
+                await ws.send_data('')
+
+            await ws.send_text('text')
+            await ws.send_data(b'data')
+
+            with pytest.raises(falcon.PayloadTypeError):
+                await ws.receive_data()
+
+            with pytest.raises(falcon.PayloadTypeError):
+                await ws.receive_text()
+
+    assert resource.error_count == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('options_code', [
+    999,
+    100,
+    0,
+    -1,
+    1004,
+    1005,
+    1006,
+    1015,
+    1016,
+    1017,
+    1050,
+    1099,
+    'NaN'
+])
+async def test_client_disconnect_uncaught_error(options_code, conductor):
+    class Resource:
+        def __init__(self):
+            self.disconnected = False
+
+        async def on_websocket(self, req, ws):
+            await ws.accept()
+            while True:
+                try:
+                    await ws.receive_text()
+                except falcon.WebSocketDisconnected:
+                    self.disconnected = True
+                    raise
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+    conductor.app.ws_options.error_close_code = options_code
+
+    async with conductor as c:
+        try:
+            async with c.simulate_ws('/') as ws:
+                await ws.send_text('hello')
+        except ValueError:
+            assert options_code == 'NaN'
+
+    assert resource.disconnected
+    assert ws.close_code == CloseCode.NORMAL
+
+
+def test_mw_methods_must_be_coroutines():
+    class MiddlewareA:
+        def process_resource_ws(self, req, ws, resource, params):
+            pass
+
+    class MiddlewareB:
+        def process_request_ws(self, req, ws):
+            pass
+
+    app = App()
+
+    for mw in [MiddlewareA(), MiddlewareB()]:
+        with pytest.raises(falcon.CompatibilityError):
+            app.add_middleware(mw)
+
+        with pytest.raises(falcon.CompatibilityError):
+            App(middleware=mw)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('version', ['1.9', '20.5', '3.0', '3.1'])
+async def test_bad_spec_version(version, conductor):
+    async with conductor as c:
+        with pytest.raises(falcon.UnsupportedScopeError):
+            async with c.simulate_ws('/', spec_version=version):
+                pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('version', ['1.0', '1'])
+async def test_bad_http_version(version, conductor):
+    async with conductor as c:
+        with pytest.raises(falcon.UnsupportedError):
+            async with c.simulate_ws('/', http_version=version):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_bad_first_event():
+    app = App()
+
+    scope = testing.create_scope_ws()
+    del scope['asgi']['spec_version']
+
+    ws = testing.ASGIWebSocketSimulator()
+    wrapped_emit = ws._emit
+
+    async def _emit():
+        if ws._state == ClientWebSocketState.CONNECT:
+            ws._state = ClientWebSocketState.HANDSHAKE
+            return {'type': EventType.WS_SEND}
+
+        return await wrapped_emit(ws)
+
+    ws._emit = _emit
+
+    # NOTE(kgriffs): If there is a bad first event, the framework should
+    #   just bail out early and close the request...
+    await app(scope, ws._emit, ws._collect)
+
+    assert ws.closed
+    assert ws.close_code == CloseCode.SERVER_ERROR
+
+
+@pytest.mark.asyncio
+async def test_missing_http_version():
+    app = App()
+
+    scope = testing.create_scope_ws()
+    del scope['http_version']
+
+    ws = testing.ASGIWebSocketSimulator()
+
+    # NOTE(kgriffs): As long as this does not raise, we know the http
+    #   version defaulted OK.
+    await app(scope, ws._emit, ws._collect)
+
+
+@pytest.mark.asyncio
+async def test_missing_spec_version():
+    app = App()
+
+    scope = testing.create_scope_ws()
+    del scope['asgi']['spec_version']
+
+    ws = testing.ASGIWebSocketSimulator()
+
+    # NOTE(kgriffs): As long as this does not raise, we know the spec
+    #   version defaulted OK.
+    await app(scope, ws._emit, ws._collect)
+
+
+@pytest.mark.asyncio
+async def test_translate_webserver_error(conductor):
+    class Resource:
+        def __init__(self):
+            self.error_count = 0
+            self.test_complete = asyncio.Event()
+
+        async def on_websocket(self, req, ws):
+            await ws.accept()
+
+            async def raise_disconnect(self):
+                raise Exception('Disconnected with code = 1000 (OK)')
+
+            async def raise_protocol_mismatch(self):
+                raise Exception('protocol accepted must be from the list')
+
+            async def raise_other(self):
+                raise RuntimeError()
+
+            _asgi_send = ws._asgi_send
+
+            ws._asgi_send = raise_other
+            try:
+                await ws.send_data(b'123')
+            except Exception:
+                self.error_count += 1
+
+            ws._asgi_send = raise_protocol_mismatch
+            try:
+                await ws.send_data(b'123')
+            except ValueError:
+                self.error_count += 1
+
+            ws._asgi_send = raise_disconnect
+            try:
+                await ws.send_data(b'123')
+            except falcon.WebSocketDisconnected:
+                self.error_count += 1
+
+            ws._asgi_send = _asgi_send
+
+            self.test_complete.set()
+
+    resource = Resource()
+    conductor.app.add_route('/', resource)
+
+    async with conductor as c:
+        async with c.simulate_ws():
+            await resource.test_complete.wait()
+
+
+def test_ws_base_not_implemented():
+    th = media.TextBaseHandlerWS()
+
+    with pytest.raises(NotImplementedError):
+        th.serialize({})
+
+    with pytest.raises(NotImplementedError):
+        th.deserialize('')
+
+    bh = media.BinaryBaseHandlerWS()
+
+    with pytest.raises(NotImplementedError):
+        bh.serialize({})
+
+    with pytest.raises(NotImplementedError):
+        bh.deserialize(b'')
+
+
+@pytest.mark.asyncio
+async def test_ws_context_timeout(conductor):
+    class Resource:
+        async def on_websocket(self, req, ws):
+            await asyncio.sleep(5.1)  # Anything longer than 5 is sufficient
+
+    conductor.app.add_route('/', Resource())
+
+    async with conductor as c:
+        with pytest.raises(asyncio.TimeoutError):
+            async with c.simulate_ws():
+                pass
+
+
+@pytest.mark.asyncio
+async def test_ws_simulator_client_require_accepted(conductor):
+    class Resource:
+        async def on_websocket(self, req, ws):
+            await asyncio.sleep(5.1)  # Anything longer than 5 is sufficient
+
+    conductor.app.add_route('/', Resource())
+
+    async with conductor as c:
+        context = c.simulate_ws()
+        ws = context._ws
+
+        assert not ws.ready
+
+        m = 'not yet been accepted'
+        with pytest.raises(falcon.OperationNotAllowed, match=m):
+            await ws.receive_text()
+
+
+@pytest.mark.asyncio
+async def test_ws_simulator_collect_edge_cases(conductor):
+    class Resource:
+        pass
+
+    conductor.app.add_route('/', Resource())
+
+    async with conductor as c:
+        context = c.simulate_ws()
+        ws = context._ws
+
+        m = 'must receive the first websocket.connect'
+        with pytest.raises(falcon.OperationNotAllowed, match=m):
+            await ws._collect({'type': 'test'})
+
+        event = await ws._emit()
+        assert event['type'] == EventType.WS_CONNECT
+
+        m = 'before sending any other event types'
+        with pytest.raises(falcon.OperationNotAllowed, match=m):
+            await ws._collect({'type': EventType.WS_SEND})
+
+        await ws.close()
+
+        # NOTE(kgriffs): The collector should just eat all subsequent events
+        #   returned from the ASGI app.
+        for __ in range(100):
+            await ws._collect({'type': EventType.WS_SEND})
+
+        assert not ws._collected_server_events
+
+        event = await ws._emit()
+        assert event['type'] == EventType.WS_DISCONNECT
+
+        m = 'websocket.disconnect event has already been emitted'
+        with pytest.raises(falcon.OperationNotAllowed, match=m):
+            event = await ws._emit()

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -67,7 +67,7 @@ class TestInspectApp:
         assert ai.middleware.independent is True
         assert ai.static_routes == []
         assert ai.sinks == []
-        assert len(ai.error_handlers) == 3
+        assert len(ai.error_handlers) == 4 if asgi else 3
         assert ai.asgi is asgi
 
     def test_dependent_middlewares(self, asgi):
@@ -85,7 +85,7 @@ class TestInspectApp:
         assert len(ai.middleware.middleware_classes) == 3
         assert len(ai.static_routes) == 2
         assert len(ai.sinks) == 2
-        assert len(ai.error_handlers) == 4
+        assert len(ai.error_handlers) == 5 if asgi else 4
         assert ai.asgi is asgi
 
     def check_route(self, asgi, r, p, cn, ml, fnt):
@@ -162,7 +162,7 @@ class TestInspectApp:
         assert errors[-1].internal is False
         for eh in errors[:-1]:
             assert eh.internal
-            assert eh.error in ('Exception', 'HTTPStatus', 'HTTPError')
+            assert eh.error in ('WebSocketDisconnected', 'Exception', 'HTTPStatus', 'HTTPError')
 
     def test_middleware(self, asgi):
         mi = inspect.inspect_middlewares(make_app_async() if asgi else make_app())

--- a/tools/mintest.sh
+++ b/tools/mintest.sh
@@ -3,4 +3,7 @@
 pip install -U tox coverage
 
 rm -f .coverage.*
-tox -e pep8 && tox -e mypy && tox -e py35,py38 && tools/testing/combine_coverage.sh
+
+# NOTE(kgriffs): Do one at a time so we can just bail and not waste time
+#   with the other envs which will also likely fail anyway.
+tox -e pep8 && tox -e mypy && tox -e py35 && tox -e py38 && tools/testing/combine_coverage.sh

--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ deps = {[with-debug-tools]deps}
 # mypy
 # --------------------------------------------------------------------
 [testenv:mypy]
+basepython = python3.8
 deps = {[testenv]deps}
        pytest-mypy
 commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon


### PR DESCRIPTION
# Summary of Changes

This patch adds support for the ASGI WebSocket connection scope. The primary code paths have been tested via uvicorn/daphne and the feature is considered alpha quality until full test coverage and documentation are added. Note also that there is currently no support in the testing module for simulating WebSocket connections.

# Related Issues

#321

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
