### PR TITLE
test(test_post_read_bounded_stream_large): validate body digest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,14 +35,14 @@ $ pip install -U black
 $ black .
 ```
 
-You can check all this by running ``tox`` from within the Falcon project directory (requires your environment to be based on Python 3.8 or 3.10):
+You can check all this by running ``tox`` from within the Falcon project directory. Your environment must be based on CPython 3.8 or 3.10:
 
 ```bash
 $ pip install -U tox
 $ tox --recreate
 ```
 
-You may also use a CPython 3.9 environment, however beware that ``coverage`` will likely report a false positive on missing branches, and the total coverage might fall short of 100%. This is caused by bugs in the interpreter itself, and is unlikely to ever get fixed.
+You may also use a CPython 3.9 environment, although in that case ``coverage`` will likely report a false positive on missing branches, and the total coverage might fall short of 100%. These issues are caused by bugs in the interpreter itself, and are unlikely to ever get fixed.
 
 #### Reviews
 

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -108,11 +108,15 @@ class Bucket:
         resp.text = await req.stream.read()
 
     async def on_put_drops(self, req, resp):
+        # NOTE(kgriffs): Integrity check
+        sha1 = hashlib.sha1()
+
         drops = 0
         async for drop in req.stream:
             drops += 1
+            sha1.update(drop)
 
-        resp.media = {'drops': drops}
+        resp.media = {'drops': drops, 'sha1': sha1.hexdigest()}
 
 
 class Feed:

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -115,8 +115,8 @@ class TestASGIServer:
     def test_post_read_bounded_stream_large(self, server_base_url):
         """Test that we can correctly read large bodies chunked server-side.
 
-        ASGI servers employ some type of flow control to stream large
-        request bodies to the app. This occurs regardless of whether
+        ASGI servers typically employ some type of flow control to stream
+        large request bodies to the app. This occurs regardless of whether
         "chunked" Transfer-Encoding is employed by the client.
         """
 
@@ -130,6 +130,7 @@ class TestASGIServer:
         )
         assert resp.status_code == 200
         assert resp.json().get('drops') > size_mb
+        assert resp.json().get('sha1') == hashlib.sha1(body).hexdigest()
 
     def test_post_read_bounded_stream_no_body(self, server_base_url):
         resp = requests.post(server_base_url + 'bucket', timeout=_REQUEST_TIMEOUT)


### PR DESCRIPTION
# Summary of Changes

This patch adds a check to `test_post_read_bounded_stream_large()` to validate the digest of the body to ensure that the chunks are read completely with no overlap or repetition.
