### PR TITLE
chore: deprecate Python 3.6 support

### DIFF
--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -15,6 +15,7 @@ Changes to Supported Platforms
 ------------------------------
 
 - CPython 3.10 is now fully supported. (pending `#1966 <https://github.com/falconry/falcon/issues/1966>`__)
+- Support for Python 3.6 is now deprecated and will be removed in Falcon 4.0.
 - As with the previous release, Python 3.5 support remains deprecated and will
   no longer be supported in Falcon 4.0.
 


### PR DESCRIPTION
I'm proposing to mark Python 3.6 support as deprecated as of Falcon 3.1.

CPython 3.6 goes [EOL in December 2021](https://endoflife.date/python) (only two months left at the time of writing), and realistically thinking, we probably won't release Falcon 3.1 much earlier than that (if at all earlier). PyPy already has a 3.7 compatible version out there, so it shouldn't hurt PyPy users too much either.
