### PR TITLE
chore(wheel): attempt to fix some issues found in 3.1.0rc1 build

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -124,7 +124,8 @@ jobs:
         env:
           py_tag: ${{ matrix.python-version }}
         run: |
-          version="${py_tag: 2:1}.${py_tag: 3:1}"
+          platform=${py_tag%%-*}
+          version=${platform:2:1}.${platform:3:3}
           echo $version
           echo "::set-output name=python-version::$version"
 

--- a/requirements/tests
+++ b/requirements/tests
@@ -20,8 +20,8 @@ msgpack
 mujson
 ujson
 
-# it's slow to compile on emulated architectures
-python-rapidjson; platform_machine != 's390x' and platform_machine != 'aarch64'
+# it's slow to compile on emulated architectures; wheels missing for some EoL interpreters
+python-rapidjson; python_version >= '3.7' and platform_machine != 's390x' and platform_machine != 'aarch64'
 
-# python_version >= '3.6': arm64 wheels are missing for py35
-orjson; python_version >= '3.6' and platform_python_implementation != 'PyPy' and platform_machine != 's390x'
+# wheels are missing some EoL interpreters and non-x86 platforms; build would fail unless rust is available
+orjson; python_version >= '3.7' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'


### PR DESCRIPTION
Trying to fix the following issues highlighted by the [failed 3.1.0rc1 build](https://github.com/falconry/falcon/runs/5541468531?check_suite_focus=true):
* `rapidjson` doesn't build on some EoL interpreters
* `orjson` doesn't ship ARM wheels, and rust isn't installed
* Bash script in Actions doesn't properly extract `3.10` from `cp310-cp310`
