### PR TITLE
chore: use tox to run wheel tests. make daphne optional when testing

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -65,11 +65,8 @@ jobs:
           FALCON_ASGI_WRAP_NON_COROUTINES: Y
           FALCON_TESTING_SESSION: Y
         run: |
-          pip install -f dist --no-index falcon
-          python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri'
-          pip install 'setuptools>=44'
-          pip install -r requirements/tests
-          pytest -q tests ${{ matrix.pytest-extra }}
+          pip install 'tox>=3.20'
+          tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
       - name: Get wheel name
         id: wheel-name
@@ -180,11 +177,8 @@ jobs:
           FALCON_ASGI_WRAP_NON_COROUTINES: Y
           FALCON_TESTING_SESSION: Y
         run: |
-          pip install 'setuptools>=44'
-          pip install -f dist --no-index falcon
-          python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri'
-          pip install -r requirements/tests
-          pytest -q tests ${{ matrix.pytest-extra }}
+          pip install 'tox>=3.20'
+          tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
       - name: Get wheel names
         id: wheel-name
@@ -359,14 +353,8 @@ jobs:
           args: |
             bash -c "
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            yum install -y openssl-devel &&
-            pip install -f dist --no-index falcon &&
-            pip install 'setuptools>=44' 'cryptography<3.2' &&
-            python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri' &&
-            [[ $PYTHON_VERSION != 'cp35-cp35m' ]] && (
-            pip install -r requirements/tests &&
-            pytest -q tests ${{ matrix.pytest-extra }}
-            ) || echo 'Install requirements fails on python 3.5 on arm. Skipping tests.'
+            pip install 'tox>=3.20' 'pip>=20' &&
+            tox -e wheel_check -- ${{ matrix.pytest-extra }}
             "
 
       - name: Create wheel for manylinux 2014 for s390x
@@ -389,12 +377,8 @@ jobs:
           args: |
             bash -c "
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            yum install -y openssl-devel &&
-            pip install -f dist --no-index falcon &&
-            pip install 'setuptools>=44' 'cryptography<3.2' &&
-            python -c 'import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri' &&
-            pip install -r requirements/tests &&
-            pytest -q tests ${{ matrix.pytest-extra }}
+            pip install 'tox>=3.20' 'pip>=20' &&
+            tox -e wheel_check -- ${{ matrix.pytest-extra }}
             "
 
       - name: Get wheel name

--- a/.github/workflows/tests-emulated.yaml
+++ b/.github/workflows/tests-emulated.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           path: |
             .pip
-          key: python-${{ matrix.architecture }}
+          key: python-${{ matrix.architecture }}-${{ hashFiles('requirements/tests') }}
 
       - name: Set up emulation
         run: |

--- a/.github/workflows/tests-emulated.yaml
+++ b/.github/workflows/tests-emulated.yaml
@@ -39,6 +39,7 @@ jobs:
         env:
           PIP_CACHE_DIR: /github/workspace/.pip/
         with:
+          # NOTE: without 'pip install ujson' tox fails to install it with "Requested ujson from <url> has different version in metadata: '0.0.0'"
           args: |
             /bin/bash -c "
             lscpu &&
@@ -48,6 +49,7 @@ jobs:
             python --version &&
             pip --version &&
             tox --version &&
+            pip install ujson &&
             tox -e py38_cython"
 
       - name: Run tox arm64v8

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,6 +35,7 @@ jobs:
           - "check_vendored"
           - "twine_check"
           - "daphne"
+          - "no_optional_packages"
           # TODO(kgriffs): Re-enable once hug has a chance to address
           # breaking changes in Falcon 3.0
           # - "hug"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,6 +34,7 @@ jobs:
           - "look"
           - "check_vendored"
           - "twine_check"
+          - "daphne"
           # TODO(kgriffs): Re-enable once hug has a chance to address
           # breaking changes in Falcon 3.0
           # - "hug"

--- a/requirements/tests
+++ b/requirements/tests
@@ -4,12 +4,11 @@ pyyaml
 requests
 testtools
 
-# ASGI Specific
+# ASGI Specific (daphne is installed on a its own tox env)
 pytest-asyncio
 httpx; python_version >= '3.6'
 uvicorn; python_version >= '3.6'
 aiofiles; python_version >= '3.6'
-daphne; python_version >= '3.6' and sys_platform != 'win32'
 httpx; python_version >= '3.6'
 uvicorn; python_version >= '3.6'
 websockets; python_version >= '3.6'
@@ -20,7 +19,8 @@ msgpack
 mujson
 ujson
 
-python-rapidjson
+# it's slow to compile on emulated architectures
+python-rapidjson; platform_machine != 's390x' and platform_machine != 'aarch64'
 
-# TODO(kgriffs): orjson is failing to build on CI
-orjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x'
+# python_version >= '3.6': arm64 wheels are missing for py35
+orjson; python_version >= '3.6' and platform_python_implementation != 'PyPy' and platform_machine != 's390x'

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -460,11 +460,20 @@ def _daphne_factory(host, port):
     )
 
 
+def _can_run(factory):
+    if _WIN32 and factory == _daphne_factory:
+        pytest.skip('daphne does not support windows')
+    if factory == _daphne_factory:
+        try:
+            import daphne  # noqa
+        except Exception:
+            pytest.skip('daphne not installed')
+
+
 @pytest.fixture(params=[_uvicorn_factory, _daphne_factory])
 def server_base_url(request):
     process_factory = request.param
-    if _WIN32 and process_factory == _daphne_factory:
-        pytest.skip('daphne does not support windows')
+    _can_run(process_factory)
 
     for i in range(3):
         server_port = testing.get_unused_port()

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -4,13 +4,19 @@ import os
 
 import cbor2
 import pytest
-import rapidjson
+
 
 import falcon
 from falcon import media, testing
 from falcon.asgi import App
 from falcon.asgi.ws import _WebSocketState as ServerWebSocketState
 from falcon.testing.helpers import _WebSocketState as ClientWebSocketState
+
+
+try:
+    import rapidjson  # type: ignore
+except ImportError:
+    rapidjson = None
 
 
 # NOTE(kgriffs): We do not use codes defined in the framework because we
@@ -425,6 +431,9 @@ async def test_media(custom_text, custom_data, conductor):  # NOQA: C901
     app.add_route('/', resource)
 
     if custom_text:
+        if rapidjson is None:
+            pytest.skip('rapidjson is required for this test')
+
         # Let's say we want to use a faster JSON library. You could also use this
         #   pattern to add serialization support for custom types that aren't
         #   normally JSON-serializable out of the box.

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,14 @@ commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
            pytest tests []
 
 # --------------------------------------------------------------------
+# Daphne
+# --------------------------------------------------------------------
+
+[testenv:daphne]
+deps = {[testenv]deps}
+       daphne
+
+# --------------------------------------------------------------------
 # Coverage
 # --------------------------------------------------------------------
 
@@ -350,3 +358,26 @@ deps = virtualenv
 commands =
      {toxinidir}/tools/testing/install_hug.sh
      {toxinidir}/tools/testing/test_hug.sh
+
+# --------------------------------------------------------------------
+# Wheels stuff
+# --------------------------------------------------------------------
+
+[testenv:wheel_check]
+basepython = python
+skipsdist = True
+skip_install = True
+deps = setuptools>=44
+       pytest
+setenv =
+    PYTHONASYNCIODEBUG=0
+    PYTHONNOUSERSITE=1
+    FALCON_ASGI_WRAP_NON_COROUTINES=Y
+    FALCON_TESTING_SESSION=Y
+commands =
+    pip uninstall --yes falcon
+    pip install --find-links {toxinidir}/dist --no-index --ignore-installed falcon
+    python --version
+    python -c "import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri"
+    pip install -r{toxinidir}/requirements/tests
+    pytest -q tests []

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,16 @@ deps = {[testenv]deps}
        daphne
 
 # --------------------------------------------------------------------
+# Test without optional packages
+# --------------------------------------------------------------------
+
+[testenv:no_optional_packages]
+deps = {[testenv]deps}
+commands = {toxinidir}/tools/clean.sh {toxinidir}/falcon
+           pip uninstall --yes python-rapidjson daphne orjson
+           pytest tests []
+
+# --------------------------------------------------------------------
 # Coverage
 # --------------------------------------------------------------------
 


### PR DESCRIPTION
# Summary of Changes

- Move daphne to a tox env
- Use tox to check the wheels reducing duplication

# Related Issues

fixes #1795
