### PR TITLE
docs(middleware): fix typo in middleware

### DIFF
--- a/docs/api/middleware.rst
+++ b/docs/api/middleware.rst
@@ -78,7 +78,7 @@ defined below.
 
     .. tab:: ASGI
 
-        The ASGI middleware interface is similar to ASGI, but also supports the
+        The ASGI middleware interface is similar to WSGI, but also supports the
         standard ASGI lifespan events. However, because lifespan events are an
         optional part of the ASGI specification, they may or may not fire depending
         on your ASGI server.


### PR DESCRIPTION
Just a short documentation typo fix.

I've just noticed that github from the website does not place the branch on my fork. Sorry about that