### PR TITLE
dry create wheel workflow using a better action to upload wheels to release

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -223,6 +223,7 @@ jobs:
           pip install setuptools>=44 wheel>=0.34 cython>=0.29.21
           # cythonize -3 falcon/**/*.pyx
           python setup.py sdist --dist-dir dist
+          python .github/workflows/scripts/verify_tag.py dist
 
       - name: Upload wheels to release
         # upload the generated wheels to the github release

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -9,7 +9,7 @@ env:
   # set this so the falcon test uses the installed version and not the local one
   PYTHONNOUSERSITE: 1
   # comment TWINE_REPOSITORY_URL to use the real pypi. NOTE: change also the secret used in TWINE_PASSWORD
-  TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+  # TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
 
 jobs:
   # four jobs are defined make-wheel-win-osx, make-wheel-linux, make-source-dist and make-emulated-wheels
@@ -70,26 +70,12 @@ jobs:
           pip install tox
           tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
-      - name: Get wheel name
-        id: wheel-name
-        shell: bash
-        # the command `echo "::set-output ...` is used to create an step output that can be used in following steps
-        # ref https://github.community/t5/GitHub-Actions/Using-the-output-of-run-inside-of-if-condition/td-p/33920
-        run: |
-          echo ::set-output name=wheel::`ls dist`
-
-      - name: Upload wheel to release
-        # upload the generated wheel to the github release.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload wheels to release
+        # upload the generated wheels to the github release
+        uses: AButler/upload-release-assets@v2.0
         with:
-          # this is a release to the event is called release: https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release
-          # the release event has the structure of this response https://developer.github.com/v3/repos/releases/#create-a-release
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.wheel-name.outputs.wheel }}
-          asset_name: ${{ steps.wheel-name.outputs.wheel }}
-          asset_content_type: application/zip # application/octet-stream
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'dist/*.whl'
 
       - name: Publish wheel
         # the action https://github.com/marketplace/actions/pypi-publish runs only on linux and we cannot specify
@@ -184,47 +170,12 @@ jobs:
           pip install tox
           tox -e wheel_check -- ${{ matrix.pytest-extra }}
 
-      - name: Get wheel names
-        id: wheel-name
-        shell: bash
-        # the wheel creation step generates 4 wheels: linux, manylinux1, manylinux2010 and manylinux2014
-        # Pypi accepts only the manylinux versions
-        run: |
-          cd dist
-          ls -l
-          echo ::set-output name=wheel1::`ls *manylinux1*`
-          echo ::set-output name=wheel2010::`ls *manylinux2010*`
-          echo ::set-output name=wheel2014::`ls *manylinux2014*`
-
-      - name: Upload wheel manylinux1 to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload wheels to release
+        # upload the generated wheels to the github release
+        uses: AButler/upload-release-assets@v2.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.wheel-name.outputs.wheel1 }}
-          asset_name: ${{ steps.wheel-name.outputs.wheel1 }}
-          asset_content_type: application/zip # application/octet-stream
-
-      - name: Upload wheel manylinux2010 to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.wheel-name.outputs.wheel2010 }}
-          asset_name: ${{ steps.wheel-name.outputs.wheel2010 }}
-          asset_content_type: application/zip # application/octet-stream
-
-      - name: Upload wheel manylinux2014 to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.wheel-name.outputs.wheel2014 }}
-          asset_name: ${{ steps.wheel-name.outputs.wheel2014 }}
-          asset_content_type: application/zip # application/octet-stream
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'dist/*manylinux*'
 
       - name: Publish wheel
         # We upload all manylinux wheels. pip will download the appropriate one according to the system.
@@ -273,21 +224,12 @@ jobs:
           # cythonize -3 falcon/**/*.pyx
           python setup.py sdist --dist-dir dist
 
-      - name: Get sdist name
-        id: sdist-name
-        shell: bash
-        run: |
-          echo ::set-output name=sdist::`ls dist`
-
-      - name: Upload sdist to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload wheels to release
+        # upload the generated wheels to the github release
+        uses: AButler/upload-release-assets@v2.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.sdist-name.outputs.sdist }}
-          asset_name: ${{ steps.sdist-name.outputs.sdist }}
-          asset_content_type: application/zip # application/octet-stream
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'dist/*.tar.gz'
 
       - name: Publish sdist
         env:
@@ -389,25 +331,12 @@ jobs:
             tox -e wheel_check -- ${{ matrix.pytest-extra }}
             "
 
-      - name: Get wheel name
-        id: wheel-name
-        shell: bash
-        # the wheel creation step generates 2 wheels: linux and manylinux2014
-        # Pypi accepts only the manylinux version
-        run: |
-          cd dist
-          ls -l
-          echo ::set-output name=wheel2014::`ls *manylinux2014*`
-
-      - name: Upload wheel manylinux2014 to release
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload wheels to release
+        # upload the generated wheels to the github release
+        uses: AButler/upload-release-assets@v2.0
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.wheel-name.outputs.wheel2014 }}
-          asset_name: ${{ steps.wheel-name.outputs.wheel2014 }}
-          asset_content_type: application/zip # application/octet-stream
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'dist/*manylinux*'
 
       - name: Set up Python
         uses: actions/setup-python@v2.1.4

--- a/.github/workflows/scripts/verify_tag.py
+++ b/.github/workflows/scripts/verify_tag.py
@@ -1,0 +1,47 @@
+import argparse
+from os import environ
+from pathlib import Path
+
+# See https://docs.github.com/en/actions/reference/environment-variables
+ENV_VARIABLE = 'GITHUB_REF'
+
+
+def go():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('folder', help='Directory where to look for wheels and source dist')
+
+    args = parser.parse_args()
+
+    if ENV_VARIABLE not in environ:
+        raise RuntimeError('Expected to find %r in environ' % ENV_VARIABLE)
+
+    directory = Path(args.folder)
+    candidates = list(directory.glob('*.whl')) + list(directory.glob('*.tar.gz'))
+    if not candidates:
+        raise RuntimeError('No wheel or source dist found in folder ' + args.folder)
+    raw_value = environ[ENV_VARIABLE]
+    tag_value = raw_value.split('/')[-1]
+
+    errors = []
+    for candidate in candidates:
+        name = candidate.stem
+        if name.endswith('.tar'):
+            name = name[:-4]
+        parts = name.split('-')
+        if len(parts) < 2:
+            errors.append(str(candidate))
+            continue
+        version = parts[1]
+        if version.lower() != tag_value.lower():
+            errors.append(str(candidate))
+
+    if errors:
+        raise RuntimeError(
+            'Expected to find only wheels or or source dist with tag %r (from env variable '
+            'value %r). Found instead %s' % (tag_value, raw_value, errors)
+        )
+    print('Found %s wheels or source dist with tag %r' % (len(candidates), tag_value))
+
+
+if __name__ == '__main__':
+    go()

--- a/tox.ini
+++ b/tox.ini
@@ -430,6 +430,7 @@ skipsdist = True
 skip_install = True
 deps = setuptools>=44
        pytest
+passenv = GITHUB_*
 setenv =
     PYTHONASYNCIODEBUG=0
     PYTHONNOUSERSITE=1
@@ -440,5 +441,6 @@ commands =
     pip install --find-links {toxinidir}/dist --no-index --ignore-installed falcon
     python --version
     python -c "import sys; sys.path.pop(0); from falcon.cyutil import misc, reader, uri"
+    python .github/workflows/scripts/verify_tag.py {toxinidir}/dist
     pip install -r{toxinidir}/requirements/tests
     pytest -q tests []


### PR DESCRIPTION
https://github.com/actions/upload-release-asset is discontinued, and I've found a better action to upload the asset to the release.

it also allows us to dry things quite a bit