### PR TITLE
chore(build): exclude pyproject.toml to avoid inadvertently triggerin…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include tox.ini
 include README.rst
 include LICENSE
 include docs/conf.py docs/Makefile
+exclude pyproject.toml
 graft docs/_static
 graft docs/_templates
 graft tools


### PR DESCRIPTION
As discussed under #1709 