### PR TITLE
fix: prevent "examples" from being installed as top-level pkg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ setup(
     author_email='mail@kgriffs.com',
     url='https://falconframework.org',
     license='Apache 2.0',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.5',


### PR DESCRIPTION
# Summary of Changes

Prevent the top-level `examples` package from being installed to sitedir.

# Related Issues

N/A

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
