### PR TITLE
perf(asgi): Optimize media (de)serialization

### DIFF
--- a/docs/_newsfragments/1822.breakingchange.rst
+++ b/docs/_newsfragments/1822.breakingchange.rst
@@ -1,3 +1,5 @@
 The private attributes for :class:`~.falcon.media.JSONHandler` were renamed, and
 the private attributes used by :class:`~.falcon.media.MessagePackHandler` were
-replaced. Subclasses that refer to these variables will need to be updated.
+replaced. Subclasses that refer to these variables will need to be updated. In
+addition, the undocumented :meth:`falcon.media.Handlers.find_by_media_type`
+method was deprecated and may be removed in a future release.

--- a/docs/_newsfragments/1822.breakingchange.rst
+++ b/docs/_newsfragments/1822.breakingchange.rst
@@ -1,0 +1,3 @@
+The private attributes for :class:`~.falcon.media.JSONHandler` were renamed, and
+the private attributes used by :class:`~.falcon.media.MessagePackHandler` were
+replaced. Subclasses that refer to these variables will need to be updated.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,8 +67,9 @@ extensions = [
     'sphinx_tabs.tabs',
 
     # Falcon-specific extensions
-    'ext.rfc',
     'ext.doorway',
+    'ext.private_args',
+    'ext.rfc',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/ext/private_args.py
+++ b/docs/ext/private_args.py
@@ -1,0 +1,40 @@
+# Copyright 2021 by Kurt Griffiths
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Private args module extension for Sphinx.
+
+This extension exludes underscore-prefixed args and kwargs from the function
+signature.
+"""
+
+
+def _on_process_signature(app, what, name, obj, options, signature, return_annotation):
+    if what in ('function', 'method') and signature and '_' in signature:
+        filtered = []
+
+        for token in signature[1:-1].split(','):
+            token = token.strip()
+
+            if not token.startswith('_'):
+                filtered.append(token)
+
+        signature = f'({", ".join(filtered)})'
+
+    return signature, return_annotation
+
+
+def setup(app):
+    app.connect('autodoc-process-signature', _on_process_signature)
+
+    return {'parallel_read_safe': True}

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -25,7 +25,6 @@ the framework's classes, functions, and variables::
 """
 
 import logging as _logging
-import sys as _sys
 
 # Hoist classes and functions into the falcon namespace
 from falcon.version import __version__  # NOQA
@@ -49,10 +48,6 @@ from falcon.util import *  # NOQA
 from falcon.hooks import before, after  # NOQA
 from falcon.request import Request, RequestOptions, Forwarded  # NOQA
 from falcon.response import Response, ResponseOptions  # NOQA
-
-
-ASGI_SUPPORTED = _sys.version_info >= (3, 6)
-"""Set to ``True`` when ASGI is supported for the current Python version."""
 
 
 # NOTE(kgriffs): Only to be used internally on the rare occasion that we

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -236,7 +236,7 @@ def default_serialize_error(req, resp, exception):
 
     if preferred is not None:
         if preferred == MEDIA_JSON:
-            handler, *_ = resp.options.media_handlers.find_by_media_type(
+            handler, _, _ = resp.options.media_handlers.find_by_media_type(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
             resp.data = exception.to_json(handler)

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -236,7 +236,7 @@ def default_serialize_error(req, resp, exception):
 
     if preferred is not None:
         if preferred == MEDIA_JSON:
-            handler, _, _ = resp.options.media_handlers.find_by_media_type(
+            handler, _, _ = resp.options.media_handlers._resolve(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
             resp.data = exception.to_json(handler)

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -236,7 +236,7 @@ def default_serialize_error(req, resp, exception):
 
     if preferred is not None:
         if preferred == MEDIA_JSON:
-            handler = resp.options.media_handlers.find_by_media_type(
+            handler, *_ = resp.options.media_handlers.find_by_media_type(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
             resp.data = exception.to_json(handler)

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -554,7 +554,7 @@ class App(falcon.app.App):
 
             self._schedule_callbacks(resp)
 
-            handler, *_ = self.resp_options.media_handlers.find_by_media_type(
+            handler, _, _ = self.resp_options.media_handlers.find_by_media_type(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
 

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -554,7 +554,7 @@ class App(falcon.app.App):
 
             self._schedule_callbacks(resp)
 
-            handler = self.resp_options.media_handlers.find_by_media_type(
+            handler, *_ = self.resp_options.media_handlers.find_by_media_type(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
 

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -554,7 +554,7 @@ class App(falcon.app.App):
 
             self._schedule_callbacks(resp)
 
-            handler, _, _ = self.resp_options.media_handlers.find_by_media_type(
+            handler, _, _ = self.resp_options.media_handlers._resolve(
                 MEDIA_JSON, MEDIA_JSON, raise_not_found=False
             )
 

--- a/falcon/asgi/multipart.py
+++ b/falcon/asgi/multipart.py
@@ -40,7 +40,7 @@ class BodyPart(multipart.BodyPart):
 
     async def get_media(self):
         if self._media is None:
-            handler = self._parse_options.media_handlers.find_by_media_type(
+            handler, *_ = self._parse_options.media_handlers.find_by_media_type(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/asgi/multipart.py
+++ b/falcon/asgi/multipart.py
@@ -40,7 +40,7 @@ class BodyPart(multipart.BodyPart):
 
     async def get_media(self):
         if self._media is None:
-            handler, *_ = self._parse_options.media_handlers.find_by_media_type(
+            handler, _, _ = self._parse_options.media_handlers.find_by_media_type(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/asgi/multipart.py
+++ b/falcon/asgi/multipart.py
@@ -40,7 +40,7 @@ class BodyPart(multipart.BodyPart):
 
     async def get_media(self):
         if self._media is None:
-            handler, _, _ = self._parse_options.media_handlers.find_by_media_type(
+            handler, _, _ = self._parse_options.media_handlers._resolve(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -700,7 +700,7 @@ class Request(falcon.request.Request):
 
         return netloc_value
 
-    async def get_media(self, default_when_empty=_UNSET, _deserialize_cache={}):
+    async def get_media(self, default_when_empty=_UNSET):
         """Return a deserialized form of the request stream.
 
         The first time this method is called, the request stream will be

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -759,17 +759,17 @@ class Request(falcon.request.Request):
         # PERF(kgriffs): Avoid using an additional await and flatten the call
         #   stack when possible.
         try:
-            __deserialize_sync__ = _deserialize_cache[handler]
+            deserialize_sync = _deserialize_cache[handler]
         except KeyError:
             # PERF(kgriffs): Do not use EAFP, but rather check and
             #   cache since we don't want a significant penalty if
             #   a custom handler does not subclass the ABC.
-            __deserialize_sync__ = getattr(handler, '__deserialize_sync__', None)
-            _deserialize_cache[handler] = __deserialize_sync__
+            deserialize_sync = getattr(handler, '_deserialize_sync', None)
+            _deserialize_cache[handler] = deserialize_sync
 
         try:
-            if __deserialize_sync__:
-                self._media = __deserialize_sync__(await self.stream.read())
+            if deserialize_sync:
+                self._media = deserialize_sync(await self.stream.read())
             else:
                 self._media = await handler.deserialize_async(
                     self.stream,

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -751,7 +751,7 @@ class Request(falcon.request.Request):
                 return default_when_empty
             raise self._media_error
 
-        handler, _, deserialize_sync = self.options.media_handlers.find_by_media_type(
+        handler, _, deserialize_sync = self.options.media_handlers._resolve(
             self.content_type,
             self.options.default_media_type
         )

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -263,7 +263,7 @@ class Response(falcon.response.Response):
                     if not self.content_type:
                         self.content_type = self.options.default_media_type
 
-                    handler, serialize_sync, _ = self.options.media_handlers.find_by_media_type(
+                    handler, serialize_sync, _ = self.options.media_handlers._resolve(
                         self.content_type,
                         self.options.default_media_type
                     )

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -271,16 +271,16 @@ class Response(falcon.response.Response):
                     # PERF(kgriffs): Avoid using an additional await and flatten
                     #   the call stack when possible.
                     try:
-                        __serialize_sync__ = _serialize_cache[handler]
+                        serialize_sync = _serialize_cache[handler]
                     except KeyError:
                         # PERF(kgriffs): Do not use EAFP, but rather check and
                         #   cache since we don't want a significant penalty if
                         #   a custom handler does not subclass the ABC.
-                        __serialize_sync__ = getattr(handler, '__serialize_sync__', None)
-                        _serialize_cache[handler] = __serialize_sync__
+                        serialize_sync = getattr(handler, '_serialize_sync', None)
+                        _serialize_cache[handler] = serialize_sync
 
-                    if __serialize_sync__:
-                        self._media_rendered = __serialize_sync__(self._media)
+                    if serialize_sync:
+                        self._media_rendered = serialize_sync(self._media)
                     else:
                         self._media_rendered = await handler.serialize_async(
                             self._media,

--- a/falcon/bench/bench.py
+++ b/falcon/bench/bench.py
@@ -49,6 +49,7 @@ except ImportError:
     vmprof = None
 
 from falcon.bench import create  # NOQA
+from falcon.constants import PYPY
 import falcon.testing as helpers
 
 
@@ -63,8 +64,6 @@ ITER_DETECTION_DURATION_MIN = 1.0
 ITER_DETECTION_DURATION_MAX = 6.0
 
 JIT_WARMING_MULTIPLIER = 30
-
-PYPY = platform.python_implementation() == 'PyPy'
 
 BODY = helpers.rand_string(10240, 10240).encode('utf-8') # NOQA
 HEADERS = {'X-Test': 'Funky Chicken'}  # NOQA

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -1,5 +1,13 @@
 from enum import Enum
 import os
+import sys
+
+
+PYPY = (sys.implementation.name == 'pypy')
+"""Evaluates to ``True`` when the current Python implementation is PyPy."""
+
+ASGI_SUPPORTED = sys.version_info >= (3, 6)
+"""Evaluates to ``True`` when ASGI is supported for the current Python version."""
 
 # RFC 7231, 5789 methods
 HTTP_METHODS = [

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -19,7 +19,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
     """Override to provide a synchronous serialization method that takes an object."""
 
     _deserialize_sync = None
-    """Override to provide a synchronous derialization method that takes a byte string."""
+    """Override to provide a synchronous deserialization method that takes a byte string."""
 
     def serialize(self, media, content_type) -> bytes:
         """Serialize the media object on a :any:`falcon.Response`.

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -8,6 +8,12 @@ from falcon.constants import MEDIA_JSON
 class BaseHandler(metaclass=abc.ABCMeta):
     """Abstract Base Class for an internet media type handler."""
 
+    __serialize_sync__ = None
+    """Override to provide a synchronous serialization method that takes an object."""
+
+    __deserialize_sync__ = None
+    """Override to provide a synchronous derialization method that takes a byte string."""
+
     def serialize(self, media, content_type):
         """Serialize the media object on a :any:`falcon.Response`.
 

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -8,13 +8,18 @@ from falcon.constants import MEDIA_JSON
 class BaseHandler(metaclass=abc.ABCMeta):
     """Abstract Base Class for an internet media type handler."""
 
-    __serialize_sync__ = None
+    # NOTE(kgriffs): The following special methods are used to enable an
+    #   optimized media (de)serialization protocol for ASGI. This is not
+    #   currently part of the public interface for Falcon, and is not
+    #   included in the docs.
+
+    _serialize_sync = None
     """Override to provide a synchronous serialization method that takes an object."""
 
-    __deserialize_sync__ = None
+    _deserialize_sync = None
     """Override to provide a synchronous derialization method that takes a byte string."""
 
-    def serialize(self, media, content_type):
+    def serialize(self, media, content_type) -> bytes:
         """Serialize the media object on a :any:`falcon.Response`.
 
         By default, this method raises an instance of
@@ -45,7 +50,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
         else:
             raise NotImplementedError()
 
-    async def serialize_async(self, media, content_type):
+    async def serialize_async(self, media, content_type) -> bytes:
         """Serialize the media object on a :any:`falcon.Response`.
 
         This method is similar to :py:meth:`~.BaseHandler.serialize`
@@ -72,7 +77,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
         """
         return self.serialize(media, content_type)
 
-    def deserialize(self, stream, content_type, content_length):
+    def deserialize(self, stream, content_type, content_length) -> object:
         """Deserialize the :any:`falcon.Request` body.
 
         By default, this method raises an instance of
@@ -104,7 +109,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
         else:
             raise NotImplementedError()
 
-    async def deserialize_async(self, stream, content_type, content_length):
+    async def deserialize_async(self, stream, content_type, content_length) -> object:
         """Deserialize the :any:`falcon.Request` body.
 
         This method is similar to :py:meth:`~.BaseHandler.deserialize` except

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -11,7 +11,9 @@ class BaseHandler(metaclass=abc.ABCMeta):
     # NOTE(kgriffs): The following special methods are used to enable an
     #   optimized media (de)serialization protocol for ASGI. This is not
     #   currently part of the public interface for Falcon, and is not
-    #   included in the docs.
+    #   included in the docs. Once we are happy with the protocol, we
+    #   might make it part of the public interface for use by custom
+    #   media type handlers.
 
     _serialize_sync = None
     """Override to provide a synchronous serialization method that takes an object."""

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -1,7 +1,7 @@
 from collections import UserDict
 
 from falcon import errors
-from falcon.constants import MEDIA_JSON, MEDIA_MULTIPART, MEDIA_URLENCODED
+from falcon.constants import MEDIA_JSON, MEDIA_MULTIPART, MEDIA_URLENCODED, PYPY
 from falcon.media.json import JSONHandler
 from falcon.media.multipart import MultipartFormHandler, MultipartParseOptions
 from falcon.media.urlencoded import URLEncodedFormHandler
@@ -58,47 +58,46 @@ class Handlers(UserDict):
         #   to a cached handler that was removed.
         self._resolve.cache_clear()
 
-    def _best_match(self, media_type, all_media_types):
-        result = None
-
-        try:
-            # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
-            # parse the media type, but cannot find a suitable type.
-            result = mimeparse.best_match(
-                all_media_types,
-                media_type
-            )
-        except ValueError:
-            pass
-
-        return result
-
     def _create_resolver(self):
-        # NOTE(kgriffs): This is defined as a private method since it is meant to
-        #   only be called by the framework, rather than the app.
-        # NOTE(kgriffs): Most apps will probably only use one or two media handlers,
+        # PERF(kgriffs): Under PyPy the LRU is relatively expensive as compared
+        #   to the common case of the self.data lookup succeeding. Using
+        #   _lru_cache_for_simple_logic() takes this into account by essentially
+        #   creating a nop but also decorating the method with a dummy
+        #   cache_clear().
+        # PERF(kgriffs): Most apps will probably only use one or two media handlers,
         #   but we use maxsize=64 to give us some wiggle room just in case someone
         #   is using versioned media types or something, and to cover various
         #   combinations of the method args. We may need to tune this later.
-        @misc._lru_cache_safe(maxsize=64)
+        @misc._lru_cache_for_simple_logic(maxsize=64)
         def resolve(media_type, default, raise_not_found=True):
             if media_type == '*/*' or not media_type:
                 media_type = default
 
-            # PERF(kgriffs): We just do this slower check every time, rather
-            #   than trying to first check the dict directly, since the result
-            #   will almost always be cached anyway.
-            matched_type = self._best_match(media_type, self.data.keys())
+            # PERF(kgriffs): Under CPython we do not need this shortcut to
+            #   improve performance since most calls will be resolved by the
+            #   LRU cache on resolve(). On the other hand, it doesn't hurt,
+            #   and it certainly makes a difference under PyPy.
+            try:
+                handler = self.data[media_type]
+            except KeyError:
+                handler = None
 
-            if not matched_type:
-                if raise_not_found:
-                    raise errors.HTTPUnsupportedMediaType(
-                        description='{0} is an unsupported media type.'.format(media_type)
-                    )
+            if not handler:
+                # PERF(kgriffs): We just do this slower check every time, rather
+                #   than trying to first check the dict directly, since the result
+                #   will almost always be cached anyway.
+                # NOTE(kgriffs): Wrap keys in a tuple to make them hashable.
+                matched_type = _best_match(media_type, tuple(self.data.keys()))
 
-                return None, None, None
+                if not matched_type:
+                    if raise_not_found:
+                        raise errors.HTTPUnsupportedMediaType(
+                            description='{0} is an unsupported media type.'.format(media_type)
+                        )
 
-            handler = self.data[matched_type]
+                    return None, None, None
+
+                handler = self.data[matched_type]
 
             return (
                 handler,
@@ -122,8 +121,9 @@ class Handlers(UserDict):
         except KeyError:
             pass
 
-        # PERF(jmvrbanac): Fallback to the slower method
-        resolved = self._best_match(media_type, self.data.keys())
+        # PERF(jmvrbanac): Fallback to the slower method.
+        # NOTE(kgriffs): Wrap keys in a tuple to make them hashable.
+        resolved = _best_match(media_type, tuple(self.data.keys()))
 
         if not resolved:
             if raise_not_found:
@@ -133,6 +133,34 @@ class Handlers(UserDict):
             return None
 
         return self.data[resolved]
+
+
+def _best_match(media_type, all_media_types):
+    result = None
+
+    try:
+        # NOTE(jmvrbanac): Mimeparse will return an empty string if it can
+        # parse the media type, but cannot find a suitable type.
+        result = mimeparse.best_match(
+            all_media_types,
+            media_type
+        )
+    except ValueError:
+        pass
+
+    return result
+
+
+if PYPY:
+    # NOTE(kgriffs): The most common case for resolve() is that the
+    #   direct self.data shortcut will succeed. In this case, the LRU
+    #   lookup for resolve() is actually slower under PyPy than just
+    #   executing the method's body each time.
+    #
+    #   However, if the shortcut does not succeed, invoking best_match()
+    #   is relatively expensive, so it does make sense to use an LRU
+    #   in that case.
+    _best_match = misc._lru_cache_safe(maxsize=64)(_best_match)  # pragma: nocover
 
 
 # NOTE(vytas): An ugly way to work around circular imports.

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -43,8 +43,8 @@ class Handlers(UserDict):
         # Also, this results in self.update(...) being called.
         UserDict.__init__(self, handlers)
 
-    def __setitem__(self, key, item):
-        super().__setitem__(key, item)
+    def __setitem__(self, key, value):
+        super().__setitem__(key, value)
 
         # NOTE(kgriffs): When the mapping changes, we do not want to use a
         #   cached handler from the previous mapping, in case it was

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -84,6 +84,11 @@ class JSONHandler(BaseHandler):
             self.serialize = self._serialize_b
             self.serialize_async = self._serialize_async_b
 
+        # NOTE(kgriffs): To be safe, only enable the optimization when not subclassed
+        if type(self) is JSONHandler:
+            self.__serialize_sync__ = self.serialize
+            self.__deserialize_sync__ = self._deserialize
+
     def _deserialize(self, data):
         if not data:
             raise errors.MediaNotFoundError('JSON')

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -84,10 +84,11 @@ class JSONHandler(BaseHandler):
             self.serialize = self._serialize_b
             self.serialize_async = self._serialize_async_b
 
-        # NOTE(kgriffs): To be safe, only enable the optimization when not subclassed
+        # NOTE(kgriffs): To be safe, only enable the optimized protocol when
+        #   not subclassed.
         if type(self) is JSONHandler:
-            self.__serialize_sync__ = self.serialize
-            self.__deserialize_sync__ = self._deserialize
+            self._serialize_sync = self.serialize
+            self._deserialize_sync = self._deserialize
 
     def _deserialize(self, data):
         if not data:
@@ -105,16 +106,16 @@ class JSONHandler(BaseHandler):
 
     # NOTE(kgriffs): Make content_type a kwarg to support the
     #   Request.render_body() shortcut optimization.
-    def _serialize_s(self, media, content_type=None):
+    def _serialize_s(self, media, content_type=None) -> bytes:
         return self._dumps(media).encode()
 
-    async def _serialize_async_s(self, media, content_type):
+    async def _serialize_async_s(self, media, content_type) -> bytes:
         return self._dumps(media).encode()
 
-    def _serialize_b(self, media, content_type):
+    def _serialize_b(self, media, content_type) -> bytes:
         return self._dumps(media)
 
-    async def _serialize_async_b(self, media, content_type):
+    async def _serialize_async_b(self, media, content_type) -> bytes:
         return self._dumps(media)
 
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -71,12 +71,12 @@ class JSONHandler(BaseHandler):
     """
 
     def __init__(self, dumps=None, loads=None):
-        self.dumps = dumps or partial(json.dumps, ensure_ascii=False)
-        self.loads = loads or json.loads
+        self._dumps = dumps or partial(json.dumps, ensure_ascii=False)
+        self._loads = loads or json.loads
 
         # PERF(kgriffs): Test dumps once up front so we can set the
         #     proper serialize implementation.
-        result = self.dumps({'message': 'Hello World'})
+        result = self._dumps({'message': 'Hello World'})
         if isinstance(result, str):
             self.serialize = self._serialize_s
             self.serialize_async = self._serialize_async_s
@@ -88,7 +88,7 @@ class JSONHandler(BaseHandler):
         if not data:
             raise errors.MediaNotFoundError('JSON')
         try:
-            return self.loads(data.decode())
+            return self._loads(data.decode())
         except ValueError as err:
             raise errors.MediaMalformedError('JSON') from err
 
@@ -98,17 +98,19 @@ class JSONHandler(BaseHandler):
     async def deserialize_async(self, stream, content_type, content_length):
         return self._deserialize(await stream.read())
 
-    def _serialize_s(self, media, content_type):
-        return self.dumps(media).encode()
+    # NOTE(kgriffs): Make content_type a kwarg to support the
+    #   Request.render_body() shortcut optimization.
+    def _serialize_s(self, media, content_type=None):
+        return self._dumps(media).encode()
 
     async def _serialize_async_s(self, media, content_type):
-        return self.dumps(media).encode()
+        return self._dumps(media).encode()
 
     def _serialize_b(self, media, content_type):
-        return self.dumps(media)
+        return self._dumps(media)
 
     async def _serialize_async_b(self, media, content_type):
-        return self.dumps(media)
+        return self._dumps(media)
 
 
 class JSONHandlerWS(TextBaseHandlerWS):
@@ -170,14 +172,14 @@ class JSONHandlerWS(TextBaseHandlerWS):
     __slots__ = ['dumps', 'loads']
 
     def __init__(self, dumps=None, loads=None):
-        self.dumps = dumps or partial(json.dumps, ensure_ascii=False)
-        self.loads = loads or json.loads
+        self._dumps = dumps or partial(json.dumps, ensure_ascii=False)
+        self._loads = loads or json.loads
 
     def serialize(self, media: object) -> str:
-        return self.dumps(media)
+        return self._dumps(media)
 
     def deserialize(self, payload: str) -> object:
-        return self.loads(payload)
+        return self._loads(payload)
 
 
 http_error._DEFAULT_JSON_HANDLER = _DEFAULT_JSON_HANDLER = JSONHandler()  # type: ignore

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -34,10 +34,11 @@ class MessagePackHandler(BaseHandler):
         self._pack = packer.pack
         self._unpackb = msgpack.unpackb
 
-        # NOTE(kgriffs): To be safe, only enable the optimization when not subclassed
+        # NOTE(kgriffs): To be safe, only enable the optimized protocol when
+        #   not subclassed.
         if type(self) is MessagePackHandler:
-            self.__serialize_sync__ = self._pack
-            self.__deserialize_sync__ = self._deserialize
+            self._serialize_sync = self._pack
+            self._deserialize_sync = self._deserialize
 
     def _deserialize(self, data):
         if not data:
@@ -55,10 +56,10 @@ class MessagePackHandler(BaseHandler):
     async def deserialize_async(self, stream, content_type, content_length):
         return self._deserialize(await stream.read())
 
-    def serialize(self, media, content_type):
+    def serialize(self, media, content_type) -> bytes:
         return self._pack(media)
 
-    async def serialize_async(self, media, content_type):
+    async def serialize_async(self, media, content_type) -> bytes:
         return self._pack(media)
 
 

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -30,8 +30,9 @@ class MessagePackHandler(BaseHandler):
     def __init__(self):
         import msgpack
 
-        self.msgpack = msgpack
-        self.packer = msgpack.Packer(autoreset=True, use_bin_type=True)
+        packer = msgpack.Packer(autoreset=True, use_bin_type=True)
+        self._pack = packer.pack
+        self._unpackb = msgpack.unpackb
 
     def _deserialize(self, data):
         if not data:
@@ -39,7 +40,7 @@ class MessagePackHandler(BaseHandler):
         try:
             # NOTE(jmvrbanac): Using unpackb since we would need to manage
             # a buffer for Unpacker() which wouldn't gain us much.
-            return self.msgpack.unpackb(data, raw=False)
+            return self._unpackb(data, raw=False)
         except ValueError as err:
             raise errors.MediaMalformedError('MessagePack') from err
 
@@ -50,10 +51,10 @@ class MessagePackHandler(BaseHandler):
         return self._deserialize(await stream.read())
 
     def serialize(self, media, content_type):
-        return self.packer.pack(media)
+        return self._pack(media)
 
     async def serialize_async(self, media, content_type):
-        return self.packer.pack(media)
+        return self._pack(media)
 
 
 class MessagePackHandlerWS(BinaryBaseHandlerWS):
@@ -78,13 +79,14 @@ class MessagePackHandlerWS(BinaryBaseHandlerWS):
     def __init__(self):
         import msgpack
 
-        self.msgpack = msgpack
-        self.packer = msgpack.Packer(autoreset=True, use_bin_type=True)
+        packer = msgpack.Packer(autoreset=True, use_bin_type=True)
+        self._pack = packer.pack
+        self._unpackb = msgpack.unpackb
 
     def serialize(self, media: object) -> Union[bytes, bytearray, memoryview]:
-        return self.packer.pack(media)
+        return self._pack(media)
 
     def deserialize(self, payload: bytes) -> object:
         # NOTE(jmvrbanac): Using unpackb since we would need to manage
         #   a buffer for Unpacker() which wouldn't gain us much.
-        return self.msgpack.unpackb(payload, raw=False)
+        return self._unpackb(payload, raw=False)

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -34,6 +34,11 @@ class MessagePackHandler(BaseHandler):
         self._pack = packer.pack
         self._unpackb = msgpack.unpackb
 
+        # NOTE(kgriffs): To be safe, only enable the optimization when not subclassed
+        if type(self) is MessagePackHandler:
+            self.__serialize_sync__ = self._pack
+            self.__deserialize_sync__ = self._deserialize
+
     def _deserialize(self, data):
         if not data:
             raise errors.MediaNotFoundError('MessagePack')

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -371,7 +371,7 @@ class BodyPart:
             object: The deserialized media representation.
         """
         if self._media is None:
-            handler, _, _ = self._parse_options.media_handlers.find_by_media_type(
+            handler, _, _ = self._parse_options.media_handlers._resolve(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -371,7 +371,7 @@ class BodyPart:
             object: The deserialized media representation.
         """
         if self._media is None:
-            handler = self._parse_options.media_handlers.find_by_media_type(
+            handler, *_ = self._parse_options.media_handlers.find_by_media_type(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -371,7 +371,7 @@ class BodyPart:
             object: The deserialized media representation.
         """
         if self._media is None:
-            handler, *_ = self._parse_options.media_handlers.find_by_media_type(
+            handler, _, _ = self._parse_options.media_handlers.find_by_media_type(
                 self.content_type, 'text/plain')
 
             try:

--- a/falcon/media/urlencoded.py
+++ b/falcon/media/urlencoded.py
@@ -6,16 +6,20 @@ from falcon.util.uri import parse_query_string
 
 
 class URLEncodedFormHandler(BaseHandler):
-    """
-    URL-encoded form data handler.
+    """URL-encoded form data handler.
 
     This handler parses ``application/x-www-form-urlencoded`` HTML forms to a
-    ``dict`` in a similar way that URL query parameters are parsed. An empty body
+    ``dict``, similar to how URL query parameters are parsed. An empty body
     will be parsed as an empty dict.
 
     When deserializing, this handler will raise :class:`falcon.MediaMalformedError`
     if the request payload cannot be parsed as ASCII or if any of the URL-encoded
     strings in the payload are not valid UTF-8.
+
+    As documented for :any:`urllib.parse.urlencode`, when serializing, the
+    media object must either be a ``dict`` or a sequence of two-element
+    ``tuple``'s. If any values in the media object are sequences, each
+    sequence element is converted to a separate parameter.
 
     Keyword Arguments:
         keep_blank (bool): Whether to keep empty-string values from the form
@@ -28,17 +32,18 @@ class URLEncodedFormHandler(BaseHandler):
         self._keep_blank = keep_blank
         self._csv = csv
 
-        # NOTE(kgriffs): To be safe, only enable the optimization when not subclassed
+        # NOTE(kgriffs): To be safe, only enable the optimized protocol when
+        #   not subclassed.
         if type(self) is URLEncodedFormHandler:
-            self.__serialize_sync__ = self.serialize
-            self.__deserialize_sync__ = self._deserialize
+            self._serialize_sync = self.serialize
+            self._deserialize_sync = self._deserialize
 
     # NOTE(kgriffs): Make content_type a kwarg to support the
     #   Request.render_body() shortcut optimization.
-    def serialize(self, media, content_type=None):
+    def serialize(self, media, content_type=None) -> bytes:
         # NOTE(vytas): Setting doseq to True to mirror the parse_query_string
         # behaviour.
-        return urlencode(media, doseq=True)
+        return urlencode(media, doseq=True).encode()
 
     def _deserialize(self, body):
         try:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1031,7 +1031,7 @@ class Request:
                 return default_when_empty
             raise self._media_error
 
-        handler, _, _ = self.options.media_handlers.find_by_media_type(
+        handler, _, _ = self.options.media_handlers._resolve(
             self.content_type,
             self.options.default_media_type
         )
@@ -1800,7 +1800,7 @@ class Request:
         if param_value is None:
             return default
 
-        handler, _, _ = self.options.media_handlers.find_by_media_type(
+        handler, _, _ = self.options.media_handlers._resolve(
             MEDIA_JSON, MEDIA_JSON, raise_not_found=False
         )
         if handler is None:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1031,7 +1031,7 @@ class Request:
                 return default_when_empty
             raise self._media_error
 
-        handler = self.options.media_handlers.find_by_media_type(
+        handler, *_ = self.options.media_handlers.find_by_media_type(
             self.content_type,
             self.options.default_media_type
         )
@@ -1800,7 +1800,7 @@ class Request:
         if param_value is None:
             return default
 
-        handler = self.options.media_handlers.find_by_media_type(
+        handler, *_ = self.options.media_handlers.find_by_media_type(
             MEDIA_JSON, MEDIA_JSON, raise_not_found=False
         )
         if handler is None:

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1031,7 +1031,7 @@ class Request:
                 return default_when_empty
             raise self._media_error
 
-        handler, *_ = self.options.media_handlers.find_by_media_type(
+        handler, _, _ = self.options.media_handlers.find_by_media_type(
             self.content_type,
             self.options.default_media_type
         )
@@ -1800,7 +1800,7 @@ class Request:
         if param_value is None:
             return default
 
-        handler, *_ = self.options.media_handlers.find_by_media_type(
+        handler, _, _ = self.options.media_handlers.find_by_media_type(
             MEDIA_JSON, MEDIA_JSON, raise_not_found=False
         )
         if handler is None:

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -267,7 +267,7 @@ class Response:
                     if not self.content_type:
                         self.content_type = self.options.default_media_type
 
-                    handler, _, _ = self.options.media_handlers.find_by_media_type(
+                    handler, _, _ = self.options.media_handlers._resolve(
                         self.content_type,
                         self.options.default_media_type
                     )

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -267,7 +267,7 @@ class Response:
                     if not self.content_type:
                         self.content_type = self.options.default_media_type
 
-                    handler,*_ = self.options.media_handlers.find_by_media_type(
+                    handler, _, _ = self.options.media_handlers.find_by_media_type(
                         self.content_type,
                         self.options.default_media_type
                     )

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -238,7 +238,7 @@ class Response:
         #   so that apps relying on it do not fail silently.
         raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
-    def render_body(self, _shortcut_cache={}):
+    def render_body(self):
         """Get the raw bytestring content for the response body.
 
         This method returns the raw data for the HTTP response body, taking
@@ -267,7 +267,7 @@ class Response:
                     if not self.content_type:
                         self.content_type = self.options.default_media_type
 
-                    handler = self.options.media_handlers.find_by_media_type(
+                    handler,*_ = self.options.media_handlers.find_by_media_type(
                         self.content_type,
                         self.options.default_media_type
                     )

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -238,7 +238,7 @@ class Response:
         #   so that apps relying on it do not fail silently.
         raise AttributeError(_STREAM_LEN_REMOVED_MSG)
 
-    def render_body(self):
+    def render_body(self, _shortcut_cache={}):
         """Get the raw bytestring content for the response body.
 
         This method returns the raw data for the HTTP response body, taking

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -77,14 +77,12 @@ def _lru_cache_nop(*args, **kwargs):  # pragma: nocover
     return decorator
 
 
-if (
-    # NOTE(kgriffs): https://bugs.python.org/issue28969
-    (sys.version_info.minor == 5 and sys.version_info.micro < 4) or
-    (sys.version_info.minor == 6 and sys.version_info.micro < 1)
-):
-    _lru_cache_safe = _lru_cache_nop  # pragma: nocover
-else:
+# NOTE(kgriffs): https://bugs.python.org/issue28969
+_PYVER_TRIPLET = sys.version_info[:3]
+if _PYVER_TRIPLET >= (3, 5, 4) and _PYVER_TRIPLET != (3, 6, 0):
     _lru_cache_safe = functools.lru_cache  # type: ignore
+else:
+    _lru_cache_safe = _lru_cache_nop  # pragma: nocover
 
 
 # PERF(kgriffs): Using lru_cache is slower on pypy when the wrapped
@@ -92,7 +90,7 @@ else:
 if sys.implementation.name == 'pypy':
     _lru_cache_for_simple_logic = _lru_cache_nop  # pragma: nocover
 else:
-    _lru_cache_for_simple_logic = _lru_cache_safe
+    _lru_cache_for_simple_logic = _lru_cache_safe  # type: ignore
 
 
 def is_python_func(func):

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -80,15 +80,19 @@ def _lru_cache_nop(*args, **kwargs):  # pragma: nocover
 if (
     # NOTE(kgriffs): https://bugs.python.org/issue28969
     (sys.version_info.minor == 5 and sys.version_info.micro < 4) or
-    (sys.version_info.minor == 6 and sys.version_info.micro < 1) or
-
-    # PERF(kgriffs): Using lru_cache is slower on pypy when the wrapped
-    #   function is just doing a few non-IO operations.
-    (sys.implementation.name == 'pypy')
+    (sys.version_info.minor == 6 and sys.version_info.micro < 1)
 ):
     _lru_cache_safe = _lru_cache_nop  # pragma: nocover
 else:
     _lru_cache_safe = functools.lru_cache  # type: ignore
+
+
+# PERF(kgriffs): Using lru_cache is slower on pypy when the wrapped
+#   function is just doing a few non-IO operations.
+if sys.implementation.name == 'pypy':
+    _lru_cache_for_simple_logic = _lru_cache_nop  # pragma: nocover
+else:
+    _lru_cache_for_simple_logic = _lru_cache_safe
 
 
 def is_python_func(func):
@@ -378,7 +382,7 @@ def secure_filename(filename):
     return _UNSAFE_CHARS.sub('_', filename)
 
 
-@_lru_cache_safe(maxsize=64)
+@_lru_cache_for_simple_logic(maxsize=64)
 def http_status_to_code(status):
     """Normalize an HTTP status to an integer code.
 
@@ -416,7 +420,7 @@ def http_status_to_code(status):
         raise ValueError('status strings must start with a three-digit integer')
 
 
-@_lru_cache_safe(maxsize=64)
+@_lru_cache_for_simple_logic(maxsize=64)
 def code_to_http_status(status):
     """Normalize an HTTP status to an HTTP status line string.
 

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -71,6 +71,7 @@ utcnow = datetime.datetime.utcnow
 #   workstations, so we use the nocover pragma here.
 def _lru_cache_nop(*args, **kwargs):  # pragma: nocover
     def decorator(func):
+        func.cache_clear = lambda: None
         return func
 
     return decorator

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -24,8 +24,7 @@ in the `falcon` module, and so must be explicitly imported::
 
 """
 
-import platform
-
+from falcon.constants import PYPY
 try:
     from falcon.cyutil.uri import (
         decode as _cy_decode,
@@ -52,8 +51,6 @@ _HEX_DIGITS = '0123456789ABCDEFabcdef'
 _HEX_TO_BYTE = {(a + b).encode(): bytes([int(a + b, 16)])
                 for a in _HEX_DIGITS
                 for b in _HEX_DIGITS}
-
-_PYPY = platform.python_implementation() == 'PyPy'
 
 
 def _create_char_encoder(allowed_chars):
@@ -215,7 +212,7 @@ def _join_tokens_list(tokens):
 #     benefit of being able to decode() off it directly.
 #   * On PyPy, b''.join(list) is the recommended approach, although it may
 #     narrowly lose to BytesIO on the extreme end.
-_join_tokens = _join_tokens_list if _PYPY else _join_tokens_bytearray
+_join_tokens = _join_tokens_list if PYPY else _join_tokens_bytearray
 
 
 def decode(encoded_uri, unquote_plus=True):

--- a/tests/asgi/test_sse.py
+++ b/tests/asgi/test_sse.py
@@ -204,7 +204,7 @@ class TestSerializeJson:
 
     def test_use_media_handler_dumps(self, client):
         h = client.app.resp_options.media_handlers[falcon.MEDIA_JSON]
-        h.dumps = lambda x: json.dumps(x).upper()
+        h._dumps = lambda x: json.dumps(x).upper()
 
         result = client.simulate_get()
         assert result.text == (

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -881,7 +881,7 @@ class TestHTTPError:
     def test_serialize_error_uses_media_handler(self, client):
         client.app.add_route('/path', NotFoundResource())
         h = client.app.resp_options.media_handlers[falcon.MEDIA_JSON]
-        h.dumps = lambda x: json.dumps(x).upper()
+        h._dumps = lambda x: json.dumps(x).upper()
         response = client.simulate_request(path='/path')
 
         assert response.status == falcon.HTTP_404

--- a/tests/test_media_urlencoded.py
+++ b/tests/test_media_urlencoded.py
@@ -24,8 +24,8 @@ def test_deserialize_invalid_unicode():
 
 
 @pytest.mark.parametrize('data,expected', [
-    ({'hello': 'world'}, 'hello=world'),
-    ({'number': [1, 2]}, 'number=1&number=2'),
+    ({'hello': 'world'}, b'hello=world'),
+    ({'number': [1, 2]}, b'number=1&number=2'),
 ])
 def test_urlencoded_form_handler_serialize(data, expected):
     handler = media.URLEncodedFormHandler()

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -899,7 +899,7 @@ class TestQueryParams:
         client.app.add_route('/', resource)
         payload_dict = {'foo': 'bar'}
         query_string = 'payload={}'.format(json.dumps(payload_dict))
-        client.app.req_options.media_handlers[falcon.MEDIA_JSON].loads = lambda x: {'x': 'y'}
+        client.app.req_options.media_handlers[falcon.MEDIA_JSON]._loads = lambda x: {'x': 'y'}
         client.simulate_get(path='/', query_string=query_string)
         req = resource.captured_req
         assert req.get_param_as_json('payload') == {'x': 'y'}

--- a/tests/test_response_body.py
+++ b/tests/test_response_body.py
@@ -120,3 +120,8 @@ def test_response_body_rendition_error(asgi):
 
     resp = testing.simulate_get(app, '/test.mal')
     assert resp.status_code == 753
+
+    # NOTE(kgriffs): Validate that del works on media handlers.
+    del app.resp_options.media_handlers['text/x-malbolge']
+    resp = testing.simulate_get(app, '/test.mal')
+    assert resp.status_code == 415


### PR DESCRIPTION
# Summary of Changes

This patch optimizes the media (de)serialization paths for ASGI apps by
avoiding an extra await and slightly flattening the call stack.

BREAKING CHANGE: Private member variables for the default media handlers were
    renamed. This should only affect subclasses, as these variables were never
    documented, and were not intended to be part of the public interface.

# Related Issues

#1822

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
