### PR TITLE
chore(PEP8): pin `flake8` until its plugins have caught up

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -249,7 +249,8 @@ commands = {[smoke-test]commands}
 # --------------------------------------------------------------------
 
 [testenv:pep8]
-deps = flake8>=3.7.0
+# TODO(vytas): Unpin flake8 when the below plugins have caught up.
+deps = flake8<6.0
        flake8-quotes
        flake8-import-order
 commands = flake8 []
@@ -273,7 +274,8 @@ commands = flake8 \
              []
 
 [testenv:pep8-examples]
-deps = flake8
+# TODO(vytas): Unpin flake8 when the below plugins have caught up.
+deps = flake8<6.0
        flake8-quotes
        flake8-import-order
 


### PR DESCRIPTION
`flake8-import-order` has just been updated with support for v6.0, however, `flake8-quotes` is, at the time of this writing, still incompatible: https://github.com/zheller/flake8-quotes/issues/110.