### PR TITLE
chore: remove pinning of `importlib-resources` for Mailman tests

### DIFF
--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run_tox:

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -19,14 +19,11 @@ cd $MAILMAN_PATH
 # git checkout tags/$MAILMAN_VERSION
 
 # NOTE(vytas): Patch tox.ini to introduce a new Falcon environment.
-# TODO(vytas): Remove the shim pinning importlib-resources once
-#   https://gitlab.com/mailman/mailman/-/merge_requests/1130 is merged upstream.
 cat <<EOT >> tox.ini
 
 [testenv:falcon-nocov]
 basepython = python3.8
 commands_pre =
-    pip install "importlib-resources < 6.0"
     pip uninstall -y falcon
     pip install $FALCON_ROOT
 EOT


### PR DESCRIPTION
We had to pin `importlib-resources` for some CI gates because its very aggressive deprecation policy.
Now the dependency in question has been dropped upstream, so we don't need to pin anymore (in fact, pinning breaks the gate):  https://gitlab.com/mailman/mailman/-/merge_requests/1130.