### PR TITLE
test(asgi): correctly read large bodies chunked server-side

### DIFF
--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -112,6 +112,25 @@ class TestASGIServer:
         assert resp.status_code == 200
         assert resp.text == body
 
+    def test_post_read_bounded_stream_large(self, server_base_url):
+        """Test that we can correctly read large bodies chunked server-side.
+
+        ASGI servers employ some type of flow control to stream large
+        request bodies to the app. This occurs regardless of whether
+        "chunked" Transfer-Encoding is employed by the client.
+        """
+
+        # NOTE(kgriffs): One would hope that flow control is effective enough
+        #   to at least prevent bursting over 1 MB.
+        size_mb = 5
+
+        body = os.urandom(_SIZE_1_MB * size_mb)
+        resp = requests.put(
+            server_base_url + 'bucket/drops', data=body, timeout=_REQUEST_TIMEOUT
+        )
+        assert resp.status_code == 200
+        assert resp.json().get('drops') > size_mb
+
     def test_post_read_bounded_stream_no_body(self, server_base_url):
         resp = requests.post(server_base_url + 'bucket', timeout=_REQUEST_TIMEOUT)
         assert not resp.text


### PR DESCRIPTION
Test that in the absence of chunked `Transfer-Encoding` Falcon correctly handles server-side chunking due to flow control (e.g. https://github.com/encode/uvicorn/blob/90acede056f75a337ef023c4ae335d0d6e33d142/uvicorn/protocols/http/flow_control.py#L13). 