### PR TITLE
fix: implement `close()` method for asgi static files

### DIFF
--- a/docs/_newsfragments/1963.bugfix.rst
+++ b/docs/_newsfragments/1963.bugfix.rst
@@ -1,2 +1,1 @@
-Impemented :func:`~falcon.routing.static._AsyncFileReader.close()` method to
-close files in asgi static routes.
+Implemented method to close files in asgi static routes.

--- a/docs/_newsfragments/1963.bugfix.rst
+++ b/docs/_newsfragments/1963.bugfix.rst
@@ -1,1 +1,3 @@
-Implemented method to close files in asgi static routes.
+Previously, files could be left open when serving via an ASGI static route
+(depending on the underlying GC implementation). This has been fixed so that a
+file is closed explicitly after rendering the response.

--- a/docs/_newsfragments/1963.bugfix.rst
+++ b/docs/_newsfragments/1963.bugfix.rst
@@ -1,0 +1,2 @@
+Impemented :func:`~falcon.routing.static._AsyncFileReader.close()` method to
+close files in asgi static routes.

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -241,3 +241,6 @@ class _AsyncFileReader:
 
     async def read(self, size=-1):
         return await self._loop.run_in_executor(None, partial(self._file.read, size))
+
+    async def close(self):
+        await self._loop.run_in_executor(None, self._file.close)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -4,6 +4,7 @@ import errno
 import io
 import os
 import pathlib
+import unittest.mock
 
 import pytest
 
@@ -575,3 +576,14 @@ def test_bounded_file_wrapper():
     assert not buffer.closed
     fh.close()
     assert buffer.closed
+
+
+def test_file_closed(client, monkeypatch):
+    client.app.add_static_route('/static', '/var/www/statics')
+
+    m = unittest.mock.mock_open(read_data=b'test_data')
+    with unittest.mock.patch('io.open', m):
+        client.simulate_request(path='/static/foobar')
+    m.assert_called_once_with(unittest.mock.ANY, 'rb')
+    handler = m()
+    handler.close.assert_called_once_with()


### PR DESCRIPTION
# Summary of Changes

Implement `close()` method for `_AsyncFileReader`

# Related Issues

Fixes #1963 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
