### PR TITLE
docs(Request): integrate a spelling fix by Debian maintainers

### DIFF
--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -289,7 +289,7 @@ class Request(falcon.request.Request):
             where -1 is the last byte, -2 is the second-to-last byte,
             and so forth.
 
-            Only continous ranges are supported (e.g., "bytes=0-0,-1" would
+            Only continuous ranges are supported (e.g., "bytes=0-0,-1" would
             result in an HTTPBadRequest exception when the attribute is
             accessed.)
         range_unit (str): Unit of the range parsed from the value of the

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -357,7 +357,7 @@ class Request:
             where -1 is the last byte, -2 is the second-to-last byte,
             and so forth.
 
-            Only continous ranges are supported (e.g., "bytes=0-0,-1" would
+            Only continuous ranges are supported (e.g., "bytes=0-0,-1" would
             result in an HTTPBadRequest exception when the attribute is
             accessed.)
         range_unit (str): Unit of the range parsed from the value of the


### PR DESCRIPTION
Funnily enough, Debian is shipping a patch to fix our misspelling.

`debian/patches/fix-spelling.patch`
```
Description: Fix spelling
Author: Thomas Goirand <zigo@debian.org>
Forwarded: no
Last-Update: 2016-07-11
```

Thanks @thomasgoirand ! Don't hesitate to pipe these patches to us!