### PR TITLE
refactor(Response): rename add_link to append_link

### DIFF
--- a/docs/_newsfragments/1801.misc.rst
+++ b/docs/_newsfragments/1801.misc.rst
@@ -1,0 +1,3 @@
+The `add_link()` method of the :class:`falcon.Request` class was renamed to
+:meth:`falcon.Request.append_link`. The old name is still available as a
+deprecated alias.

--- a/docs/api/request_and_response_asgi.rst
+++ b/docs/api/request_and_response_asgi.rst
@@ -45,7 +45,7 @@ Response
 .. autoclass:: falcon.asgi.Response
     :members:
     :inherited-members:
-    :exclude-members: context_type
+    :exclude-members: context_type, add_link
 
 .. autoclass:: falcon.asgi.SSEvent
     :members:

--- a/docs/api/request_and_response_wsgi.rst
+++ b/docs/api/request_and_response_wsgi.rst
@@ -45,4 +45,4 @@ Response
 
 .. autoclass:: falcon.Response
     :members:
-    :exclude-members: context_type
+    :exclude-members: context_type, add_link

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -751,9 +751,9 @@ class Response:
 
             _headers[name] = value
 
-    def add_link(self, target, rel, title=None, title_star=None,
-                 anchor=None, hreflang=None, type_hint=None, crossorigin=None):
-        """Add a link header to the response.
+    def append_link(self, target, rel, title=None, title_star=None,
+                    anchor=None, hreflang=None, type_hint=None, crossorigin=None):
+        """Append a link header to the response.
 
         (See also: RFC 5988, Section 1)
 
@@ -876,6 +876,9 @@ class Response:
             _headers['link'] += ', ' + value
         else:
             _headers['link'] = value
+
+    # NOTE(kgriffs): Alias deprecated as of 3.0
+    add_link = append_link
 
     cache_control = header_property(
         'Cache-Control',


### PR DESCRIPTION
# Summary of Changes

Rename add_link to append_link for accuracy and consistency.

# Related Issues

#1801

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
