### PR TITLE
chore: the new `black` is the new black

### DIFF
--- a/falcon/app.py
+++ b/falcon/app.py
@@ -806,17 +806,13 @@ class App:
 
         # TODO(vytas): Remove this shimming in a future Falcon version.
         arg_names = tuple(misc.get_argnames(handler))
-        if (
-            arg_names[0:1]
-            in (
-                ('e',),
-                ('err',),
-                ('error',),
-                ('ex',),
-                ('exception',),
-            )
-            or arg_names[1:3] in (('req', 'resp'), ('request', 'response'))
-        ):
+        if arg_names[0:1] in (
+            ('e',),
+            ('err',),
+            ('error',),
+            ('ex',),
+            ('exception',),
+        ) or arg_names[1:3] in (('req', 'resp'), ('request', 'response')):
             handler = wrap_old_handler(handler)
 
         try:

--- a/falcon/asgi/stream.py
+++ b/falcon/asgi/stream.py
@@ -129,7 +129,7 @@ class BoundedStream:
             #   use sys.maxsize because 2**31 on 32-bit systems is not
             #   a large enough number (someone may have an API that accepts
             #   multi-GB payloads).
-            self._bytes_remaining = 2 ** 63
+            self._bytes_remaining = 2**63
         else:
             if len(first_chunk) > content_length:
                 self._buffer = first_chunk[:content_length]

--- a/falcon/bench/bench.py
+++ b/falcon/bench/bench.py
@@ -406,7 +406,7 @@ def main():
 
     for i, (name, sec_per_req) in enumerate(dataset):
         req_per_sec = round_to_int(Decimal(1) / sec_per_req)
-        us_per_req = sec_per_req * Decimal(10 ** 6)
+        us_per_req = sec_per_req * Decimal(10**6)
         factor = round_to_int(baseline / sec_per_req)
 
         print(

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -58,7 +58,7 @@ if 'samesite' not in _reserved_cookie_attrs:  # pragma: no cover
     _reserved_cookie_attrs['samesite'] = 'SameSite'  # type: ignore
 
 
-IS_64_BITS = sys.maxsize > 2 ** 32
+IS_64_BITS = sys.maxsize > 2**32
 
 from falcon.util.reader import BufferedReader as _PyBufferedReader  # NOQA
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -25,7 +25,7 @@ _WIN32 = sys.platform.startswith('win')
 
 _SERVER_HOST = '127.0.0.1'
 _SIZE_1_KB = 1024
-_SIZE_1_MB = _SIZE_1_KB ** 2
+_SIZE_1_MB = _SIZE_1_KB**2
 
 
 _REQUEST_TIMEOUT = 10

--- a/tests/asgi/test_boundedstream_asgi.py
+++ b/tests/asgi/test_boundedstream_asgi.py
@@ -15,7 +15,7 @@ from falcon import asgi, testing
         b'catsup',
         b'\xDE\xAD\xBE\xEF' * 512,
         testing.rand_string(1, 2048),
-        os.urandom(100 * 2 ** 20),
+        os.urandom(100 * 2**20),
     ],
     ids=['empty', 'null', 'null-ff', 'normal', 'long', 'random', 'random-large'],
 )

--- a/tests/test_buffered_reader.py
+++ b/tests/test_buffered_reader.py
@@ -172,11 +172,11 @@ def test_read_until_with_size(buffered_reader, size):
 def test_read_until(buffered_reader):
     stream = buffered_reader()
 
-    assert len(stream.read_until(b'--boundary1234567890--')) == 64 * 1024 ** 2
+    assert len(stream.read_until(b'--boundary1234567890--')) == 64 * 1024**2
     stream.read_until(b'123456789ABCDEF\n')
-    assert len(stream.read_until(b'--boundary1234567890--')) == 63 * 1024 ** 2
+    assert len(stream.read_until(b'--boundary1234567890--')) == 63 * 1024**2
     stream.read_until(b'123456789ABCDEF\n')
-    assert len(stream.read_until(b'--boundary1234567890--')) == 62 * 1024 ** 2
+    assert len(stream.read_until(b'--boundary1234567890--')) == 62 * 1024**2
 
 
 @pytest.mark.parametrize(
@@ -267,15 +267,15 @@ def test_pipe(shorter_stream):
 
 
 def test_pipe_until(buffered_reader):
-    stream = buffered_reader(2 ** 16)
+    stream = buffered_reader(2**16)
 
     output = io.BytesIO()
     stream.pipe_until(b'--boundary1234567890--', output)
-    assert len(output.getvalue()) == 64 * 1024 ** 2
+    assert len(output.getvalue()) == 64 * 1024**2
 
 
 def test_pipe_until_without_destination(buffered_reader):
-    stream = buffered_reader(2 ** 16)
+    stream = buffered_reader(2**16)
     stream.pipe_until(b'--boundary1234567890--')
     assert stream.peek(22) == b'--boundary1234567890--'
 
@@ -329,7 +329,7 @@ def test_readlines(shorter_stream):
         16,
         256,
         1024,
-        2 ** 16,
+        2**16,
     ],
 )
 def test_readlines_hint(buffered_reader, chunk_size):

--- a/tests/test_media_multipart.py
+++ b/tests/test_media_multipart.py
@@ -581,7 +581,7 @@ def test_too_many_body_parts(custom_client, max_body_part_count):
 
 @pytest.mark.skipif(not msgpack, reason='msgpack not installed')
 def test_random_form(client):
-    part_data = [os.urandom(random.randint(0, 2 ** 18)) for _ in range(64)]
+    part_data = [os.urandom(random.randint(0, 2**18)) for _ in range(64)]
     form_data = (
         b''.join(
             '--{}\r\n'.format(HASH_BOUNDARY).encode()
@@ -610,7 +610,7 @@ def test_random_form(client):
 
 
 def test_invalid_random_form(client):
-    length = random.randint(2 ** 20, 2 ** 21)
+    length = random.randint(2**20, 2**21)
     resp = client.simulate_post(
         '/submit',
         headers={

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1303,7 +1303,7 @@ class TestContextType:
     )
     def test_keys_and_values(self, context_type):
         ctx = context_type()
-        ctx.update((number, number ** 2) for number in range(1, 5))
+        ctx.update((number, number**2) for number in range(1, 5))
 
         assert set(ctx.keys()) == {1, 2, 3, 4}
         assert set(ctx.values()) == {1, 4, 9, 16}

--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -13,7 +13,7 @@ from falcon import testing
 _HERE = os.path.abspath(os.path.dirname(__file__))
 _SERVER_HOST = '127.0.0.1'
 _SIZE_1_KB = 1024
-_SIZE_1_MB = _SIZE_1_KB ** 2
+_SIZE_1_MB = _SIZE_1_KB**2
 
 _REQUEST_TIMEOUT = 10
 _STARTUP_TIMEOUT = 10

--- a/tox.ini
+++ b/tox.ini
@@ -241,7 +241,7 @@ basepython = python3.8
 commands = flake8 []
 
 [testenv:black]
-deps = black>=21.5b1
+deps = black>=22.1.0
 basepython = python3.8
 
 commands = black --check . []


### PR DESCRIPTION
It seems that `black` has finally turned stable, which also brings the usual assortment of formatting changes.