### PR TITLE
docs(recipes): add a recipe for capitalizing response header names

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -863,6 +863,31 @@ easy:
 
     resp.downloadable_as = 'report.pdf'
 
+.. _faq_header_names_lowercase:
+
+Why is Falcon changing my header names to lowercase?
+----------------------------------------------------
+
+Falcon always lowercases header names before storing them in the internal
+:class:`Response <falcon.Response>` structures in order to make the response
+header handling straightforward and performant, as header name lookup can be
+done using a simple ``dict``. Since HTTP headers are case insensitive, this
+optimization should normally not affect your API consumers.
+
+In the unlikely case you absolutely must deal with non-conformant HTTP clients
+expecting a specific header name capitalization, see this recipe how to
+override header names using generic WSGI middleware:
+:ref:`capitalizing_response_headers`.
+
+Note that this question only applies to the WSGI flavor of Falcon. The
+`ASGI HTTP scope specification
+<https://asgi.readthedocs.io/en/latest/specs/www.html#response-start-send-event>`_
+requires HTTP header names to be lowercased.
+
+Furthermore, the HTTP2 standard also mandates that header field names MUST be
+converted to lowercase (see `RFC 7540, Section 8.1.2
+<https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2>`_).
+
 Can Falcon serve static files?
 ------------------------------
 

--- a/docs/user/recipes/header-name-case.rst
+++ b/docs/user/recipes/header-name-case.rst
@@ -1,0 +1,61 @@
+.. _capitalizing_response_headers:
+
+Capitalizing Response Header Names
+==================================
+
+Falcon is opting to always render WSGI response header names in lower case; see
+also: :ref:`faq_header_names_lowercase`
+
+While this should normally never be an issue for standards-conformant HTTP
+clients, it is possible to override HTTP headers using
+`generic WSGI middleware
+<https://www.python.org/dev/peps/pep-3333/#middleware-components-that-play-both-sides>`_:
+
+.. code:: python
+
+    class CustomHeadersMiddleware:
+
+        def __init__(self, app, title_case=True, custom_capitalization=None):
+            self._app = app
+            self._title_case = title_case
+            self._capitalization = custom_capitalization or {}
+
+        def __call__(self, environ, start_response):
+            def start_response_wrapper(status, response_headers, exc_info=None):
+                if self._title_case:
+                    headers = [
+                        (self._capitalization.get(name, name.title()), value)
+                        for name, value in response_headers]
+                else:
+                    headers = [
+                        (self._capitalization.get(name, name), value)
+                        for name, value in response_headers]
+                start_response(status, headers, exc_info)
+
+            return self._app(environ, start_response_wrapper)
+
+We can now use this middleware to wrap a Falcon app:
+
+.. code:: python
+
+    import falcon
+
+    # Import or define CustomHeadersMiddleware from the above snippet...
+
+
+    class FunkyResource:
+
+        def on_get(self, req, resp):
+            resp.set_header('X-Funky-Header', 'test')
+            resp.media = {'message': 'Hello'}
+
+
+    app = falcon.App()
+    app.add_route('/test', FunkyResource())
+
+    app = CustomHeadersMiddleware(
+        app,
+        custom_capitalization={'x-funky-header': 'X-FuNkY-HeADeR'},
+    )
+
+As a bonus, this recipe applies to non-Falcon WSGI applications too.

--- a/docs/user/recipes/index.rst
+++ b/docs/user/recipes/index.rst
@@ -4,5 +4,6 @@ Recipes
 .. toctree::
    :maxdepth: 2
 
+   header-name-case
    pretty-json
    request-id


### PR DESCRIPTION
While this PR does not solve #578, it attempts to document the problem away by offering a generic WSGI middleware recipe.
