### PR TITLE
chore(tools): add a tool to aggregate contributors from GitHub commits

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -114,6 +114,7 @@ listed below by date of first contribution:
 * Vasilis Gerakaris (vgerak)
 * Eleni E (Contessina)
 * Betsy Behun (the-bets)
+* Mihai Todor (mihaitodor)
 * Abid Ahmad (abidahmadq)
 * KhiemTon (nix010)
 * dimjon (dimucciojonathan)

--- a/AUTHORS
+++ b/AUTHORS
@@ -106,6 +106,19 @@ listed below by date of first contribution:
 * Bibek Joshi (bibekjoshi54)
 * Shubhendra Singh Chauhan (withshubh)
 * Jonathan Mines (MinesJA)
+* Michał Górny (mgorny)
+* Dominika Florczykowska (dflss)
+* forana
+* Tim Burke (tipabu)
+* treharne
+* Vasilis Gerakaris (vgerak)
+* Eleni E (Contessina)
+* Betsy Behun (the-bets)
+* Abid Ahmad (abidahmadq)
+* KhiemTon (nix010)
+* dimjon (dimucciojonathan)
+* signalw
+* Laurent Chriqui (laurent-chriqui)
 
 (et al.)
 

--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -26,7 +26,7 @@ Changes to Supported Platforms
 Contributors to this Release
 ----------------------------
 
-Many thanks to contributors for this release:
+Many thanks to contributors for this release (so far):
 
 - `abidahmadq <https://github.com/abidahmadq>`__
 - `CaselIT <https://github.com/CaselIT>`__

--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -28,6 +28,19 @@ Contributors to this Release
 
 Many thanks to contributors for this release:
 
-- `CaselIT <https://github.com/CaselIT>`_
-- `kgriffs <https://github.com/kgriffs>`_
-- `vytas7 <https://github.com/vytas7>`_
+- `abidahmadq <https://github.com/abidahmadq>`__
+- `CaselIT <https://github.com/CaselIT>`__
+- `Contessina <https://github.com/Contessina>`__
+- `dflss <https://github.com/dflss>`__
+- `dimucciojonathan <https://github.com/dimucciojonathan>`__
+- `forana <https://github.com/forana>`__
+- `kgriffs <https://github.com/kgriffs>`__
+- `laurent-chriqui <https://github.com/laurent-chriqui>`__
+- `mgorny <https://github.com/mgorny>`__
+- `nix010 <https://github.com/nix010>`__
+- `signalw <https://github.com/signalw>`__
+- `the-bets <https://github.com/the-bets>`__
+- `tipabu <https://github.com/tipabu>`__
+- `treharne <https://github.com/treharne>`__
+- `vgerak <https://github.com/vgerak>`__
+- `vytas7 <https://github.com/vytas7>`__

--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -37,6 +37,7 @@ Many thanks to contributors for this release (so far):
 - `kgriffs <https://github.com/kgriffs>`__
 - `laurent-chriqui <https://github.com/laurent-chriqui>`__
 - `mgorny <https://github.com/mgorny>`__
+- `mihaitodor <https://github.com/mihaitodor>`__
 - `nix010 <https://github.com/nix010>`__
 - `signalw <https://github.com/signalw>`__
 - `the-bets <https://github.com/the-bets>`__

--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -28,4 +28,6 @@ Contributors to this Release
 
 Many thanks to contributors for this release:
 
-- *To be aggregated automatically...* (pending `#1533 <https://github.com/falconry/falcon/issues/1533>`__)
+- `CaselIT <https://github.com/CaselIT>`_
+- `kgriffs <https://github.com/kgriffs>`_
+- `vytas7 <https://github.com/vytas7>`_

--- a/tools/add_contributors.py
+++ b/tools/add_contributors.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+import argparse
+import pathlib
+import subprocess
+
+import pprint
+
+import requests
+import toml
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+
+FALCON_COMMITS_API = 'https://api.github.com/repos/falconry/falcon/commits'
+
+
+def get_count_since_last_tag():
+    output = subprocess.check_output(('git', 'describe', '--abbrev=40'))
+    output = output.decode()
+    if '-' not in output:
+        return 0
+    return int(output.split('-')[1])
+
+
+def query_contributors(count=None):
+    if count is None:
+        count = get_count_since_last_tag()
+
+    remaining = count
+    result = {}
+    page = 1
+    uri = f'{FALCON_COMMITS_API}?page={page}'
+
+    while remaining > 0:
+        commits = requests.get(uri).json()
+        for commit in commits:
+            remaining -= 1
+            print(remaining)
+
+            login = commit['author'].get('login')
+            pprint.pprint(
+                [commit['sha'], login, commit['commit']['author'].get('date')]
+            )
+            if remaining <= 0:
+                break
+            if not login or login in result:
+                continue
+            result[login] = commit['commit']['author']['name']
+
+        page += 1
+        uri = f'{FALCON_COMMITS_API}?page={page}'
+
+    return result
+
+
+def get_towncrier_filename():
+    with open(ROOT / 'pyproject.toml') as pyproject_toml:
+        project = toml.load(pyproject_toml)
+    return project['tool']['towncrier']['filename']
+
+
+def main():
+    towncrier_file = get_towncrier_filename()
+
+    description = (
+        'Find new contributors to Falcon since the last stable release. '
+        'Optionally append them to AUTHORS and the active Towncrier template.'
+    )
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        '-n', '--dry-run', action='store_true', help='dry run: do not write any files'
+    )
+    parser.add_argument(
+        '--no-authors', action='store_true', help='do not write AUTHORS'
+    )
+    parser.add_argument(
+        '--no-towncrier', action='store_true', help=f'do not write {towncrier_file}'
+    )
+    args = parser.parse_args()
+
+    contributors = query_contributors()
+    pprint.pprint(contributors)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/add_contributors.py
+++ b/tools/add_contributors.py
@@ -15,6 +15,9 @@ FALCON_REPOSITORY_API = 'https://api.github.com/repos/falconry/falcon'
 
 STABLE_RELEASE_TAG = r'^\d+\.\d+\.\d+(\.post\d+)?$'
 
+AUTHORS_SEPARATOR = '\n(et al.)\n\n'
+AUTHORS_LINE = r'^\* (?:(?:.+ \(([\w-]+)\)$)|([\w-]+$))'
+
 
 def get_latest_tag():
     uri = f'{FALCON_REPOSITORY_API}/tags'
@@ -38,31 +41,53 @@ def iter_commits(until=None):
 
 
 def aggregate_contributors(until=None):
-    authors = []
+    result = {}
     for commit in iter_commits(until):
         login = commit['author'].get('login')
         if not login:
             continue
-        authors.append((login, commit['commit']['author']['name']))
+        if login in result:
+            result.pop(login)
+        # NOTE(vytas): Exploit dictionary ordering in Python 3.7+.
+        result[login] = commit['commit']['author']['name']
 
-    seen = set()
-    result = {}
-    for login, name in reversed(authors):
-        if login not in seen:
-            seen.add(login)
-        result[login] = name
-
-    return result
+    return dict(item for item in reversed(result.items()))
 
 
 def _get_towncrier_filename():
-    with open(ROOT / 'pyproject.toml') as pyproject_toml:
+    with open(ROOT / 'pyproject.toml', 'r') as pyproject_toml:
         project = toml.load(pyproject_toml)
     return project['tool']['towncrier']['filename']
 
 
 def _update_authors(contributors):
-    pass
+    with open(ROOT / 'AUTHORS', 'r') as authors_file:
+        content = authors_file.read()
+
+    authors, separator, footer = content.partition(AUTHORS_SEPARATOR)
+    assert separator, 'AUTHORS file structure not understood, please inspect manually'
+
+    existing = set({FALCON_CREATOR})
+    for line in reversed(authors.splitlines()):
+        match = re.match(AUTHORS_LINE, line)
+        if not match:
+            break
+        login = match.group(1) or match.group(2)
+        existing.add(login.lower())
+
+    with open(ROOT / 'AUTHORS', 'w') as authors_file:
+        authors_file.write(authors)
+
+        for login, name in contributors.items():
+            if login.lower() in existing:
+                continue
+            if login == name:
+                authors_file.write(f'* {login}\n')
+            else:
+                authors_file.write(f'* {name} ({login})\n')
+
+        authors_file.write(separator)
+        authors_file.write(footer)
 
 
 def _update_towncrier_template(template, contributors):


### PR DESCRIPTION
Closes #1533

Actually running this tool should be done as part of the release process. I added a mention in #473.
We could probably add a check in CI for pre-release tags... but I left that as a future exercise for now.

Another limitation that we could hopefully live with for a while is that only the primary author with a GitHub login is considered, so commits made by multiple first-time contributors in a single PR might still need a manual review.