### PR TITLE
feat: status_code attribute for Response, HTTPError, HTTPStatus

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -124,6 +124,7 @@ listed below by date of first contribution:
 * Oday Alhayek (RioAtHome)
 * Christian Clauss (cclauss)
 * meetshah133
+* Kai Chan (kaichan1201)
 
 (et al.)
 

--- a/docs/_newsfragments/2108.newandimproved.rst
+++ b/docs/_newsfragments/2108.newandimproved.rst
@@ -1,0 +1,4 @@
+A new ``status_code`` attribute was added to the :attr:`falcon.Response <falcon.Response.status_code>`,
+:attr:`falcon.asgi.Response <falcon.Response.status_code>`,
+:attr:`HTTPStatus <falcon.HTTPStatus.status_code>`,
+and :attr:`HTTPError <falcon.HTTPError.status_code>` classes.

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -33,7 +33,6 @@ from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
 from falcon.media.multipart import MultipartFormHandler
 import falcon.routing
-from falcon.util.misc import http_status_to_code
 from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines
 from falcon.util.sync import _wrap_non_coroutine_unsafe
@@ -472,7 +471,7 @@ class App(falcon.app.App):
 
             req_succeeded = False
 
-        resp_status = http_status_to_code(resp.status)
+        resp_status = resp.status_code
         default_media_type = self.resp_options.default_media_type
 
         if req.method == 'HEAD' or resp_status in _BODILESS_STATUS_CODES:
@@ -1039,7 +1038,7 @@ class App(falcon.app.App):
                 error,
             )
 
-            code = 3000 + falcon.util.http_status_to_code(error.status)
+            code = 3000 + error.status_code
             await ws.close(code)
 
     async def _python_error_handler(self, req, resp, error, params, ws=None):

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -34,14 +34,23 @@ class Response(response.Response):
         options (dict): Set of global options passed from the App handler.
 
     Attributes:
-        status: HTTP status code or line (e.g., ``'200 OK'``). This may be set
-            to a member of :class:`http.HTTPStatus`, an HTTP status line string
-            or byte string (e.g., ``'200 OK'``), or an ``int``.
+        status (Union[str,int]): HTTP status code or line (e.g., ``'200 OK'``).
+            This may be set to a member of :class:`http.HTTPStatus`, an HTTP
+            status line string or byte string (e.g., ``'200 OK'``), or an
+            ``int``.
 
             Note:
                 The Falcon framework itself provides a number of constants for
                 common status codes. They all start with the ``HTTP_`` prefix,
                 as in: ``falcon.HTTP_204``. (See also: :ref:`status`.)
+
+        status_code (int): HTTP status code normalized from :attr:`status`.
+            When a code is assigned to this property, :attr:`status` is updated,
+            and vice-versa. The status code can be useful when needing to check
+            in middleware for codes that fall into a certain class, e.g.::
+
+                if resp.status_code >= 400:
+                    log.warning(f'returning error response: {resp.status_code}')
 
         media (object): A serializable object supported by the media handlers
             configured via :class:`falcon.RequestOptions`.

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 import xml.etree.ElementTree as et
 
 from falcon.constants import MEDIA_JSON
-from falcon.util import uri
+from falcon.util import http_status_to_code, uri
 from falcon.util.deprecation import deprecated_args
 
 
@@ -46,7 +46,10 @@ class HTTPError(Exception):
         error in a future version of falcon.
 
     Args:
-        status (str): HTTP status code and text, such as "400 Bad Request"
+        status (Union[str,int]): HTTP status code or line (e.g.,
+            ``'400 Bad Request'``). This may be set to a member of
+            :class:`http.HTTPStatus`, an HTTP status line string or byte
+            string (e.g., ``'200 OK'``), or an ``int``.
 
     Keyword Args:
         title (str): Human-friendly error title. If not provided, defaults
@@ -88,6 +91,8 @@ class HTTPError(Exception):
             getting help.
         code (int): An internal application code that a user can reference when
             requesting support for the error.
+        status_code (int): HTTP status code normalized from the ``status``
+            argument passed to the initializer.
     """
 
     __slots__ = (
@@ -134,6 +139,10 @@ class HTTPError(Exception):
         return '<%s: %s>' % (self.__class__.__name__, self.status)
 
     __str__ = __repr__
+
+    @property
+    def status_code(self) -> int:
+        return http_status_to_code(self.status)
 
     def to_dict(self, obj_type=dict):
         """Return a basic dictionary representing the error.

--- a/falcon/http_error.py
+++ b/falcon/http_error.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 import xml.etree.ElementTree as et
 
 from falcon.constants import MEDIA_JSON
-from falcon.util import http_status_to_code, uri
+from falcon.util import code_to_http_status, http_status_to_code, uri
 from falcon.util.deprecation import deprecated_args
 
 
@@ -83,7 +83,12 @@ class HTTPError(Exception):
             base articles related to this error (default ``None``).
 
     Attributes:
-        status (str): HTTP status line, e.g. '748 Confounded by Ponies'.
+        status (Union[str,int]): HTTP status code or line (e.g., ``'200 OK'``).
+            This may be set to a member of :class:`http.HTTPStatus`, an HTTP
+            status line string or byte string (e.g., ``'200 OK'``), or an
+            ``int``.
+        status_code (int): HTTP status code normalized from the ``status``
+            argument passed to the initializer.
         title (str): Error title to send to the client.
         description (str): Description of the error to send to the client.
         headers (dict): Extra headers to add to the response.
@@ -91,8 +96,6 @@ class HTTPError(Exception):
             getting help.
         code (int): An internal application code that a user can reference when
             requesting support for the error.
-        status_code (int): HTTP status code normalized from the ``status``
-            argument passed to the initializer.
     """
 
     __slots__ = (
@@ -121,7 +124,7 @@ class HTTPError(Exception):
         #   we'll probably switch over to making everything code-based to more
         #   easily support HTTP/2. When that happens, should we continue to
         #   include the reason phrase in the title?
-        self.title = title or status
+        self.title = title or code_to_http_status(status)
 
         self.description = description
         self.headers = headers

--- a/falcon/http_status.py
+++ b/falcon/http_status.py
@@ -14,6 +14,7 @@
 
 """HTTPStatus exception class."""
 
+from falcon.util import http_status_to_code
 from falcon.util.deprecation import AttributeRemovedError
 
 
@@ -25,14 +26,18 @@ class HTTPStatus(Exception):
     to ``falcon.HTTPError``, but for non-error status codes.
 
     Args:
-        status (str): HTTP status code and text, such as
-            '748 Confounded by Ponies'.
+        status (Union[str,int]): HTTP status code or line (e.g.,
+            ``'400 Bad Request'``). This may be set to a member of
+            :class:`http.HTTPStatus`, an HTTP status line string or byte
+            string (e.g., ``'200 OK'``), or an ``int``.
         headers (dict): Extra headers to add to the response.
         text (str): String representing response content. Falcon will encode
             this value as UTF-8 in the response.
 
     Attributes:
-        status (str): HTTP status line, e.g. '748 Confounded by Ponies'.
+        status (Union[str, int]): The HTTP status line or integer code for
+            the status that this exception represents.
+        status_code (int): HTTP status code normalized from :attr:`status`.
         headers (dict): Extra headers to add to the response.
         text (str): String representing response content. Falcon will encode
             this value as UTF-8 in the response.
@@ -45,6 +50,10 @@ class HTTPStatus(Exception):
         self.status = status
         self.headers = headers
         self.text = text
+
+    @property
+    def status_code(self) -> int:
+        return http_status_to_code(self.status)
 
     @property  # type: ignore
     def body(self):

--- a/falcon/http_status.py
+++ b/falcon/http_status.py
@@ -35,7 +35,7 @@ class HTTPStatus(Exception):
             this value as UTF-8 in the response.
 
     Attributes:
-        status (Union[str, int]): The HTTP status line or integer code for
+        status (Union[str,int]): The HTTP status line or integer code for
             the status that this exception represents.
         status_code (int): HTTP status code normalized from :attr:`status`.
         headers (dict): Extra headers to add to the response.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -29,6 +29,7 @@ from falcon.response_helpers import header_property
 from falcon.response_helpers import is_ascii_encodable
 from falcon.util import dt_to_http
 from falcon.util import http_cookies
+from falcon.util import http_status_to_code
 from falcon.util import structures
 from falcon.util import TimezoneGMT
 from falcon.util.deprecation import AttributeRemovedError, deprecated
@@ -58,14 +59,23 @@ class Response:
         options (dict): Set of global options passed from the App handler.
 
     Attributes:
-        status: HTTP status code or line (e.g., ``'200 OK'``). This may be set
-            to a member of :class:`http.HTTPStatus`, an HTTP status line string
-            or byte string (e.g., ``'200 OK'``), or an ``int``.
+        status (Union[str,int]): HTTP status code or line (e.g., ``'200 OK'``).
+            This may be set to a member of :class:`http.HTTPStatus`, an HTTP
+            status line string or byte string (e.g., ``'200 OK'``), or an
+            ``int``.
 
             Note:
                 The Falcon framework itself provides a number of constants for
                 common status codes. They all start with the ``HTTP_`` prefix,
                 as in: ``falcon.HTTP_204``. (See also: :ref:`status`.)
+
+        status_code (int): HTTP status code normalized from :attr:`status`.
+            When a code is assigned to this property, :attr:`status` is updated,
+            and vice-versa. The status code can be useful when needing to check
+            in middleware for codes that fall into a certain class, e.g.::
+
+                if resp.status_code >= 400:
+                    log.warning(f'returning error response: {resp.status_code}')
 
         media (object): A serializable object supported by the media handlers
             configured via :class:`falcon.RequestOptions`.
@@ -187,6 +197,14 @@ class Response:
         self._media_rendered = _UNSET
 
         self.context = self.context_type()
+
+    @property
+    def status_code(self) -> int:
+        return http_status_to_code(self.status)
+
+    @status_code.setter
+    def status_code(self, value):
+        self.status = value
 
     @property  # type: ignore
     def body(self):

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -448,10 +448,12 @@ def code_to_http_status(status):
     if isinstance(status, http.HTTPStatus):
         return '{} {}'.format(status.value, status.phrase)
 
-    if isinstance(status, str):
+    # NOTE(kgriffs): If it is a str but does not have a space, assume it is
+    #   just the number by itself.
+    if isinstance(status, str) and ' ' in status:
         return status
 
-    if isinstance(status, bytes):
+    if isinstance(status, bytes) and b' ' in status:
         return status.decode()
 
     try:

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -283,6 +283,7 @@ class TestNoBodyWithStatus:
     def test_data_is_set(self, body_client):
         res = body_client.simulate_get('/error')
         assert res.status == falcon.HTTP_IM_A_TEAPOT
+        assert res.status_code == 418
         assert res.content == b''
 
     def test_media_is_set(self, body_client):

--- a/tests/test_http_custom_method_routing.py
+++ b/tests/test_http_custom_method_routing.py
@@ -105,6 +105,7 @@ def test_foo(custom_http_client, resource_things):
 
     assert 'FOO' in falcon.constants.COMBINED_METHODS
     assert response.status == falcon.HTTP_204
+    assert response.status_code == 204
     assert resource_things.called
 
 
@@ -123,3 +124,4 @@ def test_bar(custom_http_client, resource_things):
 
     assert 'BAR' in falcon.constants.COMBINED_METHODS
     assert response.status == falcon.HTTP_405
+    assert response.status_code == 405

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8
 
 import datetime
+import http
 import json
 import wsgiref.validate
 import xml.etree.ElementTree as et  # noqa: I202
@@ -32,6 +33,21 @@ class FaultyResource:
         description = req.get_header('X-Error-Description')
         code = 10042
 
+        status_type = req.get_header('X-Error-Status-Type')
+        if status_type:
+            assert status
+
+        if status_type == 'int':
+            status = int(status)
+        elif status_type == 'bytes':
+            status = status.encode()
+        elif status_type == 'HTTPStatus':
+            status = http.HTTPStatus(int(status))
+        elif status_type == 'str':
+            pass
+        elif status_type is not None:
+            pytest.fail(f'status_type {status_type} not recognized')
+
         raise falcon.HTTPError(status, title=title, description=description, code=code)
 
     def on_post(self, req, resp):
@@ -62,7 +78,7 @@ class UnicodeFaultyResource:
     def on_get(self, req, resp):
         self.called = True
         raise falcon.HTTPError(
-            falcon.HTTP_792,
+            792,  # NOTE(kgriffs): Test that an int is acceptable even for 7xx codes
             title='Internet \xe7rashed!',
             description='\xc7atastrophic weather event',
             href='http://example.com/api/\xe7limate',
@@ -868,16 +884,27 @@ class TestHTTPError:
         self._misc_test(client, falcon.HTTPInternalServerError, falcon.HTTP_500)
         self._misc_test(client, falcon.HTTPBadGateway, falcon.HTTP_502)
 
-    def test_title_default_message_if_none(self, client):
-        headers = {'X-Error-Status': falcon.HTTP_503}
+    @pytest.mark.parametrize('status, status_type', [
+        (falcon.HTTP_503, 'str'),
+        (falcon.HTTP_503, 'bytes'),
+        (503, 'int'),
+        (503, 'str'),
+        (503, 'bytes'),
+        (503, 'HTTPStatus'),
+    ])
+    def test_title_default_message_if_none(self, status, status_type, client):
+        headers = {
+            'X-Error-Status': str(status),
+            'X-Error-Status-Type': status_type,
+        }
 
         response = client.simulate_request(path='/fail', headers=headers)
 
-        assert response.status == headers['X-Error-Status']
-        assert response.json['title'] == headers['X-Error-Status']
+        assert response.json['title'] == falcon.HTTP_503
+        assert response.status_code == 503
 
     def test_to_json_dumps(self):
-        e = falcon.HTTPError(status=falcon.HTTP_418, title='foo', description='bar')
+        e = falcon.HTTPError(status=418, title='foo', description='bar')
         assert e.to_json() == b'{"title": "foo", "description": "bar"}'
 
         class Handler:

--- a/tests/test_httperror.py
+++ b/tests/test_httperror.py
@@ -884,14 +884,17 @@ class TestHTTPError:
         self._misc_test(client, falcon.HTTPInternalServerError, falcon.HTTP_500)
         self._misc_test(client, falcon.HTTPBadGateway, falcon.HTTP_502)
 
-    @pytest.mark.parametrize('status, status_type', [
-        (falcon.HTTP_503, 'str'),
-        (falcon.HTTP_503, 'bytes'),
-        (503, 'int'),
-        (503, 'str'),
-        (503, 'bytes'),
-        (503, 'HTTPStatus'),
-    ])
+    @pytest.mark.parametrize(
+        'status, status_type',
+        [
+            (falcon.HTTP_503, 'str'),
+            (falcon.HTTP_503, 'bytes'),
+            (503, 'int'),
+            (503, 'str'),
+            (503, 'bytes'),
+            (503, 'HTTPStatus'),
+        ],
+    )
     def test_title_default_message_if_none(self, status, status_type, client):
         headers = {
             'X-Error-Status': str(status),

--- a/tox.ini
+++ b/tox.ini
@@ -385,6 +385,16 @@ commands =
     {toxinidir}/tools/add_contributors.py
     {toxinidir}/tools/towncrier_draft.py
 
+# NOTE(kgriffs): Renders the changelog to HTML so that the final result
+#   can be previewed, but then restores the changelog RST document.
+[testenv:changelog_draft]
+deps = -r{toxinidir}/requirements/docs
+        toml
+        towncrier
+commands =
+    {toxinidir}/tools/add_contributors.py --dry-run
+    {toxinidir}/tools/towncrier_draft.py --dry-run
+
 [testenv:dash]
 basepython = python3.7
 setenv =


### PR DESCRIPTION
This patch adds a status_code attribute (property) to the Response, HTTPError,
and HTTPStatus classes to afford introspection by middleware and error
handlers.
