### PR TITLE
feat(middleware): allow dynamic validation of CORS origins

### DIFF
--- a/falcon/middleware.py
+++ b/falcon/middleware.py
@@ -1,3 +1,4 @@
+from typing import Callable
 from typing import Iterable
 from typing import Optional
 from typing import Union
@@ -5,6 +6,8 @@ from typing import Union
 from .request import Request
 from .response import Response
 
+
+OriginFilter = Callable[[str], bool]
 
 class CORSMiddleware(object):
     """CORS Middleware.
@@ -19,7 +22,7 @@ class CORSMiddleware(object):
 
     Keyword Arguments:
         allow_origins (Union[str, Iterable[str]]): List of origins to allow (case
-            sensitive). The string ``'*'`` acts as a wildcard, matching every origin.
+            sensitive) or callable. The string ``'*'`` acts as a wildcard, matching every origin.
             (default ``'*'``).
         expose_headers (Optional[Union[str, Iterable[str]]]): List of additional
             response headers to expose via the ``Access-Control-Expose-Headers``
@@ -30,8 +33,8 @@ class CORSMiddleware(object):
 
             See also:
             https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
-        allow_credentials (Optional[Union[str, Iterable[str]]]): List of origins
-            (case sensitive) for which to allow credentials via the
+        allow_credentials (Optional[Union[str, Iterable[str], OriginFilter]]): List of origins
+            (case sensitive) or callable for which to allow credentials via the
             ``Access-Control-Allow-Credentials`` header.
             The string ``'*'`` acts as a wildcard, matching every allowed origin,
             while ``None`` disallows all origins. This parameter takes effect only
@@ -42,38 +45,53 @@ class CORSMiddleware(object):
 
     def __init__(
         self,
-        allow_origins: Union[str, Iterable[str]] = '*',
+        allow_origins: Union[str, Iterable[str], OriginFilter] = '*',
         expose_headers: Optional[Union[str, Iterable[str]]] = None,
-        allow_credentials: Optional[Union[str, Iterable[str]]] = None,
+        allow_credentials: Optional[Union[str, Iterable[str], OriginFilter]] = None,
     ):
-        if allow_origins == '*':
-            self.allow_origins = allow_origins
+        self.allow_origins_wildcard = False
+        if isinstance(allow_origins, Callable):
+            self.allow_origins_filter = allow_origins
         else:
-            if isinstance(allow_origins, str):
-                allow_origins = [allow_origins]
-            self.allow_origins = frozenset(allow_origins)
-            if '*' in self.allow_origins:
-                raise ValueError(
-                    'The wildcard string "*" may only be passed to allow_origins as a '
-                    'string literal, not inside an iterable.'
-                )
+            if allow_origins == '*':
+                self.allow_origins_wildcard = True
+            else:
+                if isinstance(allow_origins, str):
+                    allow_origins = [allow_origins]
+                allow_origins = frozenset(allow_origins)
+                if '*' in allow_origins:
+                    raise ValueError(
+                        'The wildcard string "*" may only be passed to allow_origins as a '
+                        'string literal, not inside an iterable.'
+                    )
+            self.allow_origins_filter = self.create_origin_filter(allow_origins)
 
         if expose_headers is not None and not isinstance(expose_headers, str):
             expose_headers = ', '.join(expose_headers)
         self.expose_headers = expose_headers
 
-        if allow_credentials is None:
-            allow_credentials = frozenset()
-        elif allow_credentials != '*':
-            if isinstance(allow_credentials, str):
-                allow_credentials = [allow_credentials]
-            allow_credentials = frozenset(allow_credentials)
-            if '*' in allow_credentials:
-                raise ValueError(
-                    'The wildcard string "*" may only be passed to allow_credentials '
-                    'as a string literal, not inside an iterable.'
-                )
-        self.allow_credentials = allow_credentials
+        if isinstance(allow_credentials, Callable):
+            self.allow_credentials_filter = allow_credentials
+        else:
+            if allow_credentials is None:
+                allow_credentials = frozenset()
+            elif allow_credentials != '*':
+                if isinstance(allow_credentials, str):
+                    allow_credentials = [allow_credentials]
+                allow_credentials = frozenset(allow_credentials)
+                if '*' in allow_credentials:
+                    raise ValueError(
+                        'The wildcard string "*" may only be passed to allow_credentials '
+                        'as a string literal, not inside an iterable.'
+                    )
+            self.allow_credentials_filter = self.create_origin_filter(allow_credentials)
+
+    def create_origin_filter(self, allow_list):
+        def filter_func(origin):
+            if allow_list == '*' or origin in allow_list:
+                return True
+            return False
+        return filter_func
 
     def process_response(self, req: Request, resp: Response, resource, req_succeeded):
         """Implement the CORS policy for all routes.
@@ -90,12 +108,12 @@ class CORSMiddleware(object):
         if origin is None:
             return
 
-        if self.allow_origins != '*' and origin not in self.allow_origins:
+        if not self.allow_origins_filter(origin):
             return
 
         if resp.get_header('Access-Control-Allow-Origin') is None:
-            set_origin = '*' if self.allow_origins == '*' else origin
-            if self.allow_credentials == '*' or origin in self.allow_credentials:
+            set_origin = '*' if self.allow_origins_wildcard else origin
+            if self.allow_credentials_filter(origin):
                 set_origin = origin
                 resp.set_header('Access-Control-Allow-Credentials', 'true')
             resp.set_header('Access-Control-Allow-Origin', set_origin)


### PR DESCRIPTION
* feat(middleware): support callable filter for CORSMiddleware

* tests(cors_middleware): add tests for dynamic origins

# Summary of Changes

Allow passing a function to the CORSMiddleware for origin validation. This allows arbitrary validation like applying regexes etc.

# Related Issues

I opened an issue regarding this feature request: #2050

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [X ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [X ] Added **tests** for changed code.
- [X ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [X ] Coding style is consistent with the rest of the framework.
- [X ] Updated **documentation** for changed code.
    - [X ] Added docstrings for any new classes, functions, or modules.
    - [X ] Updated docstrings for any modifications to existing code.
    - [X ] Updated both WSGI and ASGI docs (where applicable).
    - [X ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [X ] Updated all relevant supporting documentation files under `docs/`.
    - [X ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [X ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [X ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/index.html) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
