### PR TITLE
perf: undo ASGI cythonization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ if CYTHON:
 
     package_names = [
         'falcon',
-        'falcon.asgi',
         'falcon.cyutil',
         'falcon.media',
         'falcon.routing',
@@ -66,7 +65,6 @@ if CYTHON:
         #
         # NOTE(vytas): It is pointless to cythonize reader.py, since cythonized
         #   Falcon is using reader.pyx instead.
-        'falcon.asgi._asgi_helpers',
         'falcon.hooks',
         'falcon.responders',
         'falcon.util.reader',


### PR DESCRIPTION
It is sad having to resort to this, but it seems that cythonized coroutines, although reasonably sped up as if added directly to an async loop, suffer a severe performance hit when `await`ed from a Python coroutine (and that is what virtually all ASGI app servers out there seem to do). So much that performance deteriorates to worse than pure Python :grimacing: 

Cython 3.0 alpha shows slighty better results, but still not even demonstrably faster than the pure Python version.