### PR TITLE
fix(Response.downloadable_as): properly handle comma in unicode filenames

### DIFF
--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -102,7 +102,7 @@ def format_content_disposition(value):
     #     "filename" should occur first, due to parsing problems in some
     #     existing implementations.
     return "attachment; filename=%s; filename*=UTF-8''%s" % (
-        secure_filename(value), uri.encode(value))
+        secure_filename(value), uri.encode_value(value))
 
 
 def format_etag_header(value):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -500,6 +500,12 @@ class TestHeaders:
             'attachment; filename=A_ngstro_m_unit.txt; '
             "filename*=UTF-8''%C3%85ngstr%C3%B6m%20unit.txt",
         ),
+        ('one,two.txt', 'attachment; filename="one,two.txt"'),
+        (
+            '½,²⁄₂.txt',
+            'attachment; filename=1_2_2_2.txt; '
+            "filename*=UTF-8''%C2%BD%2C%C2%B2%E2%81%84%E2%82%82.txt"
+        ),
     ])
     def test_content_disposition_header(self, client, filename, expected):
         resource = DownloadableResource(filename)

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -506,6 +506,12 @@ class TestHeaders:
             'attachment; filename=1_2_2_2.txt; '
             "filename*=UTF-8''%C2%BD%2C%C2%B2%E2%81%84%E2%82%82.txt"
         ),
+        ('[foo] @ bar.txt', 'attachment; filename="[foo] @ bar.txt"'),
+        (
+            '[fòó]@bàr,bäz.txt',
+            'attachment; filename=_fo_o___ba_r_ba_z.txt; '
+            "filename*=UTF-8''%5Bf%C3%B2%C3%B3%5D%40b%C3%A0r%2Cb%C3%A4z.txt"
+        ),
     ])
     def test_content_disposition_header(self, client, filename, expected):
         resource = DownloadableResource(filename)


### PR DESCRIPTION
When `dowloadable_as` was updated to handle unicode in filenames in https://github.com/falconry/falcon/pull/1750 a bug was introduced when the file has unicode character and a has comma in them.

This fixes the bug by escaping also the commas.

Closes https://github.com/falconry/falcon/issues/1749 (again)