### PR TITLE
chore(requirements): resurrect `uvicorn` tests on Python 3.6

### DIFF
--- a/requirements/tests
+++ b/requirements/tests
@@ -10,7 +10,8 @@ testtools; python_version < '3.10'
 pytest-asyncio
 aiofiles; python_version >= '3.6'
 httpx; python_version >= '3.6'
-uvicorn; python_version >= '3.7'
+uvicorn < 0.17.0; python_version == '3.6'
+uvicorn >= 0.17.0; python_version >= '3.7'
 websockets; python_version >= '3.6'
 
 # Handler Specific


### PR DESCRIPTION
Restore `uvicorn` functional tests targeting Python 3.6 (using an older `uvicorn` version).

See also:
* https://github.com/falconry/falcon/pull/2004#discussion_r785427351
* https://github.com/encode/uvicorn/issues/1327
