### PR TITLE
fix(Cython): re-enable cythonization in Cython gates, do not enforce typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ def get_cython_options():
     # NOTE(vytas): Now that all our codebase is Python 3.7+, specify the
     #   Python 3 language level for Cython as well to avoid any surprises.
     for ext_mod in ext_modules:
-        ext_mod.cython_directives = {'language_level': '3'}
+        ext_mod.cython_directives = {'language_level': '3', 'annotation_typing': False}
 
     cmdclass = {'build_ext': ve_build_ext}
     return cmdclass, ext_modules

--- a/tox.ini
+++ b/tox.ini
@@ -159,6 +159,7 @@ commands = python "{toxinidir}/tools/clean.py" "{toxinidir}/falcon"
 
 [with-cython]
 deps = -r{toxinidir}/requirements/tests
+       Cython
 setenv =
     PIP_CONFIG_FILE={toxinidir}/pip.conf
     FALCON_DISABLE_CYTHON=


### PR DESCRIPTION
There is a typing issue in `FloatConverter` that is causing problems during runtime, and would be detected in `mypy` too.
This is fixed in my typing branch, but I just backported a simple switch not to enforce types in Cython since that has been observed to actually be a de-optimization in most cases.

The problem has been masked by another issue that our Cython gates have PEP 517 disabled in `tox`, however, the Cython dependency is not installed into these.
