### PR TITLE
feat(deprecation): add `__qualname__` to deprecated args warnings

### DIFF
--- a/docs/_newsfragments/2010.newandimproved.rst
+++ b/docs/_newsfragments/2010.newandimproved.rst
@@ -1,3 +1,4 @@
-Functions/methods such as :func:`falcon.errors.HTTPError` called with
-positional arguments will now raise a warning indicating the full qualified
-name of the function/method to help the developer understand where to make changes.
+When called with deprecated positional arguments, methods and class
+initializers (such as :class:`falcon.errors.HTTPError`) will now emit a
+user-friendlier warning indicating the fully qualified name of the method in
+question.

--- a/docs/_newsfragments/2010.newandimproved.rst
+++ b/docs/_newsfragments/2010.newandimproved.rst
@@ -1,0 +1,3 @@
+Functions/methods such as :func:`falcon.errors.HTTPError` called with
+positional arguments will now raise a warning indicating the full qualified
+name of the function/method to help the developer understand where to make changes.

--- a/falcon/util/deprecation.py
+++ b/falcon/util/deprecation.py
@@ -20,7 +20,6 @@ This module provides decorators to mark functions and classes as deprecated.
 import functools
 import warnings
 
-
 __all__ = (
     'DeprecatedWarning',
     'deprecated',
@@ -56,7 +55,6 @@ def deprecated(instructions, is_property=False, method_name=None):
     """
 
     def decorator(func):
-
         object_name = 'property' if is_property else 'function'
         post_name = '' if is_property else '(...)'
         message = 'Call to deprecated {} {}{}. {}'.format(
@@ -98,17 +96,23 @@ def deprecated_args(*, allowed_positional, is_method=True):
         def wraps(*args, **kwargs):
             if len(args) > allowed_positional:
                 called_args = ', '.join(
-                    f'{arg if not isinstance(arg, str) else arg!r}'
-                    for arg in args[1 if is_method else 0 :]
+                    '{!r}'.format(arg) for arg in args[1 if is_method else 0 :]
                 )
                 called_kwargs = ', '.join(
-                    f'{k}={v if not isinstance(v, str) else v!r}'
-                    for k, v in kwargs.items()
+                    '{k}={v!r}'.format(k=k, v=v) for k, v in kwargs.items()
                 )
                 warnings.warn(
                     warn_text.format(
-                        fn=f'{fn.__module__}.{fn.__qualname__}({called_args}'
-                        + (f', {called_kwargs})' if called_kwargs else '')
+                        fn='{module}.{qualname}({called_args}'.format(
+                            module=fn.__module__,
+                            qualname=fn.__qualname__,
+                            called_args=called_args,
+                        )
+                        + (
+                            ', {called_kwargs})'.format(called_kwargs=called_kwargs)
+                            if called_kwargs
+                            else ''
+                        )
                         + ')'
                     ),
                     DeprecatedWarning,

--- a/falcon/util/deprecation.py
+++ b/falcon/util/deprecation.py
@@ -85,11 +85,11 @@ def deprecated_args(*, allowed_positional, is_method=True):
     """
 
     template = (
-        'Calls with{} positional args are deprecated.'
+        'Calls to {{fn}} with{arg_text} positional args are deprecated.'
         ' Please specify them as keyword arguments instead.'
     )
     text = ' more than {}'.format(allowed_positional) if allowed_positional else ''
-    warn_text = template.format(text)
+    warn_text = template.format(arg_text=text)
     if is_method:
         allowed_positional += 1
 
@@ -97,7 +97,7 @@ def deprecated_args(*, allowed_positional, is_method=True):
         @functools.wraps(fn)
         def wraps(*args, **kwargs):
             if len(args) > allowed_positional:
-                warnings.warn(warn_text, DeprecatedWarning, stacklevel=2)
+                warnings.warn(warn_text.format(fn=fn.__name__), DeprecatedWarning, stacklevel=2)
             return fn(*args, **kwargs)
 
         return wraps

--- a/falcon/util/deprecation.py
+++ b/falcon/util/deprecation.py
@@ -97,8 +97,22 @@ def deprecated_args(*, allowed_positional, is_method=True):
         @functools.wraps(fn)
         def wraps(*args, **kwargs):
             if len(args) > allowed_positional:
+                called_args = ', '.join(
+                    f'{arg if not isinstance(arg, str) else arg!r}'
+                    for arg in args[1 if is_method else 0 :]
+                )
+                called_kwargs = ', '.join(
+                    f'{k}={v if not isinstance(v, str) else v!r}'
+                    for k, v in kwargs.items()
+                )
                 warnings.warn(
-                    warn_text.format(fn=fn.__name__), DeprecatedWarning, stacklevel=2
+                    warn_text.format(
+                        fn=f'{fn.__module__}.{fn.__qualname__}({called_args}'
+                        + (f', {called_kwargs})' if called_kwargs else '')
+                        + ')'
+                    ),
+                    DeprecatedWarning,
+                    stacklevel=2,
                 )
             return fn(*args, **kwargs)
 

--- a/falcon/util/deprecation.py
+++ b/falcon/util/deprecation.py
@@ -20,6 +20,7 @@ This module provides decorators to mark functions and classes as deprecated.
 import functools
 import warnings
 
+
 __all__ = (
     'DeprecatedWarning',
     'deprecated',
@@ -55,6 +56,7 @@ def deprecated(instructions, is_property=False, method_name=None):
     """
 
     def decorator(func):
+
         object_name = 'property' if is_property else 'function'
         post_name = '' if is_property else '(...)'
         message = 'Call to deprecated {} {}{}. {}'.format(
@@ -83,7 +85,7 @@ def deprecated_args(*, allowed_positional, is_method=True):
     """
 
     template = (
-        'Calls to {{fn}} with{arg_text} positional args are deprecated.'
+        'Calls to {{fn}}(...) with{arg_text} positional args are deprecated.'
         ' Please specify them as keyword arguments instead.'
     )
     text = ' more than {}'.format(allowed_positional) if allowed_positional else ''
@@ -95,26 +97,8 @@ def deprecated_args(*, allowed_positional, is_method=True):
         @functools.wraps(fn)
         def wraps(*args, **kwargs):
             if len(args) > allowed_positional:
-                called_args = ', '.join(
-                    '{!r}'.format(arg) for arg in args[1 if is_method else 0 :]
-                )
-                called_kwargs = ', '.join(
-                    '{k}={v!r}'.format(k=k, v=v) for k, v in kwargs.items()
-                )
                 warnings.warn(
-                    warn_text.format(
-                        fn='{module}.{qualname}({called_args}'.format(
-                            module=fn.__module__,
-                            qualname=fn.__qualname__,
-                            called_args=called_args,
-                        )
-                        + (
-                            ', {called_kwargs})'.format(called_kwargs=called_kwargs)
-                            if called_kwargs
-                            else ''
-                        )
-                        + ')'
-                    ),
+                    warn_text.format(fn=fn.__qualname__),
                     DeprecatedWarning,
                     stacklevel=2,
                 )

--- a/falcon/util/deprecation.py
+++ b/falcon/util/deprecation.py
@@ -97,7 +97,9 @@ def deprecated_args(*, allowed_positional, is_method=True):
         @functools.wraps(fn)
         def wraps(*args, **kwargs):
             if len(args) > allowed_positional:
-                warnings.warn(warn_text.format(fn=fn.__name__), DeprecatedWarning, stacklevel=2)
+                warnings.warn(
+                    warn_text.format(fn=fn.__name__), DeprecatedWarning, stacklevel=2
+                )
             return fn(*args, **kwargs)
 
         return wraps

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1325,6 +1325,12 @@ class TestDeprecatedArgs:
             "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
             "a_method(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
         )
+        # Testing that with a single argument it doesn't print 'a_method(1,)'
+        C().a_method(1)
+        assert (
+            "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
+            "a_method(1)" in str(recwarn[1].message)  # noqa: Q000
+        )
 
     def test_function(self, recwarn):
         @deprecation.deprecated_args(allowed_positional=0, is_method=False)
@@ -1338,6 +1344,12 @@ class TestDeprecatedArgs:
         assert (
             "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
             "a_function(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
+        )
+        # Testing that with a single argument it doesn't print 'a_function(1,)'
+        a_function(1)
+        assert (
+            "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
+            "a_function(1)" in str(recwarn[1].message)  # noqa: Q000
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1321,10 +1321,14 @@ class TestDeprecatedArgs:
         assert len(recwarn) == 0
         C().a_method(1, '2', c='3', d=4)
         assert len(recwarn) == 1
+        # need to split over 3 asserts because python 3.5 does not ensure ordering
+        # of kwargs
         assert (
             "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
-            "a_method(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
+            "a_method(1, '2', " in str(recwarn[0].message)  # noqa: Q000
         )
+        assert "c='3'" in str(recwarn[0].message)  # noqa: Q000
+        assert "d=4" in str(recwarn[0].message)  # noqa: Q000
         # Testing that with a single argument it doesn't print 'a_method(1,)'
         C().a_method(1)
         assert (
@@ -1341,10 +1345,14 @@ class TestDeprecatedArgs:
         assert len(recwarn) == 0
         a_function(1, '2', c='3', d=4)
         assert len(recwarn) == 1
+        # need to split over 3 asserts because python 3.5 does not ensure ordering
+        # of kwargs
         assert (
             "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
-            "a_function(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
+            "a_function(1, '2', " in str(recwarn[0].message)  # noqa: Q000
         )
+        assert "c='3'" in str(recwarn[0].message)  # noqa: Q000
+        assert "d=4" in str(recwarn[0].message)  # noqa: Q000
         # Testing that with a single argument it doesn't print 'a_function(1,)'
         a_function(1)
         assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1314,25 +1314,31 @@ class TestDeprecatedArgs:
     def test_method(self, recwarn):
         class C:
             @deprecation.deprecated_args(allowed_positional=0)
-            def a_method(self, a=1, b=2):
+            def a_method(self, a=None, b=None, c=None, d=None):
                 pass
 
         C().a_method(a=1, b=2)
         assert len(recwarn) == 0
-        C().a_method(1, b=2)
+        C().a_method(1, '2', c='3', d=4)
         assert len(recwarn) == 1
-        assert 'a_method' in str(recwarn[0].message)
+        assert (
+            "test_utils.TestDeprecatedArgs.test_method.<locals>.C.a_method("
+            "1, '2', c='3', d=4)" in str(recwarn[0].message)
+        )
 
     def test_function(self, recwarn):
         @deprecation.deprecated_args(allowed_positional=0, is_method=False)
-        def a_function(a=1, b=2):
+        def a_function(a=None, b=None, c=None, d=None):
             pass
 
         a_function(a=1, b=2)
         assert len(recwarn) == 0
-        a_function(1, b=2)
+        a_function(1, '2', c='3', d=4)
         assert len(recwarn) == 1
-        assert 'a_function' in str(recwarn[0].message)
+        assert (
+            "test_utils.TestDeprecatedArgs.test_function.<locals>.a_function("
+            "1, '2', c='3', d=4)" in str(recwarn[0].message)
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1322,8 +1322,8 @@ class TestDeprecatedArgs:
         C().a_method(1, '2', c='3', d=4)
         assert len(recwarn) == 1
         assert (
-            "test_utils.TestDeprecatedArgs.test_method.<locals>.C.a_method("
-            "1, '2', c='3', d=4)" in str(recwarn[0].message)
+            "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
+            "a_method(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
         )
 
     def test_function(self, recwarn):
@@ -1336,8 +1336,8 @@ class TestDeprecatedArgs:
         a_function(1, '2', c='3', d=4)
         assert len(recwarn) == 1
         assert (
-            "test_utils.TestDeprecatedArgs.test_function.<locals>.a_function("
-            "1, '2', c='3', d=4)" in str(recwarn[0].message)
+            "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
+            "a_function(1, '2', c='3', d=4)" in str(recwarn[0].message)  # noqa: Q000
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1314,51 +1314,25 @@ class TestDeprecatedArgs:
     def test_method(self, recwarn):
         class C:
             @deprecation.deprecated_args(allowed_positional=0)
-            def a_method(self, a=None, b=None, c=None, d=None):
+            def a_method(self, a=1, b=2):
                 pass
 
         C().a_method(a=1, b=2)
         assert len(recwarn) == 0
-        C().a_method(1, '2', c='3', d=4)
+        C().a_method(1, b=2)
         assert len(recwarn) == 1
-        # need to split over 3 asserts because python 3.5 does not ensure ordering
-        # of kwargs
-        assert (
-            "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
-            "a_method(1, '2', " in str(recwarn[0].message)  # noqa: Q000
-        )
-        assert "c='3'" in str(recwarn[0].message)  # noqa: Q000
-        assert "d=4" in str(recwarn[0].message)  # noqa: Q000
-        # Testing that with a single argument it doesn't print 'a_method(1,)'
-        C().a_method(1)
-        assert (
-            "test_utils.TestDeprecatedArgs.test_method.<locals>.C."  # noqa: Q000
-            "a_method(1)" in str(recwarn[1].message)  # noqa: Q000
-        )
+        assert 'a_method(...)' in str(recwarn[0].message)
 
     def test_function(self, recwarn):
         @deprecation.deprecated_args(allowed_positional=0, is_method=False)
-        def a_function(a=None, b=None, c=None, d=None):
+        def a_function(a=1, b=2):
             pass
 
         a_function(a=1, b=2)
         assert len(recwarn) == 0
-        a_function(1, '2', c='3', d=4)
+        a_function(1, b=2)
         assert len(recwarn) == 1
-        # need to split over 3 asserts because python 3.5 does not ensure ordering
-        # of kwargs
-        assert (
-            "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
-            "a_function(1, '2', " in str(recwarn[0].message)  # noqa: Q000
-        )
-        assert "c='3'" in str(recwarn[0].message)  # noqa: Q000
-        assert "d=4" in str(recwarn[0].message)  # noqa: Q000
-        # Testing that with a single argument it doesn't print 'a_function(1,)'
-        a_function(1)
-        assert (
-            "test_utils.TestDeprecatedArgs.test_function.<locals>."  # noqa: Q000
-            "a_function(1)" in str(recwarn[1].message)  # noqa: Q000
-        )
+        assert 'a_function(...)' in str(recwarn[0].message)
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1321,6 +1321,7 @@ class TestDeprecatedArgs:
         assert len(recwarn) == 0
         C().a_method(1, b=2)
         assert len(recwarn) == 1
+        assert 'a_method' in str(recwarn[0].message)
 
     def test_function(self, recwarn):
         @deprecation.deprecated_args(allowed_positional=0, is_method=False)
@@ -1331,6 +1332,7 @@ class TestDeprecatedArgs:
         assert len(recwarn) == 0
         a_function(1, b=2)
         assert len(recwarn) == 1
+        assert 'a_function' in str(recwarn[0].message)
 
 
 @pytest.mark.skipif(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1321,7 +1321,7 @@ class TestDeprecatedArgs:
         assert len(recwarn) == 0
         C().a_method(1, b=2)
         assert len(recwarn) == 1
-        assert 'a_method(...)' in str(recwarn[0].message)
+        assert 'C.a_method(...)' in str(recwarn[0].message)
 
     def test_function(self, recwarn):
         @deprecation.deprecated_args(allowed_positional=0, is_method=False)


### PR DESCRIPTION
# Summary of Changes

The deprecated args warning does not tell the function name which is then very hard to debug.

# Related Issues

Closes #2010 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [X] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [X] Added **tests** for changed code.
- [X] Prefixed code comments with GitHub nick and an appropriate prefix.
- [X] Coding style is consistent with the rest of the framework.
- [X] Updated **documentation** for changed code.
    - [X] Added docstrings for any new classes, functions, or modules.
    - [X] Updated docstrings for any modifications to existing code.
    - [X] Updated both WSGI and ASGI docs (where applicable).
    - [X] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [X] Updated all relevant supporting documentation files under `docs/`.
    - [X] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [X] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!