### PR TITLE
docs: tweak misc stuff, expand quick links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
 Quick Links
 -----------
 
-* `Read the docs<https://falcon.readthedocs.io/en/stable>`_
+* `Read the docs <https://falcon.readthedocs.io/en/stable>`_
 
   - `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
   - `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,12 @@ champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
 Quick Links
 -----------
 
-* `Read the docs <https://falcon.readthedocs.io/en/stable>`_
+* `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
+
+  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ ·
+  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ ·
+  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
+
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_
 * `falconry/user for Falcon users <https://gitter.im/falconry/user>`_ @ Gitter
@@ -241,8 +246,8 @@ In order to provide an extra speed boost, Falcon can compile itself with
 Cython. Wheels containing pre-compiled binaries are available from PyPI for
 several common platforms. However, if a wheel for your platform of choice is not
 available, you can install the source distribution. The installation process
-will automatically try to cythonize Falcon for your environment, falling back to 
-a normal pure-Python install if any issues are encountered during the 
+will automatically try to cythonize Falcon for your environment, falling back to
+a normal pure-Python install if any issues are encountered during the
 cythonization step:
 
 .. code:: bash

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,9 @@ Quick Links
 -----------
 
 * `Read the docs <https://falcon.readthedocs.io/en/stable>`_
-
-  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
-  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
-  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
-
+  (`FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
+  `getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
+  `reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_)
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_
 * `falconry/user for Falcon users <https://gitter.im/falconry/user>`_ @ Gitter

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
 Quick Links
 -----------
 
-* `📚 Read the docs 📚<https://falcon.readthedocs.io/en/stable>`_
+* `📚 Read the docs 📚 <https://falcon.readthedocs.io/en/stable>`_
 
   🦺 `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
   🤔 `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_

--- a/README.rst
+++ b/README.rst
@@ -1024,11 +1024,8 @@ See also: `CONTRIBUTING.md <https://github.com/falconry/falcon/blob/master/CONTR
 Legal
 -----
 
-Copyright 2013-2020 by Individual and corporate contributors as
+Copyright 2013-2021 by Individual and corporate contributors as
 noted in the individual source files.
-
-Falcon image courtesy of `John
-O'Neill <https://commons.wikimedia.org/wiki/File:Brown-Falcon,-Vic,-3.1.2008.jpg>`__.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may
 not use any portion of the Falcon framework except in compliance with

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Quick Links
 
 * `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
 
-  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ --
-  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ --
+  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
+  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
   `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
 
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_

--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,11 @@ champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
 Quick Links
 -----------
 
-* `📚 Read the docs 📚 <https://falcon.readthedocs.io/en/stable>`_
+* `Read the docs<https://falcon.readthedocs.io/en/stable>`_
 
-  🦺 `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
-  🤔 `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_
-  📚 `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
+  - `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
+  - `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_
+  - `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
 
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@ Quick Links
 
 * `Read the docs <https://falcon.readthedocs.io/en/stable>`_
 
-  - `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
-  - `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_
-  - `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
+  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
+  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
+  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
 
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Quick Links
 
 * `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
 
-  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ ·
-  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ ·
+  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ --
+  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ --
   `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
 
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_

--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,11 @@ champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
 Quick Links
 -----------
 
-* `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
+* `📚 Read the docs 📚<https://falcon.readthedocs.io/en/stable>`_
 
-  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
-  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
-  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
+  🦺 `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_
+  🤔 `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_
+  📚 `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
 
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,11 +8,11 @@ The Falcon Web Framework
 
 Release v\ |version| (:ref:`Installation <install>`)
 
-Falcon is a minimalist ASGI/WSGI framework for building mission-critical REST
-APIs and microservices, with a focus on reliability, correctness, and
-performance at scale.
+`Falcon <https://falconframework.org>`__ is a minimalist ASGI/WSGI framework for
+building mission-critical REST APIs and microservices, with a focus on
+reliability, correctness, and performance at scale.
 
-We like to think of Falcon as the `Dieter Rams` of web frameworks. Falcon
+We like to think of Falcon as the *Dieter Rams* of web frameworks. Falcon
 encourages the REST architectural style, and tries to do as little as possible
 while remaining highly effective.
 
@@ -35,6 +35,18 @@ while remaining highly effective.
 
     app = falcon.App()
     app.add_route('/quote', QuoteResource())
+
+Quick Links
+-----------
+
+* `Read the docs <https://falcon.readthedocs.io/en/stable>`_
+  (`FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
+  `getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
+  `reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_)
+* `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
+* `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_
+* `falconry/user for Falcon users <https://gitter.im/falconry/user>`_ @ Gitter
+* `falconry/dev for Falcon contributors <https://gitter.im/falconry/dev>`_ @ Gitter
 
 What People are Saying
 ----------------------
@@ -59,20 +71,6 @@ middle. Falcon seems like the requests of backend."
 documentation. It basically can't be wrong."
 
 "What other framework has integrated support for 786 TRY IT NOW ?"
-
-Quick Links
------------
-
-* `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
-
-  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
-  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
-  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
-
-* `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
-* `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_
-* `falconry/user for Falcon users <https://gitter.im/falconry/user>`_ @ Gitter
-* `falconry/dev for Falcon contributors <https://gitter.im/falconry/dev>`_ @ Gitter
 
 Features
 --------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -63,7 +63,12 @@ documentation. It basically can't be wrong."
 Quick Links
 -----------
 
-* `Read the docs <https://falcon.readthedocs.io/en/stable>`_
+* `Read the docs (stable version) <https://falcon.readthedocs.io/en/stable>`_
+
+  `Getting help <https://falcon.readthedocs.io/en/stable/community/help.html>`_ -
+  `FAQ <https://falcon.readthedocs.io/en/stable/user/faq.html>`_ -
+  `Framework reference <https://falcon.readthedocs.io/en/stable/api/index.html>`_
+
 * `Falcon add-ons and complementary packages <https://github.com/falconry/falcon/wiki>`_
 * `Falcon articles, talks and podcasts <https://github.com/falconry/falcon/wiki/Articles,-Talks-and-Podcasts>`_
 * `falconry/user for Falcon users <https://gitter.im/falconry/user>`_ @ Gitter

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -718,8 +718,9 @@ that all middleware callbacks must be asynchronous. Even calling ``ping()`` and
 rescue. An ASGI application server emits these events upon application startup
 and shutdown.
 
-Let's implement the ``process_startup()`` and ``process_shutdown()``` handlers
-in our middleware to execute code upon our application startup:
+Let's implement the ``process_startup()`` and ``process_shutdown()`` handlers
+in our middleware to execute code upon our application's startup and shutdown,
+respectively:
 
 .. code:: python
 


### PR DESCRIPTION
I was thinking it would be good to expand Quick Links to shorten time-to-FAQ for our repository's guests.

However, it doesn't look perfect: https://github.com/vytas7/falcon/tree/misc-docs-tweaks-2021-12#quick-links
(Suggestions are very welcome. I tried a nested list, and it looked odd with a dark GH theme.)

Or could we maybe add these items inside parentheses on the same line?