### PR TITLE
fix(asgi): Incomplete, add finally to stream close

### DIFF
--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -698,9 +698,11 @@ class App(falcon.app.App):
                         '__aiter__ method. Error raised while iterating over '
                         'Response.stream: ' + str(ex)
                     )
-                finally:
-                    if hasattr(stream, 'close'):
-                        await stream.close()
+
+                # TODO: Surround the .close() below with a finally:
+
+            if hasattr(stream, 'close'):
+                await stream.close()
 
         await send(_EVT_RESP_EOF)
 

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -698,9 +698,9 @@ class App(falcon.app.App):
                         '__aiter__ method. Error raised while iterating over '
                         'Response.stream: ' + str(ex)
                     )
-
-            if hasattr(stream, 'close'):
-                await stream.close()
+                finally:
+                    if hasattr(stream, 'close'):
+                        await stream.close()
 
         await send(_EVT_RESP_EOF)
 


### PR DESCRIPTION
# Summary of Changes
@vytas7 

- `finally` clause was added to `falcon/asgi/app.py`, so that the stream is closed even when an exception occurs. 
- There are now two failed assertions in `tests/asgi/test_hello_asgi.py`, which are related to closing of the file. Assistance / guidance from an expert is needed.
- No tests have been drafted yet, since I haven't been able to pass the current tests yet.

# Related Issues

#1943 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
