### PR TITLE
feat(testing): Added cookies kwarg to async simulate_request function

### DIFF
--- a/falcon/app.py
+++ b/falcon/app.py
@@ -1008,7 +1008,7 @@ class App:
         return [], 0
 
 
-# TODO(myuz): This class is a compatibility alias, and should be removed
+# TODO(myusko): This class is a compatibility alias, and should be removed
 # in the next major release (4.0).
 class API(App):
     """

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -664,9 +664,9 @@ async def _simulate_request_asgi(
             ``environ`` dictionary or the ASGI scope for the request
             (default: ``None``)
         cookies (dict): Cookies as a dict-like (Mapping) object, or an
-        iterable yielding a series of two-member (*name*, *value*)
-        iterables. Each pair of items provides the name and value
-        for the 'Set-Cookie' header.
+            iterable yielding a series of two-member (*name*, *value*)
+            iterables. Each pair of items provides the name and value
+            for the 'Set-Cookie' header.
 
     Returns:
         :py:class:`~.Result`: The result of the request

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -520,7 +520,7 @@ def simulate_request(app, method='GET', path='/', query_string=None,
             params=params, params_csv=params_csv, protocol=protocol, host=host,
             remote_addr=remote_addr, extras=extras, http_version=http_version,
             port=port, root_path=root_path, asgi_chunk_size=asgi_chunk_size,
-            asgi_disconnect_ttl=asgi_disconnect_ttl,
+            asgi_disconnect_ttl=asgi_disconnect_ttl, cookies=cookies
         )
 
     path, query_string, headers, body, extras = _prepare_sim_args(
@@ -574,7 +574,7 @@ async def _simulate_request_asgi(
     params_csv=True, protocol='http', host=helpers.DEFAULT_HOST,
     remote_addr=None, extras=None, http_version='1.1',
     port=None, root_path=None, asgi_chunk_size=4096,
-    asgi_disconnect_ttl=300,
+    asgi_disconnect_ttl=300, cookies=None,
 
     # NOTE(kgriffs): These are undocumented because they are only
     #   meant to be used internally by the framework (i.e., they are
@@ -663,6 +663,10 @@ async def _simulate_request_asgi(
         extras (dict): Additional values to add to the WSGI
             ``environ`` dictionary or the ASGI scope for the request
             (default: ``None``)
+        cookies (dict): Cookies as a dict-like (Mapping) object, or an
+        iterable yielding a series of two-member (*name*, *value*)
+        iterables. Each pair of items provides the name and value
+        for the 'Set-Cookie' header.
 
     Returns:
         :py:class:`~.Result`: The result of the request
@@ -694,6 +698,7 @@ async def _simulate_request_asgi(
         remote_addr=remote_addr,
         root_path=root_path,
         content_length=content_length,
+        cookies=cookies,
     )
 
     if 'method' in extras and extras['method'] != method.upper():

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -257,7 +257,6 @@ def create_app():
     app.add_route('/forms', Multipart())
     app.add_route('/jars', TestJar())
     app.add_route('/feeds/{feed_id}', Feed())
-    
     lifespan_handler = LifespanHandler()
     app.add_middleware(lifespan_handler)
 

--- a/tests/asgi/test_scope.py
+++ b/tests/asgi/test_scope.py
@@ -215,6 +215,11 @@ def test_cookies(cookies):
     assert any(header == b'cookie' for header, _ in scope['headers'])
 
 
+def test_cookies_options_meathod():
+    scope = testing.create_scope(method='OPTIONS', cookies={'foo': 'bar'})
+    assert not any(header == b'cookie' for header, _ in scope['headers'])
+
+
 def _call_with_scope(scope):
     app = App()
 

--- a/tests/asgi/test_scope.py
+++ b/tests/asgi/test_scope.py
@@ -8,6 +8,11 @@ from falcon.asgi import App
 from falcon.errors import UnsupportedScopeError
 
 
+class CustomCookies:
+    def items(self):
+        return [('foo', 'bar')]
+
+
 def test_missing_asgi_version():
     scope = testing.create_scope()
     del scope['asgi']
@@ -199,6 +204,15 @@ def test_scheme(scheme, valid):
     else:
         with pytest.raises(ValueError):
             testing.create_scope(scheme=scheme)
+
+
+@pytest.mark.parametrize('cookies', [
+    {'foo': 'bar', 'baz': 'foo'},
+    CustomCookies()
+])
+def test_cookies(cookies):
+    scope = testing.create_scope(cookies=cookies)
+    assert any(header == b'cookie' for header, _ in scope['headers'])
 
 
 def _call_with_scope(scope):

--- a/tests/asgi/test_testing_asgi.py
+++ b/tests/asgi/test_testing_asgi.py
@@ -3,7 +3,8 @@ import time
 import pytest
 
 import falcon
-from falcon import asgi, testing
+from falcon import testing
+from . import _asgi_test_app
 
 
 @pytest.mark.asyncio
@@ -106,28 +107,9 @@ def test_is_asgi_app_cls():
 
 
 def test_cookies_jar():
-    class Bar:
-        async def on_get(self, req, resp):
-            # NOTE(myusko): In the future we shouldn't change the cookie
-            #             a test depends on the input.
-            # NOTE(kgriffs): This is the only test that uses a single
-            #   cookie (vs. multiple) as input; if this input ever changes,
-            #   a separate test will need to be added to explicitly verify
-            #   this use case.
-            resp.set_cookie('has_permission', 'true')
+    client = testing.TestClient(_asgi_test_app.application)
 
-        async def on_post(self, req, resp):
-            if req.cookies['has_permission'] == 'true':
-                resp.status = falcon.HTTP_200
-            else:
-                resp.status = falcon.HTTP_403
-
-    app = asgi.App()
-    app.add_route('/async_jars', Bar())
-
-    client = testing.TestClient(app)
-
-    response_one = client.simulate_get('/async_jars')
-    response_two = client.simulate_post('/async_jars', cookies=response_one.cookies)
+    response_one = client.simulate_get('/jars')
+    response_two = client.simulate_post('/jars', cookies=response_one.cookies)
 
     assert response_two.status == falcon.HTTP_200

--- a/tests/asgi/test_testing_asgi.py
+++ b/tests/asgi/test_testing_asgi.py
@@ -3,7 +3,7 @@ import time
 import pytest
 
 import falcon
-from falcon import testing, asgi
+from falcon import asgi, testing
 
 
 @pytest.mark.asyncio

--- a/tests/asgi/test_testing_asgi.py
+++ b/tests/asgi/test_testing_asgi.py
@@ -2,7 +2,8 @@ import time
 
 import pytest
 
-from falcon import testing
+import falcon
+from falcon import testing, asgi
 
 
 @pytest.mark.asyncio
@@ -102,3 +103,31 @@ def test_is_asgi_app_cls():
             pass
 
     assert testing.client._is_asgi_app(Foo.class_meth)
+
+
+def test_cookies_jar():
+    class Bar:
+        async def on_get(self, req, resp):
+            # NOTE(myusko): In the future we shouldn't change the cookie
+            #             a test depends on the input.
+            # NOTE(kgriffs): This is the only test that uses a single
+            #   cookie (vs. multiple) as input; if this input ever changes,
+            #   a separate test will need to be added to explicitly verify
+            #   this use case.
+            resp.set_cookie('has_permission', 'true')
+
+        async def on_post(self, req, resp):
+            if req.cookies['has_permission'] == 'true':
+                resp.status = falcon.HTTP_200
+            else:
+                resp.status = falcon.HTTP_403
+
+    app = asgi.App()
+    app.add_route('/async_jars', Bar())
+
+    client = testing.TestClient(app)
+
+    response_one = client.simulate_get('/async_jars')
+    response_two = client.simulate_post('/async_jars', cookies=response_one.cookies)
+
+    assert response_two.status == falcon.HTTP_200

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -1,4 +1,4 @@
-# NOTE(myuz): A file contains temporary tests for API alias
+# NOTE(myusko): A file contains temporary tests for API alias
 # and it will be deleted once the API alias will be removed
 
 import pytest

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -117,10 +117,10 @@ def test_cookies_jar():
             #   cookie (vs. multiple) as input; if this input ever changes,
             #   a separate test will need to be added to explicitly verify
             #   this use case.
-            resp.set_cookie('has_async_permission', 'true')
+            resp.set_cookie('has_permission', 'true')
 
         def on_post(self, req, resp):
-            if req.cookies['has_async_permission'] == 'true':
+            if req.cookies['has_permission'] == 'true':
                 resp.status = falcon.HTTP_200
             else:
                 resp.status = falcon.HTTP_403

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,7 +1,7 @@
 import pytest
 
 import falcon
-from falcon import App, asgi, status_codes, testing
+from falcon import App, status_codes, testing
 
 
 class CustomCookies:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -134,31 +134,3 @@ def test_cookies_jar():
     response_two = client.simulate_post('/jars', cookies=response_one.cookies)
 
     assert response_two.status == falcon.HTTP_200
-
-
-def test_cookies_jar_async():
-    class Bar:
-        async def on_get(self, req, resp):
-            # NOTE(myusko): In the future we shouldn't change the cookie
-            #             a test depends on the input.
-            # NOTE(kgriffs): This is the only test that uses a single
-            #   cookie (vs. multiple) as input; if this input ever changes,
-            #   a separate test will need to be added to explicitly verify
-            #   this use case.
-            resp.set_cookie('has_permission', 'true')
-
-        async def on_post(self, req, resp):
-            if req.cookies['has_permission'] == 'true':
-                resp.status = falcon.HTTP_200
-            else:
-                resp.status = falcon.HTTP_403
-
-    app = asgi.App()
-    app.add_route('/async_jars', Bar())
-
-    client = testing.TestClient(app)
-
-    response_one = client.simulate_get('/async_jars')
-    response_two = client.simulate_post('/async_jars', cookies=response_one.cookies)
-
-    assert response_two.status == falcon.HTTP_200


### PR DESCRIPTION
# Summary of Changes

Added `cookies` kwarg to async `simulate_request` function, now a user able to pass cookies to the simulated request.

e.g

```python
response = test_client.get('/', cookies={'foo': 'bar'}

# and also we can pass custom class which implements items() method.
class CustomCookies:
    def items(self):
        return [('foo', 'bar')]

response = test_client.get('/', cookies=CustomCookies())
```

# Related Issues
Follow up for the #1715 PR.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
