### PR TITLE
docs: clarify that `TestClient` doesn't use the app's JSON handlers

### DIFF
--- a/docs/api/testing.rst
+++ b/docs/api/testing.rst
@@ -29,6 +29,8 @@ Main Interface
 .. autoclass:: Cookie
    :members:
 
+.. _testing_standalone_methods:
+
 Standalone Methods
 ~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -943,6 +943,15 @@ via custom type extensions.
 .. seealso:: See :ref:`custom-media-json-encoder` for an example on how to
     use a custom json encoder.
 
+.. note:: When testing an application employing a custom JSON encoder, bear in
+    mind that :class:`~.testing.TestClient` is decoupled from the app, and it
+    simulates requests as if they were performed by a third-party client (just
+    sans network). Therefore, passing the **json** parameter to
+    :ref:`simulate_* <testing_standalone_methods>` methods will effectively
+    use the stdlib's :func:`json.dumps`. If you want to serialize custom
+    objects for testing, you will need to dump them into a string yourself, and
+    pass it using the **body** parameter instead (accompanied by the
+    ``application/json`` content type header).
 
 Does Falcon set Content-Length or do I need to do that explicitly?
 ------------------------------------------------------------------

--- a/falcon/media/json.py
+++ b/falcon/media/json.py
@@ -133,6 +133,15 @@ class JSONHandler(BaseHandler):
         app.req_options.media_handlers.update(extra_handlers)
         app.resp_options.media_handlers.update(extra_handlers)
 
+    .. note:: When testing an application employing a custom JSON encoder, bear
+        in mind that :class:`~.testing.TestClient` is decoupled from the app,
+        and it simulates requests as if they were performed by a third-party
+        client (just sans network). Therefore, passing the **json** parameter
+        to :ref:`simulate_* <testing_standalone_methods>` methods will
+        effectively use the stdlib's :func:`json.dumps`. If you want to
+        serialize custom objects for testing, you will need to dump them into a
+        string yourself, and pass it using the **body** parameter instead
+        (accompanied by the ``application/json`` content type header).
 
     Keyword Arguments:
         dumps (func): Function to use when serializing JSON responses.

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,9 @@ deps = {[testenv]deps}
        daphne
 
 [testenv:hypercorn]
+# TODO(vytas): Unpin Hypercorn once the buggy versions are yanked upstream.
 deps = {[testenv]deps}
-       hypercorn
+       hypercorn != 0.14.0, != 0.14.1
 
 # --------------------------------------------------------------------
 # Test without optional packages


### PR DESCRIPTION
Add a note that `TestClient`'s `simulate_*()` methods don't use the app's media handlers.

Closes #2099

An unrelated change to get the CI to pass: Hypercorn is pinned in the corresponding `tox` environment to exclude the current buggy versions (ref https://github.com/pgjones/hypercorn/issues/65).
