### PR TITLE
refactor: implement `get_header_as_int` method

### DIFF
--- a/docs/_newsfragments/2060.newandimproved.rst
+++ b/docs/_newsfragments/2060.newandimproved.rst
@@ -1,0 +1,1 @@
+A new method :meth:`falcon.Request.get_header_as_int` was implemented.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1189,6 +1189,37 @@ class Request:
 
             raise errors.HTTPMissingHeader(name)
 
+    def get_header_as_int(self, header, required=False):
+        """Retrieve the int value for the given header.
+
+        Args:
+            name (str): Header name, case-insensitive (e.g., 'Content-Length')
+
+        Keyword Args:
+            required (bool): Set to ``True`` to raise
+                ``HTTPBadRequest`` instead of returning gracefully when the
+                header is not found (default ``False``).
+
+        Returns:
+            int: The value of the specified header if it exists,
+            or ``None`` if the header is not found and is not required.
+
+        Raises:
+            HTTPBadRequest: The header was not found in the request, but
+                it was required.
+            HttpInvalidHeader: The header contained a malformed/invalid value.
+        """
+
+        try:
+            http_int = self.get_header(header, required=required)
+            return int(http_int)
+        except TypeError:
+            # When the header does not exist and isn't required
+            return None
+        except ValueError:
+            msg = 'The value of the header must be an integer.'
+            raise errors.HTTPInvalidHeader(msg, header)
+
     def get_header_as_datetime(self, header, required=False, obs_date=False):
         """Return an HTTP header with HTTP-Date values as a datetime.
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -363,6 +363,34 @@ class TestHeaders:
 
         assert result.headers['Expires'] == 'Tue, 01 Jan 2013 10:30:30 GMT'
 
+    def test_get_header_as_int(self, client):
+        resource = testing.SimpleTestResource(body=SAMPLE_BODY)
+        client.app.add_route('/', resource)
+        request_headers = {
+            'X-Int-Val': '42',
+            'X-Str-Val': 'test-val',
+            'X-Float-Val': '3.14',
+        }
+        client.simulate_get(headers=request_headers)
+
+        req = resource.captured_req
+        value = req.get_header_as_int('X-Int-Val')
+        assert value == 42
+
+        value = req.get_header_as_int('X-Not-Found')
+        assert value is None
+
+        with pytest.raises(falcon.HTTPInvalidHeader) as exc_info:
+            req.get_header_as_int('X-Float-Val')
+        assert exc_info.value.args[0] == 'The value of the header must be an integer.'
+
+        with pytest.raises(falcon.HTTPInvalidHeader) as exc_info:
+            req.get_header_as_int('X-Str-Val')
+        assert exc_info.value.args[0] == 'The value of the header must be an integer.'
+
+        with pytest.raises(falcon.HTTPMissingHeader) as exc_info:
+            req.get_header_as_int('X-Not-Found', required=True)
+
     def test_default_value(self, client):
         resource = testing.SimpleTestResource(body=SAMPLE_BODY)
         client.app.add_route('/', resource)


### PR DESCRIPTION
# Summary of Changes

Implements the `get_header_as_int` method.

Wasn't sure whether (and how) to document it in the docs, as I couldn't find the part for the similar function `get_header_as_datetime()`.

# Related Issues

#2060

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
