### PR TITLE
Fix compiler router setting erroneous params

### DIFF
--- a/docs/_newsfragments/1779.bugfix.rst
+++ b/docs/_newsfragments/1779.bugfix.rst
@@ -1,0 +1,2 @@
+The compiled router no longer mistakenly sets route parameters
+while exploring non matching routes.

--- a/docs/_newsfragments/1779.bugfix.rst
+++ b/docs/_newsfragments/1779.bugfix.rst
@@ -1,2 +1,2 @@
-The compiled router no longer mistakenly sets route parameters
+The :class:`falcon.routing.CompiledRouter` no longer mistakenly sets route parameters
 while exploring non matching routes.

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -382,7 +382,7 @@ class CompiledRouter:
     ):
         """Generate a coarse AST for the router."""
         # NOTE(caselit): setting of the parameters in the params dict is delayed until
-        # a match has been found by adding the to the param_stack. This way superfluous
+        # a match has been found by adding them to the param_stack. This way superfluous
         # parameters are not set to the params dict while descending on branches that
         # ultimately do not match.
 
@@ -989,7 +989,7 @@ class _CxSetFragmentFromPath:
 class _CxVariableFromPatternMatch:
     def __init__(self, unique_idx):
         self._unique_idx = unique_idx
-        self.dict_variable_name = 'dict_value_{0}'.format(unique_idx)
+        self.dict_variable_name = 'dict_match_{0}'.format(unique_idx)
 
     def src(self, indentation):
         return '{0}{1} = match.groupdict()'.format(
@@ -1001,7 +1001,7 @@ class _CxVariableFromPatternMatch:
 class _CxVariableFromPatternMatchPrefetched:
     def __init__(self, unique_idx):
         self._unique_idx = unique_idx
-        self.dict_variable_name = 'dict1_value_{0}'.format(unique_idx)
+        self.dict_variable_name = 'dict_groups_{0}'.format(unique_idx)
 
     def src(self, indentation):
         return '{0}{1} = groups'.format(

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -26,7 +26,7 @@ from falcon.routing.util import map_http_methods, set_default_responders
 from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines, wrap_sync_to_async
 
-if False:
+if False:  # TODO: switch to TYPE_CHECKING once support for py3.5 is dropped
     from typing import Any
 
 _TAB_STR = ' ' * 4

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -26,6 +26,8 @@ from falcon.routing.util import map_http_methods, set_default_responders
 from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines, wrap_sync_to_async
 
+if False:
+    from typing import Any
 
 _TAB_STR = ' ' * 4
 _FIELD_PATTERN = re.compile(
@@ -413,6 +415,8 @@ class CompiledRouter:
 
                 fast_return = not found_var_nodes
 
+        construct = None  # type: Any
+        setter = None  # type: Any
         original_params_stack = params_stack.copy()
         for node in nodes:
             params_stack = original_params_stack.copy()
@@ -523,6 +527,8 @@ class CompiledRouter:
             parent.append_child(_CxReturnNone())
 
     def _generate_conversion_ast(self, parent, node: 'CompiledRouterNode', params_stack: list):
+        construct = None  # type: Any
+        setter = None  # type: Any
         # NOTE(kgriffs): Unroll the converter loop into
         # a series of nested "if" constructs.
         for field_name, converter_name, converter_argstr in node.var_converter_map:
@@ -547,7 +553,7 @@ class CompiledRouter:
         # NOTE(kgriffs): Add remaining fields that were not
         # converted, if any.
         if node.num_fields > len(node.var_converter_map):
-            construct = _CxVariableFromPatternMatchPrefetched(len(params_stack)+1)
+            construct = _CxVariableFromPatternMatchPrefetched(len(params_stack) + 1)
             setter = _CxSetParamsFromDict(construct.dict_variable_name)
             params_stack.append(setter)
             parent.append_child(construct)
@@ -1058,7 +1064,7 @@ class _CxSetParamsFromDict:
         self._dict_value_name = dict_value_name
 
     def src(self, indentation):
-        return "{0}params.update({1})".format(
+        return '{0}params.update({1})'.format(
             _TAB_STR * indentation,
             self._dict_value_name,
         )

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -447,8 +447,6 @@ def test_literal(router):
     )
 ])
 def test_converters(router, path, expected_params):
-    with open('finder.py', 'w') as f:
-        f.write(router.finder_src)
     __, __, params, __ = router.find(path)
     assert params == expected_params
 
@@ -680,6 +678,6 @@ def param_router():
 ))
 def test_params_in_non_taken_branches(param_router, route, expected, num):
     resource, __, params, __ = param_router.find(route)
-    print(param_router.finder_src)
+
     assert resource.resource_id == num
     assert params == expected

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -447,6 +447,8 @@ def test_literal(router):
     )
 ])
 def test_converters(router, path, expected_params):
+    with open('finder.py', 'w') as f:
+        f.write(router.finder_src)
     __, __, params, __ = router.find(path)
     assert params == expected_params
 
@@ -653,3 +655,31 @@ def test_options_converters_invalid_name_on_update(router):
             'valid_name': SpamConverter,
             '7eleven': SpamConverter,
         })
+
+
+@pytest.fixture
+def param_router():
+    r = DefaultRouter()
+
+    r.add_route('/c/foo/{bar}/baz', ResourceWithId(1))
+    r.add_route('/c/{foo}/bar/other', ResourceWithId(2))
+    r.add_route('/c/foo/{a:int}-{b}/a', ResourceWithId(3))
+    r.add_route('/upload/{service}/auth/token', ResourceWithId(4))
+    r.add_route('/upload/youtube/{project_id}/share', ResourceWithId(5))
+    r.add_route('/x/y/{a}.{b}/z', ResourceWithId(6))
+    r.add_route('/x/{y}/o.o/w', ResourceWithId(7))
+    return r
+
+
+@pytest.mark.parametrize('route, expected, num', (
+    ('/c/foo/arg/baz', {'bar': 'arg'}, 1),
+    ('/c/foo/bar/other', {'foo': 'foo'}, 2),
+    ('/c/foo/42-7/baz', {'bar': '42-7'}, 1),
+    ('/upload/youtube/auth/token', {'service': 'youtube'}, 4),
+    ('/x/y/o.o/w', {'y': 'y'}, 7),
+))
+def test_params_in_non_taken_branches(param_router, route, expected, num):
+    resource, __, params, __ = param_router.find(route)
+    print(param_router.finder_src)
+    assert resource.resource_id == num
+    assert params == expected


### PR DESCRIPTION
# Summary of Changes

The compied router now sets the params only when it matches a route. The generated code looks like this https://gist.github.com/CaselIT/8bc22a248b6c71c89940676d2e86b344

# Related Issues

Fixes #1779

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
