### PR TITLE
chore(Actions): try working around broken setuptools 50.0.0 on CPython 3.5.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -77,15 +77,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        if: ${{ matrix.toxenv == 'py35' }}
+        with:
+          python-version: 3.8
+
       - name: Set up Python 3.5.2
         if: ${{ matrix.toxenv == 'py35' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential curl python3.5 python3.5-dev
-          sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.5 10
-          curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-          sudo python /tmp/get-pip.py
-          sudo pip install coverage tox
+          python3.5 --version
 
       - name: Install smoke test dependencies
         if: ${{ matrix.toxenv == 'py38_smoke' || matrix.toxenv == 'py38_smoke_cython' }}
@@ -100,6 +103,7 @@ jobs:
           python --version
           pip --version
           tox --version
+          coverage --version
 
       - name: Run tests
         run: tox -e ${{ matrix.toxenv }}


### PR DESCRIPTION
Our `py35` environment seems to error out on GH Actions, see also: https://github.com/pypa/setuptools/issues/2356

However, I noticed that using `tox` and `virtualenv` from `python3.8` works locally on my workstation. Trying that on Actions...