### PR TITLE
chore(CI): work around Sphinx and codecov-action issues

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2.1.4
@@ -65,11 +67,7 @@ jobs:
           FALCON_ASGI_WRAP_NON_COROUTINES: Y
           FALCON_TESTING_SESSION: Y
         run: |
-          # TODO(kgriffs): Revisit second half of 2021 to see if we still need to pin tox
-          #
-          #   See also: https://github.com/tox-dev/tox/issues/1777
-          #
-          pip install 'tox==3.20'
+          pip install tox
           tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
       - name: Get wheel name
@@ -132,6 +130,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get python version
         id: linux-py-version
@@ -181,7 +181,7 @@ jobs:
           FALCON_ASGI_WRAP_NON_COROUTINES: Y
           FALCON_TESTING_SESSION: Y
         run: |
-          pip install 'tox==3.20'
+          pip install tox
           tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
       - name: Get wheel names
@@ -255,6 +255,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2.1.4
@@ -325,6 +327,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Cache wheels
         uses: actions/cache@v2
@@ -357,7 +361,7 @@ jobs:
           args: |
             bash -c "
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            pip install 'tox==3.20' 'pip>=20' &&
+            pip install tox 'pip>=20' &&
             tox -e wheel_check -- ${{ matrix.pytest-extra }}
             "
 
@@ -381,7 +385,7 @@ jobs:
           args: |
             bash -c "
             export PATH=/opt/python/${{ matrix.python-version }}/bin:$PATH &&
-            pip install 'tox==3.20' 'pip>=20' &&
+            pip install tox 'pip>=20' &&
             tox -e wheel_check -- ${{ matrix.pytest-extra }}
             "
 

--- a/.github/workflows/tests-emulated.yaml
+++ b/.github/workflows/tests-emulated.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Cache PIP
         uses: actions/cache@v2
@@ -49,7 +51,7 @@ jobs:
             lscpu &&
             mkdir -p $PIP_CACHE_DIR &&
             chown -R $(whoami) $PIP_CACHE_DIR &&
-            pip install -U pip tox==3.20 &&
+            pip install -U pip tox &&
             python --version &&
             pip --version &&
             tox --version &&
@@ -67,7 +69,7 @@ jobs:
             lscpu &&
             mkdir -p $PIP_CACHE_DIR &&
             chown -R $(whoami) $PIP_CACHE_DIR &&
-            pip install -U pip tox==3.20 &&
+            pip install -U pip tox &&
             python --version &&
             pip --version &&
             tox --version &&

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,10 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+        # NOTE(vytas): Work around
+        #   https://github.com/codecov/codecov-action/issues/190
+        with:
+          fetch-depth: 2
 
       - name: Set up Python
         uses: actions/setup-python@v2.1.4
@@ -113,7 +117,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coverage tox==3.20
+          pip install coverage tox
           python --version
           pip --version
           tox --version

--- a/requirements/docs
+++ b/requirements/docs
@@ -4,6 +4,8 @@ jinja2
 markupsafe
 pygments
 pygments-style-github
-sphinx
+# TODO(vytas): Revisit later if Sphinx 3.5.0 issues have been resolved.
+#   See also: https://github.com/sphinx-doc/sphinx/issues/8880
+sphinx < 3.5.0
 sphinx_rtd_theme
 sphinx-tabs

--- a/tools/mintest.sh
+++ b/tools/mintest.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
-# TODO(kgriffs): Revisit second half of 2021 to see if we still need to pin tox
-#
-#   See also: https://github.com/tox-dev/tox/issues/1777
-#
-pip install -U tox==3.20 coverage
+pip install -U tox coverage
 
 rm -f .coverage.*
 


### PR DESCRIPTION
Wrestle CI issues:
* Pin Sphinx to disallow the latest version (3.5.0) that's breaking the viewcode extension: https://github.com/sphinx-doc/sphinx/issues/8880.
* Work around `codecov` issues detecting the commit hash: https://github.com/codecov/codecov-action/issues/190.
* Unpin `tox` since the related issue has been fixed.