### PR TITLE
perf(asgi): optimize request header decoding

### DIFF
--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -25,11 +25,11 @@ def header_property(header_name):
 
     """
 
-    header_name = header_name.lower()
+    header_name = header_name.lower().encode()
 
     def fget(self):
         try:
-            return self._asgi_headers[header_name] or None
+            return self._asgi_headers[header_name].decode() or None
         except KeyError:
             return None
 

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -29,6 +29,9 @@ from .stream import BoundedStream
 __all__ = ['Request']
 
 _UNSET = falcon.request._UNSET
+_SINGLETON_HEADERS_BYTESTR = frozenset([
+    h.encode() for h in SINGLETON_HEADERS
+])
 
 
 class Request(falcon.request.Request):
@@ -347,6 +350,7 @@ class Request(falcon.request.Request):
     __slots__ = [
         '_asgi_headers',
         '_asgi_server_cached',
+        '_cached_headers',
         '_first_event',
         '_receive',
         '_stream',
@@ -364,20 +368,25 @@ class Request(falcon.request.Request):
             # NOTE(kgriffs): According to ASGI 3.0, header names are always
             #   lowercased, and both name and value are byte strings. Although
             #   technically header names and values are restricted to US-ASCII
-            #   we decode using the default 'utf-8' because it is a little
-            #   faster than passing an encoding option.
-            header_name = header_name.decode()
-            header_value = header_value.decode()
+            #   we decode later (just-in-time) using the default 'utf-8' because
+            #   it is a little faster than passing an encoding option (except
+            #   under Cython).
+            #
+            #   The reason we wait to decode is that the typical app will not
+            #   need to decode all request headers, and we usually can just
+            #   leave the header name as a byte string and look it up that way.
+            #
 
             # NOTE(kgriffs): There are no standard request headers that
             #   allow multiple instances to appear in the request while also
             #   disallowing list syntax.
-            if header_name not in req_headers or header_name in SINGLETON_HEADERS:
+            if header_name not in req_headers or header_name in _SINGLETON_HEADERS_BYTESTR:
                 req_headers[header_name] = header_value
             else:
-                req_headers[header_name] += ',' + header_value
+                req_headers[header_name] += b',' + header_value
 
         self._asgi_headers = req_headers
+        self._cached_headers = None
 
         # =====================================================================
         #  Misc.
@@ -422,7 +431,6 @@ class Request(falcon.request.Request):
         self._cached_forwarded = None
         self._cached_forwarded_prefix = None
         self._cached_forwarded_uri = None
-        self._cached_headers = req_headers
         self._cached_prefix = None
         self._cached_relative_uri = None
         self._cached_uri = None
@@ -430,15 +438,15 @@ class Request(falcon.request.Request):
         if self.method == 'GET':
             # PERF(kgriffs): Normally we expect no Content-Type header, so
             #   use this pattern which is a little bit faster than dict.get()
-            if 'content-type' in req_headers:
-                self.content_type = req_headers['content-type']
+            if b'content-type' in req_headers:
+                self.content_type = req_headers[b'content-type'].decode()
             else:
                 self.content_type = None
         else:
             # PERF(kgriffs): This is the most performant pattern when we expect
             #   the key to be present most of the time.
             try:
-                self.content_type = req_headers['content-type']
+                self.content_type = req_headers[b'content-type'].decode()
             except KeyError:
                 self.content_type = None
 
@@ -487,14 +495,14 @@ class Request(falcon.request.Request):
         # NOTE(kgriffs): Per RFC, a missing accept header is
         # equivalent to '*/*'
         try:
-            return self._asgi_headers['accept'] or '*/*'
+            return self._asgi_headers[b'accept'].decode() or '*/*'
         except KeyError:
             return '*/*'
 
     @property
     def content_length(self):
         try:
-            value = self._asgi_headers['content-length']
+            value = self._asgi_headers[b'content-length'].decode()
         except KeyError:
             return None
 
@@ -574,7 +582,7 @@ class Request(falcon.request.Request):
         # try to avoid calling self.forwarded if we can, since it uses a
         # try...catch that will usually result in a relatively expensive
         # raised exception.
-        if 'forwarded' in self._asgi_headers:
+        if b'forwarded' in self._asgi_headers:
             first_hop = self.forwarded[0]
             scheme = first_hop.scheme or self.scheme
         else:
@@ -583,7 +591,7 @@ class Request(falcon.request.Request):
             # first. Note also that the indexing operator is
             # slightly faster than using get().
             try:
-                scheme = self._asgi_headers['x-forwarded-proto'].lower()
+                scheme = self._asgi_headers[b'x-forwarded-proto'].decode().lower()
             except KeyError:
                 scheme = self.scheme
 
@@ -595,7 +603,7 @@ class Request(falcon.request.Request):
             # NOTE(kgriffs): Prefer the host header; the web server
             # isn't supposed to mess with it, so it should be what
             # the client actually sent.
-            host_header = self._asgi_headers['host']
+            host_header = self._asgi_headers[b'host'].decode()
             host, __ = parse_host(host_header)
         except KeyError:
             host, __ = self._asgi_server
@@ -609,7 +617,7 @@ class Request(falcon.request.Request):
         # try to avoid calling self.forwarded if we can, since it uses a
         # try...catch that will usually result in a relatively expensive
         # raised exception.
-        if 'forwarded' in self._asgi_headers:
+        if b'forwarded' in self._asgi_headers:
             first_hop = self.forwarded[0]
             host = first_hop.host or self.netloc
         else:
@@ -618,7 +626,7 @@ class Request(falcon.request.Request):
             # just go for it without wasting time checking it
             # first.
             try:
-                host = self._asgi_headers['x-forwarded-host']
+                host = self._asgi_headers[b'x-forwarded-host'].decode()
             except KeyError:
                 host = self.netloc
 
@@ -646,17 +654,17 @@ class Request(falcon.request.Request):
 
             headers = self._asgi_headers
 
-            if 'forwarded' in headers:
+            if b'forwarded' in headers:
                 self._cached_access_route = []
                 for hop in self.forwarded:
                     if hop.src is not None:
                         host, __ = parse_host(hop.src)
                         self._cached_access_route.append(host)
-            elif 'x-forwarded-for' in headers:
-                addresses = headers['x-forwarded-for'].split(',')
+            elif b'x-forwarded-for' in headers:
+                addresses = headers[b'x-forwarded-for'].decode().split(',')
                 self._cached_access_route = [ip.strip() for ip in addresses]
-            elif 'x-real-ip' in headers:
-                self._cached_access_route = [headers['x-real-ip']]
+            elif b'x-real-ip' in headers:
+                self._cached_access_route = [headers[b'x-real-ip'].decode()]
 
             if self._cached_access_route:
                 if self._cached_access_route[-1] != client:
@@ -674,7 +682,7 @@ class Request(falcon.request.Request):
     @property
     def port(self):
         try:
-            host_header = self._asgi_headers['host']
+            host_header = self._asgi_headers[b'host'].decode()
             default_port = 443 if self._secure_scheme else 80
             __, port = parse_host(host_header, default_port=default_port)
         except KeyError:
@@ -687,7 +695,7 @@ class Request(falcon.request.Request):
         # PERF(kgriffs): try..except is faster than get() when we
         # expect the key to be present most of the time.
         try:
-            netloc_value = self._asgi_headers['host']
+            netloc_value = self._asgi_headers[b'host'].decode()
         except KeyError:
             netloc_value, port = self._asgi_server
 
@@ -794,26 +802,42 @@ class Request(falcon.request.Request):
         #   gets a None back on the first reference to property, it
         #   probably isn't going to access the property again (TBD).
         if self._cached_if_match is None:
-            header_value = self._asgi_headers.get('if-match')
+            header_value = self._asgi_headers.get(b'if-match')
             if header_value:
-                self._cached_if_match = helpers._parse_etags(header_value)
+                self._cached_if_match = helpers._parse_etags(header_value.decode())
 
         return self._cached_if_match
 
     @property
     def if_none_match(self):
         if self._cached_if_none_match is None:
-            header_value = self._asgi_headers.get('if-none-match')
+            header_value = self._asgi_headers.get(b'if-none-match')
             if header_value:
-                self._cached_if_none_match = helpers._parse_etags(header_value)
+                self._cached_if_none_match = helpers._parse_etags(header_value.decode())
 
         return self._cached_if_none_match
+
+    @property
+    def headers(self):
+        # NOTE(kgriffs: First time here will cache the dict so all we
+        # have to do is clone it in the future.
+        if self._cached_headers is None:
+            self._cached_headers = {
+                name.decode(): value.decode()
+                for name, value in self._asgi_headers.items()
+            }
+
+        return self._cached_headers
 
     # ------------------------------------------------------------------------
     # Public Methods
     # ------------------------------------------------------------------------
 
-    def get_header(self, name, required=False, default=None):
+    # PERF(kgriffs): Using kwarg cache, in lieu of @lru_cache on a helper method
+    #   that is then called from get_header(), was benchmarked to be more
+    #   efficient across CPython 3.6/3.8 (regardless of cythonization) and
+    #   PyPy 3.6.
+    def get_header(self, name, required=False, default=None, _name_cache={}):
         """Retrieve the raw string value for the given header.
 
         Args:
@@ -837,14 +861,19 @@ class Request(falcon.request.Request):
 
         """
 
-        asgi_name = name.lower()
+        try:
+            asgi_name = _name_cache[name]
+        except KeyError:
+            asgi_name = name.lower().encode()
+            if len(_name_cache) < 64:  # Somewhat arbitrary ceiling to mitigate abuse
+                _name_cache[name] = asgi_name
 
         # Use try..except to optimize for the header existing in most cases
         try:
             # Don't take the time to cache beforehand, using HTTP naming.
             # This will be faster, assuming that most headers are looked
             # up only once, and not all headers will be requested.
-            return self._asgi_headers[asgi_name]
+            return self._asgi_headers[asgi_name].decode()
 
         except KeyError:
             if not required:

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -322,6 +322,10 @@ class TestHeaders:
         value = req.get_header('X-Not-Found', default='some-value')
         assert value == 'some-value'
 
+        # Excercise any result caching and associated abuse mitigations
+        for i in range(10000):
+            assert req.get_header('X-Not-Found-{0}'.format(i)) is None
+
     @pytest.mark.parametrize('with_double_quotes', [True, False])
     def test_unset_header(self, client, with_double_quotes):
         client.app.add_route('/', RemoveHeaderResource(with_double_quotes))
@@ -373,6 +377,9 @@ class TestHeaders:
             assert actual_value == expected_value
 
         client.simulate_get(headers=resource.captured_req.headers)
+
+        # Validate that the property has been cached
+        assert resource.captured_req.headers is resource.captured_req.headers
 
         # Compare the request HTTP headers with the original headers
         for name, expected_value in request_headers.items():

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ commands = "{toxinidir}/tools/clean.sh" "{toxinidir}/falcon"
            coverage run -m pytest tests --ignore=tests/asgi []
 
 [testenv:py38]
+basepython = python3.8
 deps = {[testenv]deps}
        pytest-randomly
        jsonschema
@@ -80,6 +81,7 @@ whitelist_externals = {[with-coverage]whitelist_externals}
 commands = {[with-coverage]commands}
 
 [testenv:py38_sans_msgpack]
+basepython = python3.8
 deps = {[testenv]deps}
 whitelist_externals = {[with-coverage]whitelist_externals}
 commands = pip uninstall --yes msgpack
@@ -87,6 +89,7 @@ commands = pip uninstall --yes msgpack
            coverage run -m pytest tests -k "test_ws and test_msgpack_missing"
 
 [testenv:py38_nocover]
+basepython = python3.8
 deps = {[testenv]deps}
        pytest-randomly
        jsonschema


### PR DESCRIPTION
# Summary of Changes

Avoid decoding of header names when possible, and delay value decoding until
it is necessary.

This should reduce the overhead for constructing Request
objects without significantly increasing overall application performance in
the common case, since we reason that applications do not typically access
all request headers that may be present.

The worst case scenario would be an app that accesses the same header more than
a couple of times, in which case we would have to decode said header multiple
times. If this turns out to be a common use case, we will need to look into
memoization or some other mitigation.

# Related Issues

#1822 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
