### PR TITLE
Try fixing wheel builds

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip --version
-          pip install setuptools>=44 wheel>=0.34 cython>=0.29.21
+          pip install 'setuptools>=44' 'wheel>=0.34' 'cython>=0.29.21'
           pip wheel -w dist --no-use-pep517 -v --no-deps .
 
       - name: Check created wheel
@@ -67,6 +67,7 @@ jobs:
         run: |
           pip install -f dist --no-index falcon
           python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri'
+          pip install 'setuptools>=44'
           pip install -r requirements/tests
           pytest -q tests ${{ matrix.pytest-extra }}
 
@@ -179,6 +180,7 @@ jobs:
           FALCON_ASGI_WRAP_NON_COROUTINES: Y
           FALCON_TESTING_SESSION: Y
         run: |
+          pip install 'setuptools>=44'
           pip install -f dist --no-index falcon
           python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri'
           pip install -r requirements/tests
@@ -359,6 +361,7 @@ jobs:
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
             yum install -y openssl-devel &&
             pip install -f dist --no-index falcon &&
+            pip install 'setuptools>=44' 'cryptography<3.2' &&
             python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri' &&
             [[ $PYTHON_VERSION != 'cp35-cp35m' ]] && (
             pip install -r requirements/tests &&
@@ -388,6 +391,7 @@ jobs:
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
             yum install -y openssl-devel &&
             pip install -f dist --no-index falcon &&
+            pip install 'setuptools>=44' 'cryptography<3.2' &&
             python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri' &&
             pip install -r requirements/tests &&
             pytest -q tests ${{ matrix.pytest-extra }}

--- a/requirements/tests
+++ b/requirements/tests
@@ -15,7 +15,7 @@ uvicorn; python_version >= '3.6'
 websockets; python_version >= '3.6'
 
 # Handler Specific
-cbor2
+cbor2; python_version >= '3.6'
 msgpack
 mujson
 ujson

--- a/requirements/tests
+++ b/requirements/tests
@@ -9,7 +9,7 @@ pytest-asyncio
 httpx; python_version >= '3.6'
 uvicorn; python_version >= '3.6'
 aiofiles; python_version >= '3.6'
-daphne; python_version >= '3.6'
+daphne; python_version >= '3.6' and sys_platform != 'win32'
 httpx; python_version >= '3.6'
 uvicorn; python_version >= '3.6'
 websockets; python_version >= '3.6'


### PR DESCRIPTION
# Summary of Changes

This pr should fix the errors in https://github.com/falconry/falcon/actions/runs/393277790

In particular:
- install setuptools >= 44 everywhere
- do not install daphne on windows since it's not used and twisted seem not to compile on py39
- pin `cryptography<3.2` to avoid errors due to old version of open-ssl
