### PR TITLE
chore: insert parent dir into `sys.path` when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,16 +14,14 @@
 
 from datetime import datetime
 from collections import OrderedDict
+import configparser
 import multiprocessing
 import sys
 import os
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+sys.path.insert(0, os.path.abspath('..'))
 
-import falcon
+import falcon  # noqa: E402
 
 # NOTE(kgriffs): Work around the change in Python 3.8 that breaks sphinx
 #   on macOS. See also:


### PR DESCRIPTION
This classical `conf.py` hack shouldn't really be needed, but apparently in some scenarios it is still desirable. Shouldn't hurt for anybody else.

Closes #2080