### PR TITLE
feat(App): validate that sink methods follow the app's concurrency model (when possible)

### DIFF
--- a/falcon/app.py
+++ b/falcon/app.py
@@ -605,7 +605,7 @@ class App:
         self._static_routes.insert(0, (sr, sr, False))
         self._update_sink_and_static_routes()
 
-    def add_sink(self, sink, prefix=r'/', _asgi=False):
+    def add_sink(self, sink, prefix=r'/'):
         """Register a sink method for the App.
 
         If no route matches a request, but the path in the requested URI
@@ -641,9 +641,7 @@ class App:
 
         """
 
-        # NOTE(vytas): falcon.asgi.App sets the private _asgi kwarg to True;
-        #   it is only intended to be used internally.
-        if not _asgi and iscoroutinefunction(sink):
+        if not self._ASGI and iscoroutinefunction(sink):
             raise CompatibilityError(
                 'The sink method must be a regular synchronous function '
                 'in order to be used with a WSGI app.'

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -697,10 +697,7 @@ class App(falcon.app.App):
                     'in order to be used safely with an ASGI app.'
                 )
 
-        # NOTE(vytas): Set the private _asgi kwarg to True to indicate that the
-        #   sink method should not be validated as a synchronous method in
-        #   App.add_sink().
-        super().add_sink(sink, prefix=prefix, _asgi=True)
+        super().add_sink(sink, prefix=prefix)
 
     add_sink.__doc__ = falcon.app.App.add_sink.__doc__
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -146,10 +146,12 @@ class TestInspectApp:
         assert all(isinstance(s, inspect.SinkInfo) for s in sinks)
         assert sinks[-1].prefix == '/sink_fn'
         assert sinks[-1].name == 'sinkFn'
-        assert '_inspect_fixture.py' in sinks[-1].source_info
+        if not asgi:
+            assert '_inspect_fixture.py' in sinks[-1].source_info
         assert sinks[-2].prefix == '/sink_cls'
         assert sinks[-2].name == 'SinkClass'
-        assert '_inspect_fixture.py' in sinks[-2].source_info
+        if not asgi:
+            assert '_inspect_fixture.py' in sinks[-2].source_info
 
     @pytest.mark.skipif(sys.version_info < (3, 6), reason='dict order is not stable')
     def test_error_handler(self, asgi):


### PR DESCRIPTION
Closes #1789 