### PR TITLE
docs(release): backportport misc `RELEASE.md` improvements from 3.1.1

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -132,6 +132,9 @@ jobs:
         # change the tag of this image to change the image used
         uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2010_x86_64
         # this action generates 3 wheels in dist/. linux manylinux1 and manylinux2010
+        # TODO(vytas): Drop manylinux 2010 support for all wheels:
+        #   https://github.com/pypa/manylinux/issues/1281#
+        if: ${{ matrix.python-version != 'cp311-cp311' }}
         with:
           python-versions: ${{ matrix.python-version }}
           build-requirements: "setuptools>=47 wheel>=0.34"

--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -147,7 +147,7 @@ jobs:
         # this action generates 2 wheels in dist/. linux, manylinux2014
         with:
           # Remove previous original wheel just to be sure it is recreated. Should not be needed
-          pre-build-command: "rm ./dist/*-linux*.whl"
+          pre-build-command: "rm -f ./dist/*-linux*.whl"
           python-versions: ${{ matrix.python-version }}
           build-requirements: "setuptools>=47 wheel>=0.34"
           pip-wheel-args: "-w ./dist -v --no-deps"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ field to modify.
 Update changelog filename in `pyproject.toml` to suit.
 
 Update the build tag in `setup.cfg` under `[egg_info]` for pre-release builds,
-or remove it (leaving it blank as in `tag_build = `) for a final releases.
+or remove it (leaving it blank as in `tag_build =`) for a final release.
 
 ### Update changelog and render towncrier fragments
 
@@ -59,7 +59,7 @@ Many thanks to those who contributed to this bugfix release:
 Otherwise, ensure the summary has been brought up to date; be sure to highlight
 key changes in this release.
 
-Next update the contributors and render towncrier fragments by running:
+Next, update the contributors and render towncrier fragments by running:
 
 ```sh
 $ tox -e changelog_release

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ Release Process:
 6. Publish final version and add a release note.
 7. Run benchmark and update falconframework.org with latest numbers.
 8. Announce the new version in Gitter channels and on the socials.
+9. Improve this document.
 
 ### Bump version and update tag
 
@@ -118,4 +119,9 @@ Be sure to install and test from PyPI as a sanity check afterwards.
 
 ### Run benchmark and update falconframework.org with latest numbers
 
-### Announce the new version in Gitter channels and on the socials.
+### Announce the new version in Gitter channels and on the socials
+
+### Improve this document
+
+If you find any inconsistencies, outdated notes or anything missing here, make
+sure you improve this document for future releases!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -92,8 +92,13 @@ you can re-render the docs without overwriting the changelog RST:
 $ tox -e docs
 ```
 
-Finally, if all looks good, remove the rendered towncrier fragments from
+If all looks good, remove the rendered towncrier fragments from
 `docs/_newsfragments` and then submit a PR containing the changes made so far.
+
+Finally, merge the documentation PR and check that everything renders correctly
+on https://falcon.readthedocs.io/. Note that if the release is not based on
+`master` (or `main`), you may need to manually enable build on RtD for the
+branch or tag in question.
 
 ### Release beta or rc
 


### PR DESCRIPTION
Closes #473
(The `RELEASE.md` document that we currently have isn't perfect, but it does the job... so let's close the issue and keep improving it as we go.)