### PR TITLE
chore(mailman): gate non-breaking releases on GNU Mailman 3

### DIFF
--- a/.github/workflows/test-mailman.yaml
+++ b/.github/workflows/test-mailman.yaml
@@ -1,0 +1,31 @@
+name: Run tests (GNU Mailman 3)
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run_tox:
+    name: tox -e (GNU Mailman 3)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Fetch Mailman Core
+        run: |
+          tools/testing/fetch_mailman.sh
+
+      - name: Run tox
+        uses: docker://maxking/mailman-ci-runner
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          tox -c .ecosystem/mailman/tox.ini -e py38_nocov

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -1,10 +1,9 @@
 name: Run tests (GNU Mailman 3)
 
 on:
+  # Trigger the workflow on master but also allow it to run manually.
+  workflow_dispatch:
   push:
-    branches:
-      - "*"
-  pull_request:
     branches:
       - master
 

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -1,15 +1,9 @@
 name: Run tests (GNU Mailman 3)
 
 on:
-  # # Trigger the workflow on master but also allow it to run manually.
-  # workflow_dispatch:
-  # push:
-  #    branches:
-  #      - master
+  # Trigger the workflow on master but also allow it to run manually.
+  workflow_dispatch:
   push:
-    branches:
-      - "*"
-  pull_request:
     branches:
       - master
 

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y rustc
-          sudo apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
+          sudo apt-get install -y openssh-server libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
 
       - name: Install Python dependencies
         run: |
@@ -45,5 +45,5 @@ jobs:
 
       - name: Run tox
         run: |
-          python -m pip install --upgrade pip tox
-          tox -c .ecosystem/mailman/tox.ini -e py38-nocov
+          cd .ecosystem/mailman
+          tox -e py38-nocov

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   run_tox:
-    name: tox -e (GNU Mailman 3)
-    runs-on: ubuntu-latest
+    name: tox -e py38_nocov
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout repo
@@ -19,14 +19,31 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Set up Python
+        uses: actions/setup-python@v2.1.4
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rustc
+          sudo apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip tox
+          python --version
+          pip --version
+          tox --version
+
       - name: Fetch Mailman Core
         run: |
           tools/testing/fetch_mailman.sh
 
       - name: Run tox
-        uses: docker://maxking/mailman-ci-runner
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        with:
-          args: |
-            /bin/bash -c "tox -c .ecosystem/mailman/tox.ini -e py38_nocov"
+        run: |
+          python -m pip install --upgrade pip tox
+          tox -c .ecosystem/mailman/tox.ini -e py38_nocov

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -29,8 +29,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo apt-get update
-          sudo apt-get install -y rustc
-          sudo apt-get install -y openssh-server libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
+          sudo apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
 
       - name: Install Python dependencies
         run: |
@@ -45,5 +44,4 @@ jobs:
 
       - name: Run tox
         run: |
-          cd .ecosystem/mailman
-          tox -e py38-nocov
+          tox -c .ecosystem/mailman/tox.ini -e falcon

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -24,10 +24,10 @@ jobs:
       - name: Run tox
         uses: docker://ghcr.io/maxking/mailman-ci-runner-falcon:master
         with:
+          # NOTE(vytas,maxking): The below hack to sed away ::1 is needed since
+          #   Mailman’s aiosmtpd isn’t able to bind to local IPv6 loopback
+          #   inside the container and raises exceptions upon teardown.
           args: |
-            # NOTE(vytas,maxking): The below hack to remove ::1 is needed since
-            #   Mailman’s aiosmtpd isn’t able to bind to local IPv6 loopback
-            #   inside the container and raises exceptions upon teardown.
             /bin/bash -c "
             tools/testing/fetch_mailman.sh &&
             sed '/::1/d' /etc/hosts > /tmp/hosts && cat /tmp/hosts > /etc/hosts &&

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run_tox:
-    name: tox -e py38_nocov
+    name: tox -e falcon
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -6,10 +6,7 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): remove the pull request clause before merging.
-  pull_request:
-    branches:
-      - master
+
 jobs:
   run_tox:
     name: tox -e falcon-nocov

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -1,9 +1,15 @@
 name: Run tests (GNU Mailman 3)
 
 on:
-  # Trigger the workflow on master but also allow it to run manually.
-  workflow_dispatch:
+  # # Trigger the workflow on master but also allow it to run manually.
+  # workflow_dispatch:
+  # push:
+  #    branches:
+  #      - master
   push:
+    branches:
+      - "*"
+  pull_request:
     branches:
       - master
 
@@ -18,29 +24,17 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Python
-        uses: actions/setup-python@v2.1.4
-        with:
-          python-version: 3.8
-
-      - name: Install dependencies
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libpq-dev libsqlite3-dev libmysqlclient-dev libreadline-dev libbz2-dev
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip tox
-          python --version
-          pip --version
-          tox --version
-
       - name: Fetch Mailman Core
         run: |
           tools/testing/fetch_mailman.sh
 
       - name: Run tox
-        run: |
-          tox -c .ecosystem/mailman/tox.ini -e falcon
+        uses: docker://maxking/mailman-ci-runner-falcon
+        with:
+          args: |
+            /bin/bash -c "
+            python -m pip install -U pip tox &&
+            python --version &&
+            pip --version &&
+            tox --version &&
+            tox -c .ecosystem/mailman/tox.ini -e falcon-nocov"

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   run_tox:
     name: tox -e falcon-nocov
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
@@ -24,15 +24,12 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Fetch Mailman Core
-        run: |
-          tools/testing/fetch_mailman.sh
-
       - name: Run tox
         uses: docker://ghcr.io/maxking/mailman-ci-runner-falcon:master
         with:
           args: |
             /bin/bash -c "
+            tools/testing/fetch_mailman.sh
             python3 --version &&
             tox --version &&
             tox -c .ecosystem/mailman/tox.ini -e falcon-nocov"

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   run_tox:
-    name: tox -e falcon
+    name: tox -e falcon-nocov
     runs-on: ubuntu-20.04
 
     steps:
@@ -33,8 +33,6 @@ jobs:
         with:
           args: |
             /bin/bash -c "
-            python -m pip install -U pip tox &&
-            python --version &&
-            pip --version &&
+            python3 --version &&
             tox --version &&
             tox -c .ecosystem/mailman/tox.ini -e falcon-nocov"

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -6,7 +6,10 @@ on:
   push:
     branches:
       - master
-
+  # TODO(vytas): remove the pull request clause before merging.
+  pull_request:
+    branches:
+      - master
 jobs:
   run_tox:
     name: tox -e falcon-nocov
@@ -22,8 +25,11 @@ jobs:
         uses: docker://ghcr.io/maxking/mailman-ci-runner-falcon:master
         with:
           args: |
+            # NOTE(vytas,maxking): The below hack to remove ::1 is needed since
+            #   Mailman’s aiosmtpd isn’t able to bind to local IPv6 loopback
+            #   inside the container and raises exceptions upon teardown.
             /bin/bash -c "
-            tools/testing/fetch_mailman.sh
+            tools/testing/fetch_mailman.sh &&
             sed '/::1/d' /etc/hosts > /tmp/hosts && cat /tmp/hosts > /etc/hosts &&
             python3 --version &&
             tox --version &&

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -30,6 +30,7 @@ jobs:
           args: |
             /bin/bash -c "
             tools/testing/fetch_mailman.sh
+            sed '/::1/d' /etc/hosts > /tmp/hosts && cat /tmp/hosts > /etc/hosts &&
             python3 --version &&
             tox --version &&
             tox -c .ecosystem/mailman/tox.ini -e falcon-nocov"

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -46,4 +46,4 @@ jobs:
       - name: Run tox
         run: |
           python -m pip install --upgrade pip tox
-          tox -c .ecosystem/mailman/tox.ini -e py38_nocov
+          tox -c .ecosystem/mailman/tox.ini -e py38-nocov

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -29,7 +29,7 @@ jobs:
           tools/testing/fetch_mailman.sh
 
       - name: Run tox
-        uses: docker://maxking/mailman-ci-runner-falcon
+        uses: docker://ghcr.io/maxking/mailman-ci-runner-falcon:master
         with:
           args: |
             /bin/bash -c "

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -27,5 +27,6 @@ jobs:
         uses: docker://maxking/mailman-ci-runner
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: |
-          tox -c .ecosystem/mailman/tox.ini -e py38_nocov
+        with:
+          args: |
+            /bin/bash -c "tox -c .ecosystem/mailman/tox.ini -e py38_nocov"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -107,10 +107,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libunwind-dev
 
-      # TODO(kgriffs): Revisit second half of 2021 to see if we still need to pin tox
-      #
-      #   See also: https://github.com/tox-dev/tox/issues/1777
-      #
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-MAILMAN_PATH=.ecosystem/mailman
+FALCON_ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )
+echo $FALCON_ROOT
+MAILMAN_PATH=$FALCON_ROOT/.ecosystem/mailman
 
 # TODO(vytas): Detect the latest version from git tags or PyPi JSON.
 # NOTE(vytas): One approach: `curl -Ls https://pypi.org/pypi/mailman/json | jq -r .info.version`
@@ -14,5 +16,15 @@ git clone https://gitlab.com/mailman/mailman.git/ $MAILMAN_PATH
 
 # TODO(vytas): Enable version checking when a stable release's tests pass as-is.
 #   At the time of writing, the latest version tag (3.3.5) has some failing tests.
-# cd $MAILMAN_PATH
+cd $MAILMAN_PATH
 # git checkout tags/$MAILMAN_VERSION
+
+# NOTE(vytas): Patch tox.ini to introduce a new Falcon environment.
+cat <<EOT >> tox.ini
+
+[testenv:falcon]
+commands =
+    pip uninstall -y falcon
+    pip install $FALCON_ROOT
+    python -m nose2 -v {posargs}
+EOT

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 FALCON_ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/../.." &> /dev/null && pwd )
-echo $FALCON_ROOT
 MAILMAN_PATH=$FALCON_ROOT/.ecosystem/mailman
 
 # TODO(vytas): Detect the latest version from git tags or PyPi JSON.

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -11,7 +11,7 @@ MAILMAN_PATH=$FALCON_ROOT/.ecosystem/mailman
 rm -rf $MAILMAN_PATH
 
 mkdir -p .ecosystem
-git clone https://gitlab.com/mailman/mailman.git/ $MAILMAN_PATH
+git clone --depth 100 https://gitlab.com/mailman/mailman.git/ $MAILMAN_PATH
 
 # TODO(vytas): Enable version checking when a stable release's tests pass as-is.
 #   At the time of writing, the latest version tag (3.3.5) has some failing tests.
@@ -21,9 +21,8 @@ cd $MAILMAN_PATH
 # NOTE(vytas): Patch tox.ini to introduce a new Falcon environment.
 cat <<EOT >> tox.ini
 
-[testenv:falcon]
-commands =
+[testenv:falcon-nocov]
+commands_pre =
     pip uninstall -y falcon
     pip install $FALCON_ROOT
-    python -m nose2 -v {posargs}
 EOT

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
 MAILMAN_PATH=.ecosystem/mailman
-# TODO(vytas): Detect from git tags or PyPi JSON.
+
+# TODO(vytas): Detect the latest version from git tags or PyPi JSON.
 # NOTE(vytas): One approach: `curl -Ls https://pypi.org/pypi/mailman/json | jq -r .info.version`
-MAILMAN_VERSION=3.3.5
+# MAILMAN_VERSION=3.3.5
 
 # Clean up in case we are running locally and not in CI
 rm -rf $MAILMAN_PATH
 
 mkdir -p .ecosystem
-git clone https://gitlab.com/mailman/mailman $MAILMAN_PATH
+git clone https://gitlab.com/mailman/mailman.git/ $MAILMAN_PATH
 
-cd $MAILMAN_PATH
-git checkout tags/$MAILMAN_VERSION
+# TODO(vytas): Enable version checking when a stable release's tests pass as-is.
+#   At the time of writing, the latest version tag (3.3.5) has some failing tests.
+# cd $MAILMAN_PATH
+# git checkout tags/$MAILMAN_VERSION

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+MAILMAN_PATH=.ecosystem/mailman
+# TODO(vytas): Detect from git tags or PyPi JSON.
+# NOTE(vytas): One approach: `curl -Ls https://pypi.org/pypi/mailman/json | jq -r .info.version`
+MAILMAN_VERSION=3.3.5
+
+# Clean up in case we are running locally and not in CI
+rm -rf $MAILMAN_PATH
+
+mkdir -p .ecosystem
+git clone https://gitlab.com/mailman/mailman $MAILMAN_PATH
+
+cd $MAILMAN_PATH
+git checkout tags/$MAILMAN_VERSION


### PR DESCRIPTION
This pull request adds a GNU Mailman 3 CI gate that is proposed to be run on every `master` merge. Upon every run, Mailman Core is cloned from GitLab, its `tox.ini` patched to add an additional `falcon` env where we simply uninstall Falcon and reinstall it from local source (effectively building a cythonized PEP 517 wheel).

~~A successful run is demoed here: https://github.com/falconry/falcon/runs/5279630719?check_suite_focus=true~~

The following concessions had to be made, because of the way the things are, my incompetence, or a combination thereof:
* ~~I couldn't use @maxking 's Docker image, because GitHub Actions seem to be very hostile to setting a non-root `USER`.~~
* I wished to run tests for a stable release of Mailman instead of the latest `master` commit. However, it seems that some tests inside the 3.3.5 tree are failing, so I abandoned this idea for the time being.

**Edit**: now using the Falcon flavour of @maxking's image. An example of the latest incarnation: https://github.com/falconry/falcon/runs/5351987534?check_suite_focus=true.

It is looking unlikely at this point that we'll be able to resurrect the Hug gate (Hug is still on Falcon 2.0), but I have left the scripts and definitions in question intact for now. (Because [HOPE](https://github.com/hugapi/HOPE) dies last as they say!)

Closes #259 
