### PR TITLE
docs: clarify trailing slash behaviour in compile_uri_template() docs

### DIFF
--- a/falcon/routing/util.py
+++ b/falcon/routing/util.py
@@ -52,9 +52,9 @@ def compile_uri_template(template):
         If the template contains a trailing slash character, it will be
         stripped.
 
-        Note that this is **different** to :ref:`the default behavior
-        <trailing_slash_in_path>` of ``add_route()`` with the
-        default router.
+        Note that this is **different** from :ref:`the default behavior
+        <trailing_slash_in_path>` of :func:`~falcon.App.add_route` used
+        with the default :class:`~falcon.routing.CompiledRouter`.
 
         The :attr:`~falcon.RequestOptions.strip_url_path_trailing_slash`
         request option is not considered by ``compile_uri_template()``.


### PR DESCRIPTION
# Summary of Changes
Clarify the docstring of `compile_uri_template()` ([link](https://falcon.readthedocs.io/en/3.0.1/api/routing.html#falcon.routing.compile_uri_template)), since
- it handles trailing slashes in URIs differently than the default router does
- it ignores the setting `falcon.RequestOptions.strip_url_path_trailing_slash`
- issue falconry#1929 reflects the same experience that I had of believing the docs for `compile_uri_template()` also apply to `add_route()`

Note: The default value for `falcon.RequestOptions.strip_url_path_trailing_slash` was `True` until Falcon v2.0, so the behaviour was consistent, but now is not.


# Related Issues
Closes #1929

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] **Updated **documentation** for changed code.**
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] **Updated docstrings for any modifications to existing code.**
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
