### PR TITLE
fix(tests): use integer division when passing args to rand_string

### DIFF
--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -73,7 +73,7 @@ class TestASGIServer:
         }
 
     def test_post_multiple(self, server_base_url):
-        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        body = testing.rand_string(_SIZE_1_KB // 2, _SIZE_1_KB)
         resp = requests.post(server_base_url, data=body, timeout=_REQUEST_TIMEOUT)
         assert resp.status_code == 200
         assert resp.text == body
@@ -104,7 +104,7 @@ class TestASGIServer:
             pass
 
     def test_post_read_bounded_stream(self, server_base_url):
-        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        body = testing.rand_string(_SIZE_1_KB // 2, _SIZE_1_KB)
         resp = requests.post(
             server_base_url + 'bucket', data=body, timeout=_REQUEST_TIMEOUT
         )

--- a/tests/asgi/test_request_body_asgi.py
+++ b/tests/asgi/test_request_body_asgi.py
@@ -79,7 +79,7 @@ class TestRequestBody:
 
     def test_read_body(self, client, resource):
         client.app.add_route('/', resource)
-        expected_body = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+        expected_body = testing.rand_string(SIZE_1_KB // 2, SIZE_1_KB)
         expected_len = len(expected_body)
 
         headers = {

--- a/tests/test_request_body.py
+++ b/tests/test_request_body.py
@@ -63,7 +63,7 @@ class TestRequestBody:
 
     def test_read_body(self, client, resource):
         client.app.add_route('/', resource)
-        expected_body = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+        expected_body = testing.rand_string(SIZE_1_KB // 2, SIZE_1_KB)
         expected_len = len(expected_body)
         headers = {'Content-Length': str(expected_len)}
 
@@ -97,7 +97,7 @@ class TestRequestBody:
         assert len(data) == 0
 
     def test_body_stream_wrapper(self):
-        data = testing.rand_string(SIZE_1_KB / 2, SIZE_1_KB)
+        data = testing.rand_string(SIZE_1_KB // 2, SIZE_1_KB)
         expected_body = data.encode('utf-8')
         expected_len = len(expected_body)
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -34,7 +34,7 @@ class TestWSGIServer:
         assert resp.status_code == 405
 
     def test_post(self):
-        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        body = testing.rand_string(_SIZE_1_KB // 2, _SIZE_1_KB)
         resp = requests.post(_SERVER_BASE_URL, data=body)
         assert resp.status_code == 200
         assert resp.text == body
@@ -45,7 +45,7 @@ class TestWSGIServer:
         assert resp.status_code == 400
 
     def test_post_read_bounded_stream(self):
-        body = testing.rand_string(_SIZE_1_KB / 2, _SIZE_1_KB)
+        body = testing.rand_string(_SIZE_1_KB // 2, _SIZE_1_KB)
         resp = requests.post(_SERVER_BASE_URL + 'bucket', data=body)
         assert resp.status_code == 200
         assert resp.text == body


### PR DESCRIPTION
# Summary of Changes

This cleans up some deprecation warnings that look like

    DeprecationWarning: non-integer arguments to randrange() have been deprecated since Python 3.10 and will be removed in a subsequent version

# Related Issues

#1966 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
