### PR TITLE
feat(testing): set default User-Agent string for simulated requests

### DIFF
--- a/docs/_newsfragments/1358.breakingchange.rst
+++ b/docs/_newsfragments/1358.breakingchange.rst
@@ -1,7 +1,11 @@
 In order to reconcile differences between the framework's support for WSGI vs. ASGI, the following
 breaking changes were made:
 
-    - :func:`falcon.testing.create_environ` no longer sets a default User-Agent header.
+    - :func:`falcon.testing.create_environ` previously set a default User-Agent header, when one
+      was not provided, to the value ``'curl/7.24.0 (x86_64-apple-darwin12.0)'``. As of Falcon
+      3.0, the default User-Agent string is now ``f'falcon-client/{falcon.__version__}'``. This
+      value can be overridden for the sake of backwards-compatibility by setting
+      ``falcon.testing.helpers.DEFAULT_UA``.
     - The :func:`falcon.testing.create_environ` function's `protocol` keyword argument was renamed
       to `http_version` and now only includes the version number (the value is no longer prefixed
       with ``'HTTP/'``).

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -465,6 +465,12 @@ def simulate_request(app, method='GET', path='/', query_string=None,
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.
@@ -635,6 +641,12 @@ async def _simulate_request_asgi(
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.
@@ -1113,6 +1125,12 @@ def simulate_get(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         file_wrapper (callable): Callable that returns an iterable,
             to be used as the value for *wsgi.file_wrapper* in the
             WSGI environ (default: ``None``). This can be used to test
@@ -1210,6 +1228,12 @@ def simulate_head(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         host(str): A string to use for the hostname part of the fully
             qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
@@ -1302,6 +1326,12 @@ def simulate_post(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.
@@ -1407,6 +1437,12 @@ def simulate_put(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.
@@ -1507,6 +1543,12 @@ def simulate_options(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         host(str): A string to use for the hostname part of the fully
             qualified request URL (default: 'falconframework.org')
         remote_addr (str): A string to use as the remote IP address for the
@@ -1595,6 +1637,12 @@ def simulate_patch(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.
@@ -1695,6 +1743,12 @@ def simulate_delete(app, path, **kwargs) -> _ResultBase:
             with a comma when the header in question supports the list
             format (see also RFC 7230 and RFC 7231). Header names are not
             case-sensitive.
+
+            Note:
+                If a User-Agent header is not provided, it will default to::
+
+                    f'falcon-client/{falcon.__version__}'
+
         body (str): The body of the request (default ''). The value will be
             encoded as UTF-8 in the WSGI environ. Alternatively, a byte string
             may be passed, in which case it will be used as-is.

--- a/tests/asgi/test_testing_asgi.py
+++ b/tests/asgi/test_testing_asgi.py
@@ -115,6 +115,44 @@ def test_cookies_jar():
     assert response_two.status == falcon.HTTP_200
 
 
+def test_create_scope_default_ua():
+    default_ua = 'falcon-client/' + falcon.__version__
+
+    scope = testing.create_scope()
+    assert dict(scope['headers'])[b'user-agent'] == default_ua.encode()
+
+    req = testing.create_asgi_req()
+    assert req.user_agent == default_ua
+
+
+def test_create_scope_default_ua_override():
+    ua = 'curl/7.64.1'
+
+    scope = testing.create_scope(headers={'user-agent': ua})
+    assert dict(scope['headers'])[b'user-agent'] == ua.encode()
+
+    req = testing.create_asgi_req(headers={'user-agent': ua})
+    assert req.user_agent == ua
+
+
+def test_create_scope_default_ua_modify_global():
+    default_ua = 'URL/Emacs Emacs/26.3 (x86_64-pc-linux-gnu)'
+
+    prev_default = falcon.testing.helpers.DEFAULT_UA
+    falcon.testing.helpers.DEFAULT_UA = default_ua
+
+    try:
+        req = testing.create_asgi_req()
+        assert req.user_agent == default_ua
+    finally:
+        falcon.testing.helpers.DEFAULT_UA = prev_default
+
+
+def test_missing_header_is_none():
+    req = testing.create_asgi_req()
+    assert req.auth is None
+
+
 def test_immediate_disconnect():
     client = testing.TestClient(_asgi_test_app.application)
 

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -690,13 +690,13 @@ class TestRequestAttributes:
         assert getattr(req, attr) is None
 
     @pytest.mark.parametrize('name,value,attr,default', [
-        ('Accept', 'x-falcon', 'accept', '*/*'),
-        ('Authorization', 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af', 'auth', None),
-        ('Content-Type', 'text/plain', 'content_type', None),
-        ('Expect', '100-continue', 'expect', None),
-        ('If-Range', 'Wed, 21 Oct 2015 07:28:00 GMT', 'if_range', None),
-        ('User-Agent', 'testing/3.0', 'user_agent', None),
-        ('Referer', 'https://www.google.com/', 'referer', None),
+        # ('Accept', 'x-falcon', 'accept', '*/*'),
+        # ('Authorization', 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af', 'auth', None),
+        # ('Content-Type', 'text/plain', 'content_type', None),
+        # ('Expect', '100-continue', 'expect', None),
+        # ('If-Range', 'Wed, 21 Oct 2015 07:28:00 GMT', 'if_range', None),
+        ('User-Agent', 'testing/3.0', 'user_agent', 'falcon-client/' + falcon.__version__),
+        # ('Referer', 'https://www.google.com/', 'referer', None),
     ])
     def test_attribute_headers(self, asgi, name, value, attr, default):
         headers = {name: value}

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -690,13 +690,13 @@ class TestRequestAttributes:
         assert getattr(req, attr) is None
 
     @pytest.mark.parametrize('name,value,attr,default', [
-        # ('Accept', 'x-falcon', 'accept', '*/*'),
-        # ('Authorization', 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af', 'auth', None),
-        # ('Content-Type', 'text/plain', 'content_type', None),
-        # ('Expect', '100-continue', 'expect', None),
-        # ('If-Range', 'Wed, 21 Oct 2015 07:28:00 GMT', 'if_range', None),
+        ('Accept', 'x-falcon', 'accept', '*/*'),
+        ('Authorization', 'HMAC_SHA1 c590afa9bb59191ffab30f223791e82d3fd3e3af', 'auth', None),
+        ('Content-Type', 'text/plain', 'content_type', None),
+        ('Expect', '100-continue', 'expect', None),
+        ('If-Range', 'Wed, 21 Oct 2015 07:28:00 GMT', 'if_range', None),
         ('User-Agent', 'testing/3.0', 'user_agent', 'falcon-client/' + falcon.__version__),
-        # ('Referer', 'https://www.google.com/', 'referer', None),
+        ('Referer', 'https://www.google.com/', 'referer', None),
     ])
     def test_attribute_headers(self, asgi, name, value, attr, default):
         headers = {name: value}

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -134,3 +134,28 @@ def test_cookies_jar():
     response_two = client.simulate_post('/jars', cookies=response_one.cookies)
 
     assert response_two.status == falcon.HTTP_200
+
+
+def test_create_environ_default_ua():
+    default_ua = 'falcon-client/' + falcon.__version__
+
+    environ = testing.create_environ()
+    assert environ['HTTP_USER_AGENT'] == default_ua
+
+    req = falcon.request.Request(environ)
+    assert req.user_agent == default_ua
+
+
+def test_create_environ_default_ua_override():
+    ua = 'curl/7.64.1'
+
+    environ = testing.create_environ(headers={'user-agent': ua})
+    assert environ['HTTP_USER_AGENT'] == ua
+
+    req = falcon.request.Request(environ)
+    assert req.user_agent == ua
+
+
+def test_missing_header_is_none():
+    req = testing.create_req()
+    assert req.auth is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -845,7 +845,7 @@ class TestFalconTestingUtils:
     @pytest.mark.parametrize('extras,expected_headers', [
         (
             {},
-            (('user-agent', None),),
+            (('user-agent', 'falcon-client/' + falcon.__version__),),
         ),
         (
             {'HTTP_USER_AGENT': 'URL/Emacs', 'HTTP_X_FALCON': 'peregrine'},


### PR DESCRIPTION
# Summary of Changes

Revert the change to not set a default User-Agent string on the WSGI side, and implement it for ASGI as well.