### PR TITLE
docs(media): add an example for using a custom JSON encoder

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -916,7 +916,7 @@ types than JSON, either as part of the respective (de)serialization format, or
 via custom type extensions.
 
 .. seealso:: See :ref:`custom-media-json-encoder` for an example on how to
-          use a custom json encoder.
+    use a custom json encoder.
 
 
 Does Falcon set Content-Length or do I need to do that explicitly?

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -915,6 +915,10 @@ Furthermore, different Internet media types such as YAML,
 types than JSON, either as part of the respective (de)serialization format, or
 via custom type extensions.
 
+.. seealso:: See :class:`falcon.media.json.JSONHandler` for an exmaple on how to
+          use a custom json encoder.
+
+
 Does Falcon set Content-Length or do I need to do that explicitly?
 ------------------------------------------------------------------
 Falcon will try to do this for you, based on the value of

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -915,7 +915,7 @@ Furthermore, different Internet media types such as YAML,
 types than JSON, either as part of the respective (de)serialization format, or
 via custom type extensions.
 
-.. seealso:: See :class:`falcon.media.json.JSONHandler` for an exmaple on how to
+.. seealso:: See :ref:`custom-media-json-encoder` for an example on how to
           use a custom json encoder.
 
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -94,8 +94,8 @@ class JSONHandler(BaseHandler):
             ),
         )
 
-    You can also override the JSONEncoder used by using a custom Encoder by
-    updating the media handlers for ``application/json`` type::
+    You can also override the default JSONEncoder by using a custom Encoder and
+    updating the media handlers for ``application/json`` type to use that::
 
         import json
         from datetime import datetime

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -94,6 +94,10 @@ class JSONHandler(BaseHandler):
             ),
         )
 
+    .. _custom-media-json-encoder:
+
+    .. rubric:: Custom Json Encoder
+
     You can also override the default JSONEncoder by using a custom Encoder and
     updating the media handlers for ``application/json`` type to use that::
 

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -102,7 +102,7 @@ class JSONHandler(BaseHandler):
         from functools import partial
 
         import falcon
-        from falcon import meda
+        from falcon import media
 
         class DatetimeEncoder(json.JSONEncoder):
             \"\"\"Json Encoder that supports datetime objects.\"\"\"

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -26,6 +26,8 @@ class JSONHandler(BaseHandler):
         library's JSON implementation, since it will be faster in most cases
         as compared to a third-party library.
 
+    .. rubric:: Custom JSON library
+
     You can replace the default JSON handler by using a custom JSON library
     (see also: :ref:`custom_media_handlers`). Overriding the default JSON
     implementation is simply a matter of specifying the desired ``dumps`` and
@@ -47,6 +49,8 @@ class JSONHandler(BaseHandler):
         app = falcon.App()
         app.req_options.media_handlers.update(extra_handlers)
         app.resp_options.media_handlers.update(extra_handlers)
+
+    .. rubric:: Custom serialization parameters
 
     Even if you decide to stick with the stdlib's :any:`json.dumps` and
     :any:`json.loads`, you can wrap them using :any:`functools.partial` to
@@ -96,10 +100,11 @@ class JSONHandler(BaseHandler):
 
     .. _custom-media-json-encoder:
 
-    .. rubric:: Custom Json Encoder
+    .. rubric:: Custom JSON encoder
 
-    You can also override the default JSONEncoder by using a custom Encoder and
-    updating the media handlers for ``application/json`` type to use that::
+    You can also override the default :class:`~json.JSONEncoder` by using a
+    custom Encoder and updating the media handlers for ``application/json``
+    type to use that::
 
         import json
         from datetime import datetime

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -94,6 +94,37 @@ class JSONHandler(BaseHandler):
             ),
         )
 
+    You can also override the JSONEncoder used by using a custom Encoder by
+    updating the media handlers for ``application/json`` type::
+
+        import json
+        from datetime import datetime
+        from functools import partial
+
+        import falcon
+        from falcon import meda
+
+        class DatetimeEncoder(json.JSONEncoder):
+            \"\"\"Json Encoder that supports datetime objects.\"\"\"
+
+            def default(self, obj):
+                if isinstance(obj, datetime):
+                    return obj.isoformat()
+                super().default(obj)
+
+        app = falcon.App()
+
+        json_handler = media.JSONHandler(
+            dumps=partial(json.dumps, cls=DatetimeEncoder),
+        )
+        extra_handlers = {
+            'application/json': json_handler,
+        }
+
+        app.req_options.media_handlers.update(extra_handlers)
+        app.resp_options.media_handlers.update(extra_handlers)
+
+
     Keyword Arguments:
         dumps (func): Function to use when serializing JSON responses.
         loads (func): Function to use when deserializing JSON requests.

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -110,7 +110,7 @@ class JSONHandler(BaseHandler):
             def default(self, obj):
                 if isinstance(obj, datetime):
                     return obj.isoformat()
-                super().default(obj)
+                return super().default(obj)
 
         app = falcon.App()
 


### PR DESCRIPTION
# Summary of Changes

Adds an example on how to override the default json encoder used by Falcon.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
