### PR TITLE
fix(tests): spawn servers via sys.executable

### DIFF
--- a/docs/_newsfragments/2047.bugfix.rst
+++ b/docs/_newsfragments/2047.bugfix.rst
@@ -1,0 +1,3 @@
+The web servers used for tests are now run through `sys.executable`
+in order to ensure that they respect the virtualenv in which tests
+are being run.

--- a/docs/_newsfragments/2047.bugfix.rst
+++ b/docs/_newsfragments/2047.bugfix.rst
@@ -1,3 +1,2 @@
-The web servers used for tests are now run through `sys.executable`
-in order to ensure that they respect the virtualenv in which tests
-are being run.
+The web servers used for tests are now run through :any:`sys.executable` in
+order to ensure that they respect the virtualenv in which tests are being run.

--- a/examples/look/tests/conftest.py
+++ b/examples/look/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import time
 
 import requests
@@ -14,7 +15,14 @@ def pytest_sessionstart(session):
     global gunicorn
 
     gunicorn = subprocess.Popen(
-        ('gunicorn', '--pythonpath', LOOK_PATH, 'look.app:get_app()'),
+        (
+            sys.executable,
+            '-m',
+            'gunicorn',
+            '--pythonpath',
+            LOOK_PATH,
+            'look.app:get_app()',
+        ),
         env=dict(os.environ, LOOK_STORAGE_PATH='/tmp'),
     )
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -500,7 +500,13 @@ uvicorn.run('_asgi_test_app:application', host='{host}', port={port})
     )
 
     return subprocess.Popen(
-        ('uvicorn',) + loop_options + options,
+        (
+            sys.executable,
+            '-m',
+            'uvicorn',
+        )
+        + loop_options
+        + options,
         cwd=_MODULE_DIR,
     )
 
@@ -508,6 +514,8 @@ uvicorn.run('_asgi_test_app:application', host='{host}', port={port})
 def _daphne_factory(host, port):
     return subprocess.Popen(
         (
+            sys.executable,
+            '-m',
             'daphne',
             '--bind',
             host,
@@ -543,6 +551,8 @@ run(config)
         )
     return subprocess.Popen(
         (
+            sys.executable,
+            '-m',
             'hypercorn',
             '--bind',
             f'{host}:{port}',

--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -28,6 +28,8 @@ def _gunicorn_args(host, port, extra_opts=()):
         pytest.skip('gunicorn not installed')
 
     args = (
+        sys.executable,
+        '-m',
         'gunicorn',
         '--access-logfile',
         '-',
@@ -72,6 +74,8 @@ def _uvicorn_args(host, port):
         pytest.skip('uvicorn not installed')
 
     return (
+        sys.executable,
+        '-m',
         'uvicorn',
         '--host',
         host,
@@ -102,7 +106,9 @@ def _waitress_args(host, port):
         pytest.skip('waitress not installed')
 
     return (
-        'waitress-serve',
+        sys.executable,
+        '-m',
+        'waitress',
         '--listen',
         '{}:{}'.format(host, port),
         '_wsgi_test_app:app',


### PR DESCRIPTION
# Summary of Changes

Spawn the servers (gunicorn, uvicorn, etc.) during tests through
sys.executable rather than directly, in order to ensure that the test
server is run using the same Python executable as the test suite.
Otherwise, the test servers are started using the Python executable
specified in their shebang and can therefore escape the virtualenv they
are being run in.

This is particularly problem for tests being run from Gentoo ebuilds.
We create a --system-site-packages venv to install falcon in, in order
to test whether it works correctly against the dependencies installed
on the system prior to installing it.  However, the installed packages
such as gunicorn specify /usr/bin/python* shebangs that override
the venv and therefore make these servers unable to find venv-installed
falcon.  Running them via sys.executable ensures that they are started
through Python installed in the venv.

# Related Issues

n/a

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)