### PR TITLE
django.conf.urls.url() was deprecated in Dj 3.0, and is removed in Dj 4.0+

### DIFF
--- a/falcon/bench/dj/dj/urls.py
+++ b/falcon/bench/dj/dj/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path as url
 from hello import views
 
 


### PR DESCRIPTION
Running docker bench_py3.Dockerfile ends with error:

```
 File "/usr/local/lib/python3.8/site-packages/falcon/bench/dj/dj/urls.py", line 1, in <module>
    from django.conf.urls import url
ImportError: cannot import name 'url' from 'django.conf.urls' (/usr/local/lib/python3.8/site-packages/django/conf/urls/__init__.py)
```
