### PR TITLE
fix(App): cement the fact that body serialization error handling has been fixed

### DIFF
--- a/docs/_newsfragments/1607.bugfix.rst
+++ b/docs/_newsfragments/1607.bugfix.rst
@@ -1,0 +1,6 @@
+Previously, response serialization errors (such as in the case of a faulty
+custom media handler, or because an instance of
+:class:`~falcon.HTTPUnsupportedMediaType` was raised for an unsupported
+response content type) were unexpectedly bubbled up to the application server.
+This has been fixed, and these errors are now handled exactly the same way as
+other exceptions raised in a responder (see also: :ref:`errors`).


### PR DESCRIPTION
This patch aims to wrap up #1607 which seems to have already been fixed earlier:
* Add a Towncrier news fragment
* Add regression tests explicitly targeting the scenario in question

Closes #1607 