### PR TITLE
docs(recipes): add a recipe for streaming CSV reports on the fly

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -852,7 +852,9 @@ cookie in subsequent requests.
 
 (See also the :ref:`cookie documentation <cookie-secure-attribute>`.)
 
-How can I serve a downloadable file with falcon?
+.. _serve-downloadable-as:
+
+How can I serve a downloadable file with Falcon?
 ------------------------------------------------
 In the ``on_get()`` responder method for the resource, you can tell the user
 agent to download the file by setting the Content-Disposition header. Falcon

--- a/docs/user/recipes/index.rst
+++ b/docs/user/recipes/index.rst
@@ -4,4 +4,5 @@ Recipes
 .. toctree::
    :maxdepth: 2
 
+   output-csv
    request-id

--- a/docs/user/recipes/output-csv.rst
+++ b/docs/user/recipes/output-csv.rst
@@ -1,0 +1,141 @@
+Outputting CSV Files
+====================
+
+Generating a CSV (or PDF etc) report and making it available as a downloadable
+file is a fairly common back-end service task.
+
+The easiest approach is to simply write CSV rows to an ``io.StringIO`` stream,
+and then assign its value to :attr:`resp.body <falcon.Response.body>`:
+
+.. tabs::
+
+    .. group-tab:: WSGI
+
+        .. code:: python
+
+            class Report:
+
+                def on_get(self, req, resp):
+                    output = io.StringIO()
+                    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+                    writer.writerow(('fruit', 'quantity'))
+                    writer.writerow(('apples', 13))
+                    writer.writerow(('oranges', 37))
+
+                    resp.content_type = 'text/csv'
+                    resp.downloadable_as = 'report.csv'
+                    resp.body = output.getvalue()
+
+    .. group-tab:: ASGI
+
+        .. code:: python
+
+            class Report:
+
+                async def on_get(self, req, resp):
+                    output = io.StringIO()
+                    writer = csv.writer(output, quoting=csv.QUOTE_NONNUMERIC)
+                    writer.writerow(('fruit', 'quantity'))
+                    writer.writerow(('apples', 13))
+                    writer.writerow(('oranges', 37))
+
+                    resp.content_type = 'text/csv'
+                    resp.downloadable_as = 'report.csv'
+                    resp.body = output.getvalue()
+
+Here we are setting the response ``Content-Type`` to ``"text/csv"`` as
+recommended by `RFC 4180 <https://tools.ietf.org/html/rfc4180>`_, and assigning
+the downloadable file name ``report.csv`` via the ``Content-Disposition``
+header (see also: :ref:`serve-downloadable-as`).
+
+Streaming Large CSV Files on the Fly
+------------------------------------
+
+If generated CSV responses are expected to be very large, it might be worth
+considering streaming CSV data on the fly. This will both avoid excessive
+memory consumption to hold whole response data, and reduce the time to first
+byte for the viewer.
+
+In order to stream CSV rows on the fly, we will initialize the CSV writer with
+our own pseudo stream object which implements the ``write()`` method by
+accumulating data in a list. We will then set :attr:`resp.stream
+<falcon.Response.stream>` to a generator yielding data chunks from this list:
+
+
+.. tabs::
+
+    .. group-tab:: WSGI
+
+        .. code:: python
+
+            class Report:
+
+                class PseudoTextStream:
+                    def __init__(self):
+                        self.clear()
+
+                    def clear(self):
+                        self.result = []
+
+                    def write(self, data):
+                        self.result.append(data.encode())
+
+                def fibonacci_generator(self, n=1000):
+                    stream = self.PseudoTextStream()
+                    writer = csv.writer(stream, quoting=csv.QUOTE_NONNUMERIC)
+                    writer.writerow(('n', 'Fibonacci Fn'))
+
+                    previous = 1
+                    current = 0
+                    for i in range(n+1):
+                        writer.writerow((i, current))
+                        previous, current = current, current + previous
+
+                        yield from stream.result
+                        stream.clear()
+
+                def on_get(self, req, resp):
+                    resp.content_type = 'text/csv'
+                    resp.downloadable_as = 'report.csv'
+                    resp.stream = self.fibonacci_generator()
+
+    .. group-tab:: ASGI
+
+        .. code:: python
+
+            class Report:
+
+                class PseudoTextStream:
+                    def __init__(self):
+                        self.clear()
+
+                    def clear(self):
+                        self.result = []
+
+                    def write(self, data):
+                        self.result.append(data.encode())
+
+                async def fibonacci_generator(self, n=1000):
+                    stream = self.PseudoTextStream()
+                    writer = csv.writer(stream, quoting=csv.QUOTE_NONNUMERIC)
+                    writer.writerow(('n', 'Fibonacci Fn'))
+
+                    previous = 1
+                    current = 0
+                    for i in range(n+1):
+                        writer.writerow((i, current))
+                        previous, current = current, current + previous
+
+                        for chunk in stream.result:
+                            yield chunk
+                        stream.clear()
+
+                async def on_get(self, req, resp):
+                    resp.content_type = 'text/csv'
+                    resp.downloadable_as = 'report.csv'
+                    resp.stream = self.fibonacci_generator()
+
+        .. note::
+            At the time of writing, Python does not support ``yield from`` here
+            in an asynchronous generator, so we substitute it with a loop
+            expression.


### PR DESCRIPTION
Based on the help I've given on the `falconry/user` Gitter channel.
