### PR TITLE
chore: drop Python 3.5 & 3.6 support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ parallel = True
 [report]
 show_missing = True
 exclude_lines =
+    if TYPE_CHECKING:
     pragma: nocover
     pragma: no cover
     pragma: no py39,py310 cover

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -101,7 +101,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U coverage setuptools tox wheel
+          pip install -U coverage fixtures setuptools tox wheel
           python --version
           pip --version
           tox --version

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,15 +51,6 @@ jobs:
           - python-version: pypy3
             os: ubuntu-20.04
             toxenv: pypy3
-          - python-version: 3.5
-            os: ubuntu-20.04
-            toxenv: py35
-          - python-version: 3.6
-            os: ubuntu-20.04
-            toxenv: py36
-          - python-version: 3.6
-            os: ubuntu-20.04
-            toxenv: py36_cython
           - python-version: 3.7
             os: ubuntu-20.04
             toxenv: py37
@@ -120,14 +111,14 @@ jobs:
         run: tox -e ${{ matrix.toxenv }}
 
       - name: Combine coverage
-        if: ${{ matrix.toxenv == 'py35' || matrix.toxenv == 'py38' || matrix.toxenv == 'py38_sans_msgpack' }}
+        if: ${{ matrix.toxenv == 'py38' || matrix.toxenv == 'py38_sans_msgpack' }}
         run: |
           coverage --version
           coverage combine
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
-        if: ${{ matrix.toxenv == 'py35' || matrix.toxenv == 'py38' || matrix.toxenv == 'py38_sans_msgpack' }}
+        if: ${{ matrix.toxenv == 'py38' || matrix.toxenv == 'py38_sans_msgpack' }}
         with:
           env_vars: PYTHON
           fail_ci_if_error: true

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ clean design that embraces HTTP and the REST architectural style.
 
 Falcon apps work with any `WSGI <https://www.python.org/dev/peps/pep-3333/>`_
 or `ASGI <https://asgi.readthedocs.io/en/latest/>`_ server, and run like a
-champ under CPython 3.5+ and PyPy 3.5+ (3.6+ required for ASGI).
+champ under CPython 3.7+ and PyPy 3.7+.
 
 Quick Links
 -----------
@@ -79,7 +79,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic HTTP error responses
 - Straightforward exception handling
 - Snappy testing with WSGI/ASGI helpers and mocks
-- CPython 3.5+ and PyPy 3.5+ support
+- CPython 3.7+ and PyPy 3.7+ support
 
 .. Patron list starts here. For Python package, we substitute this section with:
    Support Falcon Development
@@ -210,7 +210,7 @@ PyPy
 ^^^^
 
 `PyPy <http://pypy.org/>`__ is the fastest way to run your Falcon app.
-PyPy3.5+ is supported as of PyPy v5.10.
+PyPy3.7+ is supported as of PyPy v7.3.4+.
 
 .. code:: bash
 
@@ -226,7 +226,7 @@ CPython
 ^^^^^^^
 
 Falcon also fully supports
-`CPython <https://www.python.org/downloads/>`__ 3.5+.
+`CPython <https://www.python.org/downloads/>`__ 3.7+.
 
 The latest stable version of Falcon can be installed directly from PyPI:
 

--- a/docs/api/multipart.rst
+++ b/docs/api/multipart.rst
@@ -145,5 +145,5 @@ Parsing Options
 Parsing Errors
 --------------
 
-.. autoclass:: falcon.media.multipart.MultipartParseError
+.. autoclass:: falcon.MultipartParseError
     :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,7 +90,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic :ref:`HTTP error <errors>` responses
 - Straightforward exception handling
 - Snappy :ref:`testing <testing>` with WSGI/ASGI helpers and mocks
-- CPython 3.5+ and PyPy 3.5+ support
+- CPython 3.7+ and PyPy 3.7+ support
 
 Who's Using Falcon?
 -------------------

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -7,7 +7,7 @@ PyPy
 ----
 
 `PyPy <http://pypy.org/>`__ is the fastest way to run your Falcon app.
-PyPy3.5+ is supported as of PyPy v5.10.
+PyPy3.7+ is supported as of PyPy v7.3.4.
 
 .. code:: bash
 
@@ -23,7 +23,7 @@ CPython
 -------
 
 Falcon fully supports
-`CPython <https://www.python.org/downloads/>`__ 3.5+.
+`CPython <https://www.python.org/downloads/>`__ 3.7+.
 
 The latest stable version of Falcon can be installed directly from PyPI:
 

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -15,7 +15,7 @@ architectural style, and tries to do as little as possible while
 remaining highly effective.
 
 Falcon apps work with any WSGI server, and run like a champ under
-CPython 3.5+ and PyPy 3.5+.
+CPython 3.7+ and PyPy 3.7+.
 
 Features
 --------
@@ -35,7 +35,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic :ref:`HTTP error <errors>` responses
 - Straightforward exception handling
 - Snappy :ref:`testing <testing>` with WSGI/ASGI helpers and mocks
-- CPython 3.5+ and PyPy 3.5+ support
+- CPython 3.7+ and PyPy 3.7+ support
 
 How is Falcon different?
 ------------------------

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -32,7 +32,7 @@ WSGI tutorial::
       └── app.py
 
 We'll create a *virtualenv* using the ``venv`` module from the standard library
-(Falcon requires Python 3.6+ for ASGI)::
+(Falcon requires Python 3.7+)::
 
   $ mkdir asgilook
   $ python3 -m venv asgilook/.venv

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -193,8 +193,7 @@ class App:
     _STATIC_ROUTE_TYPE = routing.StaticRoute
 
     # NOTE(kgriffs): This makes it easier to tell what we are dealing with
-    #   without having to import falcon.asgi to get at the falcon.asgi.App
-    #   type (which we may not be able to do under Python 3.5).
+    #   without having to import falcon.asgi.
     _ASGI = False
 
     # NOTE(kgriffs): We do it like this rather than just implementing the

--- a/falcon/asgi/__init__.py
+++ b/falcon/asgi/__init__.py
@@ -22,9 +22,8 @@ the framework's ASGI-related classes, functions, and variables::
     app = falcon.asgi.API()
 
 Some ASGI-related methods and classes are found in other modules
-(most notably falcon.testing) when (A) they are compatible with Python 3.5,
-and (B) their purpose is particularly cohesive with that of the module in
-question.
+(most notably falcon.testing) when their purpose is particularly cohesive with
+that of the module in question.
 """
 
 from .app import App

--- a/falcon/asgi/__init__.py
+++ b/falcon/asgi/__init__.py
@@ -27,11 +27,6 @@ and (B) their purpose is particularly cohesive with that of the module in
 question.
 """
 
-from falcon.constants import ASGI_SUPPORTED as _asgi_supported
-
-if not _asgi_supported:
-    raise ImportError('falcon.asgi requires Python 3.6+')
-
 from .app import App
 from .request import Request
 from .response import Response

--- a/falcon/asgi/_asgi_helpers.py
+++ b/falcon/asgi/_asgi_helpers.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import inspect
 
 from falcon.errors import UnsupportedError, UnsupportedScopeError
-from falcon.util.misc import _lru_cache_safe
 
 
-@_lru_cache_safe(maxsize=16)
+@functools.lru_cache(maxsize=16)
 def _validate_asgi_scope(scope_type, spec_version, http_version):
     if scope_type == 'http':
         spec_version = spec_version or '2.0'

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -52,7 +52,7 @@ from .ws import WebSocketOptions
 __all__ = ['App']
 
 
-# TODO(vytas): Clean up these foul workarounds when we drop Python 3.5 support.
+# TODO(vytas): Clean up these foul workarounds before the 4.0 release.
 MultipartFormHandler._ASGI_MULTIPART_FORM = MultipartForm  # type: ignore
 
 _EVT_RESP_EOF = {'type': EventType.HTTP_RESPONSE_BODY}
@@ -255,8 +255,7 @@ class App(falcon.app.App):
     _STATIC_ROUTE_TYPE = falcon.routing.StaticRouteAsync
 
     # NOTE(kgriffs): This makes it easier to tell what we are dealing with
-    #   without having to import falcon.asgi to get at the falcon.asgi.App
-    #   type (which we may not be able to do under Python 3.5).
+    #   without having to import falcon.asgi.
     _ASGI = True
 
     _default_responder_bad_request = falcon.responders.bad_request_async

--- a/falcon/asgi/multipart.py
+++ b/falcon/asgi/multipart.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 by Vytautas Liuolia.
+# Copyright 2019-2022 by Vytautas Liuolia.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -14,7 +14,6 @@
 
 """ASGI Response class."""
 
-from asyncio.coroutines import CoroWrapper  # type: ignore
 from inspect import iscoroutine
 from inspect import iscoroutinefunction
 
@@ -320,10 +319,8 @@ class Response(response.Response):
                 invoked without arguments.
         """
 
-        # NOTE(kgriffs): We also have to do the CoroWrapper check because
-        #   iscoroutine is less reliable under Python 3.6.
         if not iscoroutinefunction(callback):
-            if iscoroutine(callback) or isinstance(callback, CoroWrapper):
+            if iscoroutine(callback):
                 raise TypeError(
                     'The callback object appears to '
                     'be a coroutine, rather than a coroutine function. Please '

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -9,8 +9,21 @@ PYPY = sys.implementation.name == 'pypy'
 PYTHON_VERSION = tuple(sys.version_info[:3])
 """Python version information triplet: (major, minor, micro)."""
 
-ASGI_SUPPORTED = True
-"""Evaluates to ``True`` when ASGI is supported for the current Python version."""
+FALCON_SUPPORTED = PYTHON_VERSION >= (3, 7, 0)
+"""Whether this version of Falcon supports the current Python version."""
+
+if not FALCON_SUPPORTED:  # pragma: nocover
+    raise ImportError(
+        'Falcon requires Python 3.7+. '
+        '(Recent Pip should automatically pick a suitable Falcon version.)'
+    )
+
+ASGI_SUPPORTED = FALCON_SUPPORTED
+"""Evaluates to ``True`` when ASGI is supported for the current Python version.
+
+This constant is no longer referenced by the framework itself, and left for
+compatibility with Falcon 3.x.
+"""
 
 # RFC 7231, 5789 methods
 HTTP_METHODS = [

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -8,18 +8,8 @@ PYPY = sys.implementation.name == 'pypy'
 
 PYTHON_VERSION = tuple(sys.version_info[:3])
 """Python version information triplet: (major, minor, micro)."""
-# If FALCON_TESTING_MOCK_PY35 is defined in the env, pretend that we are
-# on 3.5.0. Only intended for testing of the framework itself.
-_is_py35 = PYTHON_VERSION[:2] == (3, 5)
-_mock_py35 = os.environ.get('FALCON_TESTING_MOCK_PY35')
 
-# TODO(vytas): Remove these hacks in 4.0 once we have dropped 3.5/3.6 support.
-# NOTE(vytas): Do not alter the microversion if already on 3.5
-#   (read: a hack to hit coverage on 3.5 as well).
-if _mock_py35 or _is_py35:
-    PYTHON_VERSION = (3, 5, PYTHON_VERSION[-1] if _is_py35 else 0)
-
-ASGI_SUPPORTED = PYTHON_VERSION >= (3, 6)
+ASGI_SUPPORTED = True
 """Evaluates to ``True`` when ASGI is supported for the current Python version."""
 
 # RFC 7231, 5789 methods

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -84,6 +84,7 @@ __all__ = (
     'MediaMalformedError',
     'MediaNotFoundError',
     'MediaValidationError',
+    'MultipartParseError',
     'OperationNotAllowed',
     'PayloadTypeError',
     'UnsupportedError',
@@ -2508,6 +2509,36 @@ class MediaValidationError(HTTPBadRequest):
             title=title,
             description=description,
             headers=headers,
+            **kwargs,
+        )
+
+
+class MultipartParseError(MediaMalformedError):
+    """Represents a multipart form parsing error.
+
+    This error may refer to a malformed or truncated form, usage of deprecated
+    or unsupported features, or form parameters exceeding limits configured in
+    :class:`~.media.multipart.MultipartParseOptions`.
+
+    :class:`MultipartParseError` instances raised in this module always include
+    a short human-readable description of the error.
+
+    The cause of this exception, if any, is stored in the ``__cause__`` attribute
+    using the "raise ... from" form when raising.
+
+    Args:
+        source_error (Exception): The source exception that was the cause of this one.
+    """
+
+    # NOTE(caselit): remove the description @property in MediaMalformedError
+    description = None
+
+    @deprecated_args(allowed_positional=0)
+    def __init__(self, description=None, **kwargs):
+        HTTPBadRequest.__init__(
+            self,
+            title='Malformed multipart/form-data request media',
+            description=description,
             **kwargs,
         )
 

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -166,7 +166,7 @@ if PYPY:
     #   However, if the shortcut does not succeed, invoking best_match()
     #   is relatively expensive, so it does make sense to use an LRU
     #   in that case.
-    _best_match = functools._lru_cache(maxsize=64)(_best_match)  # pragma: nocover
+    _best_match = functools.lru_cache(maxsize=64)(_best_match)  # pragma: nocover
 
 
 # NOTE(vytas): An ugly way to work around circular imports.

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -1,4 +1,5 @@
 from collections import UserDict
+import functools
 
 from falcon import errors
 from falcon.constants import MEDIA_JSON
@@ -165,7 +166,7 @@ if PYPY:
     #   However, if the shortcut does not succeed, invoking best_match()
     #   is relatively expensive, so it does make sense to use an LRU
     #   in that case.
-    _best_match = misc._lru_cache_safe(maxsize=64)(_best_match)  # pragma: nocover
+    _best_match = functools._lru_cache(maxsize=64)(_best_match)  # pragma: nocover
 
 
 # NOTE(vytas): An ugly way to work around circular imports.

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -523,9 +523,6 @@ class MultipartFormHandler(BaseHandler):
     def _deserialize_form(
         self, stream, content_type, content_length, form_cls=MultipartForm
     ):
-        if not form_cls:
-            raise NotImplementedError
-
         _, options = cgi.parse_header(content_type)
         try:
             boundary = options['boundary']

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 by Vytautas Liuolia.
+# Copyright 2019-2022 by Vytautas Liuolia.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ import re
 from urllib.parse import unquote_to_bytes
 
 from falcon import errors
+from falcon.errors import MultipartParseError
 from falcon.media.base import BaseHandler
 from falcon.stream import BoundedStream
 from falcon.util import BufferedReader
 from falcon.util import misc
-from falcon.util.deprecation import deprecated_args
 
 
 # TODO(vytas):
@@ -43,36 +43,6 @@ _FILENAME_STAR_RFC5987 = re.compile(r"([\w-]+)'[\w]*'(.+)")
 
 _CRLF = b'\r\n'
 _CRLF_CRLF = _CRLF + _CRLF
-
-
-class MultipartParseError(errors.MediaMalformedError):
-    """Represents a multipart form parsing error.
-
-    This error may refer to a malformed or truncated form, usage of deprecated
-    or unsupported features, or form parameters exceeding limits configured in
-    :class:`MultipartParseOptions`.
-
-    :class:`MultipartParseError` instances raised in this module always include
-    a short human-readable description of the error.
-
-    The cause of this exception, if any, is stored in the ``__cause__`` attribute
-    using the "raise ... from" form when raising.
-
-    Args:
-        source_error (Exception): The source exception that was the cause of this one.
-    """
-
-    # NOTE(caselit): remove the description @property in MediaMalformedError
-    description = None
-
-    @deprecated_args(allowed_positional=0)
-    def __init__(self, description=None, **kwargs):
-        errors.HTTPBadRequest.__init__(
-            self,
-            title='Malformed multipart/form-data request media',
-            description=description,
-            **kwargs,
-        )
 
 
 # TODO(vytas): Consider supporting -charset- stuff.
@@ -130,7 +100,7 @@ class BodyPart:
             wrt using this name as a filename on a regular file system.
 
             If `filename` is empty or unset when referencing this property, an
-            instance of :class:`MultipartParseError` will be raised.
+            instance of :class:`.MultipartParseError` will be raised.
 
             See also: :func:`~.secure_filename`
 
@@ -268,7 +238,7 @@ class BodyPart:
 
         If decoding fails due to invalid `data` bytes (for the specified
         encoding), or the specified encoding itself is unsupported, a
-        :class:`MultipartParseError` will be raised when referencing this
+        :class:`.MultipartParseError` will be raised when referencing this
         property.
 
         Note:
@@ -581,18 +551,18 @@ class MultipartParseOptions:
 
         max_body_part_count (int): The maximum number of body parts in the form
             (default: 64). If the form contains more parts than this number,
-            an instance of :class:`MultipartParseError` will be raised. If this
+            an instance of :class:`.MultipartParseError` will be raised. If this
             option is set to 0, no limit will be imposed by the parser.
 
         max_body_part_buffer_size (int): The maximum number of bytes to buffer
             and return when the :meth:`BodyPart.get_data` method is called
             (default: 1 MiB). If the body part size exceeds this value, an
-            instance of :class:`MultipartParseError` will be raised.
+            instance of :class:`.MultipartParseError` will be raised.
 
         max_body_part_headers_size (int): The maximum size (in bytes) of the
             body part headers structure (default: 8192). If the body part
             headers size exceeds this value, an instance of
-            :class:`MultipartParseError` will be raised.
+            :class:`.MultipartParseError` will be raised.
 
         media_handlers (Handlers): A dict-like object for configuring the
             media-types to handle. By default, handlers are provided for the

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -19,6 +19,7 @@ from inspect import iscoroutinefunction
 import keyword
 import re
 from threading import Lock
+from typing import TYPE_CHECKING
 
 from falcon.routing import converters
 from falcon.routing.util import map_http_methods
@@ -27,7 +28,7 @@ from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines
 from falcon.util.sync import wrap_sync_to_async
 
-if False:  # TODO: switch to TYPE_CHECKING once support for py3.5 is dropped
+if TYPE_CHECKING:
     from typing import Any
 
 _TAB_STR = ' ' * 4

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -1,7 +1,6 @@
 from functools import partial
 import io
 import os
-import pathlib
 import re
 
 import falcon
@@ -129,10 +128,6 @@ class StaticRoute:
     def __init__(self, prefix, directory, downloadable=False, fallback_filename=None):
         if not prefix.startswith('/'):
             raise ValueError("prefix must start with '/'")
-
-        # TODO(vgerak): Remove the check when py3.5 is dropped.
-        if isinstance(directory, pathlib.Path):
-            directory = str(directory)
 
         self._directory = os.path.normpath(directory)
         if not os.path.isabs(self._directory):

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -44,6 +44,7 @@ from typing import Union
 
 import falcon
 from falcon import errors as falcon_errors
+import falcon.asgi
 from falcon.asgi_spec import EventType
 from falcon.asgi_spec import ScopeType
 from falcon.asgi_spec import WSCloseCode
@@ -1288,11 +1289,6 @@ def create_asgi_req(body=None, req_type=None, options=None, **kwargs) -> falcon.
     disconnect_at = time.time() + 300
 
     req_event_emitter = ASGIRequestEventEmitter(body, disconnect_at=disconnect_at)
-
-    # NOTE(kgriffs): Import here in case the app is running under
-    #   Python 3.5 (in which case as long as it does not call the
-    #   present function, it won't trigger an import error).
-    import falcon.asgi
 
     req_type = req_type or falcon.asgi.Request
     return req_type(scope, req_event_emitter, options=options)

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -73,25 +73,19 @@ BufferedReader = (
     (_CyBufferedReader or _PyBufferedReader) if IS_64_BITS else _PyBufferedReader
 )
 
-if PYTHON_VERSION >= (3, 7):
-    # NOTE(caselit): __getattr__ support for modules was added only in py 3.7.
-    # Deprecating an import on previous version is hard to do, so we are
-    # displaying the warning only on 3.7+
-    def __getattr__(name):
-        if name == 'json':
-            import warnings
-            import json  # NOQA
-            from .deprecation import DeprecatedWarning
 
-            warnings.warn(
-                'Importing json from "falcon.util" is deprecated.', DeprecatedWarning
-            )
-            return json
-        from types import ModuleType
+def __getattr__(name):
+    if name == 'json':
+        import warnings
+        import json  # NOQA
+        from .deprecation import DeprecatedWarning
 
-        # fallback to the default implementation
-        mod = sys.modules[__name__]
-        return ModuleType.__getattr__(mod, name)
+        warnings.warn(
+            'Importing json from "falcon.util" is deprecated.', DeprecatedWarning
+        )
+        return json
+    from types import ModuleType
 
-else:
-    import json  # NOQA
+    # fallback to the default implementation
+    mod = sys.modules[__name__]
+    return ModuleType.__getattr__(mod, name)

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -74,9 +74,9 @@ strptime = datetime.datetime.strptime
 utcnow = datetime.datetime.utcnow
 
 
-# NOTE(kgriffs): This is tested in the gate but we do not want devs to
-#   have to install a specific version of 3.5 to check coverage on their
-#   workstations, so we use the nocover pragma here.
+# NOTE(kgriffs,vytas): This is tested in the PyPy gate but we do not want devs
+#   to have to install PyPy to check coverage on their workstations, so we use
+#   the nocover pragma here.
 def _lru_cache_nop(*args, **kwargs):  # pragma: nocover
     def decorator(func):
         # NOTE(kgriffs): Partially emulate the lru_cache protocol; only add
@@ -88,19 +88,12 @@ def _lru_cache_nop(*args, **kwargs):  # pragma: nocover
     return decorator
 
 
-# NOTE(kgriffs): https://bugs.python.org/issue28969
-if PYTHON_VERSION >= (3, 5, 4) and PYTHON_VERSION != (3, 6, 0):
-    _lru_cache_safe = functools.lru_cache  # type: ignore
-else:
-    _lru_cache_safe = _lru_cache_nop  # pragma: nocover
-
-
-# PERF(kgriffs): Using lru_cache is slower on pypy when the wrapped
+# PERF(kgriffs): Using lru_cache is slower on PyPy when the wrapped
 #   function is just doing a few non-IO operations.
 if PYPY:
     _lru_cache_for_simple_logic = _lru_cache_nop  # pragma: nocover
 else:
-    _lru_cache_for_simple_logic = _lru_cache_safe  # type: ignore
+    _lru_cache_for_simple_logic = functools.lru_cache  # type: ignore
 
 
 def is_python_func(func):

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -32,7 +32,6 @@ import unicodedata
 
 from falcon import status_codes
 from falcon.constants import PYPY
-from falcon.constants import PYTHON_VERSION
 from falcon.uri import encode_value
 
 # NOTE(vytas): Hoist `deprecated` here since it is documented as part of the

--- a/falcon/util/sync.py
+++ b/falcon/util/sync.py
@@ -20,26 +20,8 @@ __all__ = [
 
 _one_thread_to_rule_them_all = ThreadPoolExecutor(max_workers=1)
 
-
-try:
-    get_running_loop = asyncio.get_running_loop
-except AttributeError:  # pragma: nocover
-    # NOTE(kgriffs): This branch is definitely covered under py35 and py36
-    #   but for some reason the codecov gate doesn't pick this up, hence
-    #   the pragma above.
-
-    get_running_loop = asyncio.get_event_loop
-
-
-try:
-    create_task = asyncio.create_task
-except AttributeError:  # pragma: nocover
-    # NOTE(kgriffs): This branch is definitely covered under py35 and py36
-    #   but for some reason the codecov gate doesn't pick this up, hence
-    #   the pragma above.
-
-    def create_task(coro, name=None):
-        return asyncio.ensure_future(coro)
+create_task = asyncio.create_task
+get_running_loop = asyncio.get_running_loop
 
 
 def wrap_sync_to_async_unsafe(func) -> Callable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@
 [tool.black]
     # this is kept to avoid reformatting all the code if one were to
     # inadvertently run black on the probject
-    target-version = ["py35"]
+    target-version = ["py37"]
     skip-string-normalization = true
     line-length = 88
     extend-exclude = "falcon/vendor"
 
 [tool.blue]
-    target-version = ["py35"]
+    target-version = ["py37"]
     line-length = 88
     extend-exclude = "falcon/vendor"

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,4 +1,4 @@
-coverage>=4.1
+coverage >= 4.1
 pytest
 pyyaml
 requests
@@ -8,14 +8,13 @@ testtools; python_version < '3.10'
 
 # ASGI Specific (daphne is installed on a its own tox env)
 pytest-asyncio
-aiofiles; python_version >= '3.6'
-httpx; python_version >= '3.6'
-uvicorn < 0.17.0; python_version == '3.6'
-uvicorn >= 0.17.0; python_version >= '3.7'
-websockets; python_version >= '3.6'
+aiofiles
+httpx
+uvicorn >= 0.17.0
+websockets
 
 # Handler Specific
-cbor2; python_version >= '3.6'
+cbor2
 msgpack
 mujson
 ujson
@@ -24,4 +23,4 @@ ujson
 python-rapidjson; python_version >= '3.7' and platform_machine != 's390x' and platform_machine != 'aarch64'
 
 # wheels are missing some EoL interpreters and non-x86 platforms; build would fail unless rust is available
-orjson; python_version >= '3.7' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
+orjson; python_version < '3.11' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,6 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -52,7 +50,7 @@ project_urls =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.5
+python_requires = >=3.7
 install_requires =
 tests_require =
     testtools

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ def get_cython_options():
         if (package + '.' + module) not in modules_to_exclude
     ]
 
-    # NOTE(vytas): Now that all our codebase is Python 3.5+, specify the
+    # NOTE(vytas): Now that all our codebase is Python 3.7+, specify the
     #   Python 3 language level for Cython as well to avoid any surprises.
     for ext_mod in ext_modules:
         ext_mod.cython_directives = {'language_level': '3'}

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,9 +1,8 @@
 from contextlib import contextmanager
 import os
 
-import pytest
-
 import falcon
+import falcon.asgi
 import falcon.testing
 
 try:
@@ -27,20 +26,13 @@ __all__ = [
 
 
 def create_app(asgi, **app_kwargs):
-    if asgi:
-        skipif_asgi_unsupported()
-        from falcon.asgi import App
-    else:
-        from falcon import App
-
+    App = falcon.asgi.App if asgi else falcon.App
     app = App(**app_kwargs)
     return app
 
 
 def create_req(asgi, options=None, **environ_or_scope_kwargs):
     if asgi:
-        skipif_asgi_unsupported()
-
         req = falcon.testing.create_asgi_req(options=options, **environ_or_scope_kwargs)
 
     else:
@@ -51,10 +43,7 @@ def create_req(asgi, options=None, **environ_or_scope_kwargs):
 
 def create_resp(asgi):
     if asgi:
-        skipif_asgi_unsupported()
-        from falcon.asgi import Response
-
-        return Response()
+        return falcon.asgi.Response()
 
     return falcon.Response()
 
@@ -64,11 +53,6 @@ def to_coroutine(callable):
         return callable(*args, **kwargs)
 
     return wrapper
-
-
-def skipif_asgi_unsupported():
-    if not falcon.ASGI_SUPPORTED:
-        pytest.skip('ASGI requires Python 3.6+')
 
 
 @contextmanager

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections import deque
 import os
-import sys
 
 import cbor2
 import pytest
@@ -343,9 +342,7 @@ async def test_client_disconnect_early(  # noqa: C901
                             # Ensure recv_task() has a chance to get ahead
                             await asyncio.sleep(0)
                             ws_close = ws.close(4099)
-                            if sys.version_info >= (3, 7):
-                                # using create_task on py3.6 causes this to hang
-                                ws_close = asyncio.create_task(ws_close)
+                            ws_close = asyncio.create_task(ws_close)
                             await asyncio.wait([recv_task, ws_close])
 
                         self.data_received.set()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,7 @@ _FALCON_TEST_ENV = (
 
 @pytest.fixture(params=[True, False], ids=['asgi', 'wsgi'])
 def asgi(request):
-    is_asgi = request.param
-
-    if is_asgi and not falcon.constants.ASGI_SUPPORTED:
-        pytest.skip('ASGI requires Python 3.6+')
-
-    return is_asgi
+    return request.param
 
 
 # NOTE(kgriffs): Some modules actually run a wsgiref server, so

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,7 +1,8 @@
 import pytest
 
 import falcon
-from falcon import ASGI_SUPPORTED, constants, testing
+from falcon import constants, testing
+import falcon.asgi
 
 from _util import create_app, disable_asgi_non_coroutine_wrapping  # NOQA
 
@@ -84,11 +85,6 @@ class TestErrorHandler:
     def test_caught_error_async(self, asgi):
         if not asgi:
             pytest.skip('Test only applies to ASGI')
-
-        if not ASGI_SUPPORTED:
-            pytest.skip('ASGI requires Python 3.6+')
-
-        import falcon.asgi
 
         app = falcon.asgi.App()
         app.add_route('/', ErroredClassResource())

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -6,8 +6,8 @@ import _inspect_fixture as i_f
 import pytest
 
 import falcon
-import falcon.asgi
 from falcon import inspect, routing
+import falcon.asgi
 
 
 def get_app(asgi, cors=True, **kw):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -5,18 +5,16 @@ import sys
 import _inspect_fixture as i_f
 import pytest
 
+import falcon
+import falcon.asgi
 from falcon import inspect, routing
 
 
 def get_app(asgi, cors=True, **kw):
     if asgi:
-        from falcon.asgi import App as AsyncApp
-
-        return AsyncApp(cors_enable=cors, **kw)
+        return falcon.asgi.App(cors_enable=cors, **kw)
     else:
-        from falcon import App
-
-        return App(cors_enable=cors, **kw)
+        return falcon.App(cors_enable=cors, **kw)
 
 
 def make_app():

--- a/tests/test_media_handlers.py
+++ b/tests/test_media_handlers.py
@@ -8,7 +8,8 @@ import pytest
 import ujson
 
 import falcon
-from falcon import ASGI_SUPPORTED, media, testing
+from falcon import media, testing
+from falcon.asgi.stream import BoundedStream
 from falcon.util.deprecation import DeprecatedWarning
 
 from _util import create_app  # NOQA
@@ -98,11 +99,6 @@ def test_deserialization(asgi, func, body, expected):
     args = ['application/javacript', len(body)]
 
     if asgi:
-        if not ASGI_SUPPORTED:
-            pytest.skip('ASGI requires Python 3.6+')
-
-        from falcon.asgi.stream import BoundedStream
-
         s = BoundedStream(testing.ASGIRequestEventEmitter(body))
         args.insert(0, s)
 

--- a/tests/test_media_multipart.py
+++ b/tests/test_media_multipart.py
@@ -317,18 +317,6 @@ def test_empty_filename():
             part.secure_filename
 
 
-@falcon.runs_sync
-async def test_async_unsupported():
-    if falcon.ASGI_SUPPORTED:
-        pytest.skip('Testing missing ASGI support')
-
-    handler = media.MultipartFormHandler()
-    with pytest.raises(NotImplementedError):
-        await handler.deserialize_async(
-            'Dummy', 'multipart/form-data; boundary=BOUNDARY', None
-        )
-
-
 class MultipartAnalyzer:
     def on_post(self, req, resp):
         values = []

--- a/tests/test_python_version_requirements.py
+++ b/tests/test_python_version_requirements.py
@@ -1,12 +1,8 @@
-import pytest
-
-from falcon import ASGI_SUPPORTED
+import falcon
 
 
 def test_asgi():
-    if ASGI_SUPPORTED:
-        # Should not raise
-        import falcon.asgi  # NOQA
-    else:
-        with pytest.raises(ImportError):
-            import falcon.asgi  # NOQA
+    # TODO(vytas): consider removing this file completely.
+    #   Its only purpose left is verifying that ASGI_SUPPORTED is still
+    #   available for compatiblity.
+    assert falcon.ASGI_SUPPORTED

--- a/tests/test_response_body.py
+++ b/tests/test_response_body.py
@@ -67,9 +67,8 @@ def test_content_length_not_set_when_streaming_response(asgi, method):
 
     class SynthesizedHeadAsync:
         async def on_get(self, req, resp):
-            # NOTE(kgriffs): Using an iterator in lieu of a generator
-            #   makes this code parsable by 3.5 and also tests our support
-            #   for iterators vs. generators.
+            # NOTE(kgriffs): Using an iterator in lieu of a generator tests our
+            #   support for iterators vs. generators.
             class Words:
                 def __init__(self):
                     self._stream = iter(('Hello', ',', ' ', 'World!'))

--- a/tests/test_response_context.py
+++ b/tests/test_response_context.py
@@ -1,19 +1,15 @@
 import pytest
 
-from falcon import Response
+import falcon
+import falcon.asgi
 
-from _util import skipif_asgi_unsupported  # NOQA
 
-
-@pytest.fixture(params=[True, False])
+@pytest.fixture(params=[True, False], ids=['asgi.Response', 'Response'])
 def resp_type(request):
     if request.param:
-        skipif_asgi_unsupported()
-        import falcon.asgi
-
         return falcon.asgi.Response
 
-    return Response
+    return falcon.Response
 
 
 class TestResponseContext:

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -1,5 +1,7 @@
 import pytest
 
+import falcon
+import falcon.asgi
 import falcon.testing as testing
 
 
@@ -14,12 +16,8 @@ class TestSlots:
 
     def test_slots_response(self, asgi):
         if asgi:
-            import falcon.asgi
-
             resp = falcon.asgi.Response()
         else:
-            import falcon
-
             resp = falcon.Response()
 
         try:

--- a/tox.ini
+++ b/tox.ini
@@ -83,7 +83,6 @@ setenv =
     PIP_CONFIG_FILE={toxinidir}/pip.conf
     PYTHONASYNCIODEBUG=1
     FALCON_DISABLE_CYTHON=Y
-    FALCON_TESTING_MOCK_PY35=Y
 deps = -r{toxinidir}/requirements/mintest
 commands = coverage run -m pytest tests --ignore=tests/asgi []
 
@@ -97,13 +96,6 @@ commands = coverage run -m pytest tests []
 deps = {[testenv]deps}
 commands = pip uninstall --yes msgpack
            coverage run -m pytest tests -k "test_ws and test_msgpack_missing"
-
-[testenv:py35]
-deps = {[testenv]deps}
-       pytest-randomly
-       jsonschema
-commands = python "{toxinidir}/tools/clean.py" "{toxinidir}/falcon"
-           coverage run -m pytest tests --ignore=tests/asgi []
 
 [testenv:py38]
 basepython = python3.8
@@ -174,20 +166,6 @@ setenv =
     PYTHONASYNCIODEBUG=1
 install_command = python -m pip install --no-build-isolation {opts} {packages}
 commands = pytest tests []
-
-[testenv:py35_cython]
-basepython = python3.5
-install_command = {[with-cython]install_command}
-deps = {[with-cython]deps}
-setenv = {[with-cython]setenv}
-commands = {[with-cython]commands}
-
-[testenv:py36_cython]
-basepython = python3.6
-install_command = {[with-cython]install_command}
-deps = {[with-cython]deps}
-setenv = {[with-cython]setenv}
-commands = {[with-cython]commands}
 
 [testenv:py37_cython]
 basepython = python3.7
@@ -314,28 +292,6 @@ commands = python tests/dump_wsgi.py
 # --------------------------------------------------------------------
 # Benchmarking
 # --------------------------------------------------------------------
-
-[testenv:py35_bench]
-basepython = python3.5
-deps = -r{toxinidir}/requirements/bench
-commands = falcon-bench []
-
-[testenv:py35_bench_cython]
-basepython = python3.5
-deps = -r{toxinidir}/requirements/bench
-       cython
-commands = falcon-bench []
-
-[testenv:py36_bench]
-basepython = python3.6
-deps = -r{toxinidir}/requirements/bench
-commands = falcon-bench []
-
-[testenv:py36_bench_cython]
-basepython = python3.6
-deps = -r{toxinidir}/requirements/bench
-       cython
-commands = falcon-bench []
 
 [testenv:py37_bench]
 basepython = python3.7


### PR DESCRIPTION
~~This is work in progress. I created a Draft PR in order to be able to verify progress with CI.~~

I had to stop short of some planned improvements in favour of getting the bulk of 3.5 & 3.6 removals out, I'll address these things in follow-up PRs.
