### PR TITLE
chore(CI): add CPython 3.10 beta gates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,6 +68,12 @@ jobs:
           - python-version: 3.9
             os: ubuntu-20.04
             toxenv: py39_cython
+          - python-version: 3.10.0-beta.1
+            os: ubuntu-20.04
+            toxenv: py310
+          - python-version: 3.10.0-beta.1
+            os: ubuntu-20.04
+            toxenv: py310_cython
           - python-version: 3.8
             os: ubuntu-20.04
             toxenv: py38_sans_msgpack

--- a/tox.ini
+++ b/tox.ini
@@ -177,6 +177,13 @@ deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
+[testenv:py310_cython]
+basepython = python3.10
+install_command = {[with-cython]install_command}
+deps = {[with-cython]deps}
+setenv = {[with-cython]setenv}
+commands = {[with-cython]commands}
+
 # --------------------------------------------------------------------
 # WSGI servers (Cythonized Falcon)
 # --------------------------------------------------------------------


### PR DESCRIPTION
I haven't added the corresponding Trove classifier yet, waiting for @CaselIT 's PEP 517 changes to land, as well as for 3.10 itself to stabilize.
