### PR TITLE
test: constrain aioredis to <2 in example requirements.

### DIFF
--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -685,7 +685,7 @@ Let's mitigate this problem with response caching. We'll use Redis, taking
 advantage of `aioredis <https://github.com/aio-libs/aioredis>`_ for async
 support::
 
-  pip install aioredis
+  pip install "aioredis < 2.0"
 
 We will also need to serialize response data (the ``Content-Type`` header and
 the body in the first version); ``msgpack`` should do::

--- a/examples/asgilook/requirements/asgilook
+++ b/examples/asgilook/requirements/asgilook
@@ -1,4 +1,4 @@
 aiofiles>=0.4.0
-aioredis
+aioredis<2
 msgpack
 Pillow>=6.0.0


### PR DESCRIPTION
aioredis 2 instroduces breaking changes. 

I've just constrained it to <2 to fix the tests
I've opened https://github.com/falconry/falcon/issues/1938 to add support for v2 instead
