### PR TITLE
chore(testing): allow test to be run using pytest-xdist

### DIFF
--- a/tests/_util.py
+++ b/tests/_util.py
@@ -72,6 +72,7 @@ def disable_asgi_non_coroutine_wrapping():
 def as_params(*values, prefix=None):
     if not prefix:
         prefix = ''
+    # NOTE(caselit): each value must be a tuple/list even when using one single argument
     return [
         pytest.param(*value, id=f'{prefix}_{i}' if prefix else f'{i}')
         for i, value in enumerate(values, 1)

--- a/tests/_util.py
+++ b/tests/_util.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 import os
 
+import pytest
+
 import falcon
 import falcon.asgi
 import falcon.testing
@@ -65,3 +67,12 @@ def disable_asgi_non_coroutine_wrapping():
 
     if should_wrap:
         os.environ['FALCON_ASGI_WRAP_NON_COROUTINES'] = 'Y'
+
+
+def as_params(*values, prefix=None):
+    if not prefix:
+        prefix = ''
+    return [
+        pytest.param(*value, id=f'{prefix}_{i}' if prefix else f'{i}')
+        for i, value in enumerate(values, 1)
+    ]

--- a/tests/test_uri_converters.py
+++ b/tests/test_uri_converters.py
@@ -3,6 +3,7 @@ import math
 import string
 import uuid
 
+from _util import as_params
 import pytest
 
 from falcon.routing import converters
@@ -150,7 +151,7 @@ def test_datetime_converter_default_format():
 
 @pytest.mark.parametrize(
     'value, expected',
-    [
+    as_params(
         (_TEST_UUID_STR, _TEST_UUID),
         (_TEST_UUID_STR.replace('-', '', 1), _TEST_UUID),
         (_TEST_UUID_STR_SANS_HYPHENS, _TEST_UUID),
@@ -163,7 +164,8 @@ def test_datetime_converter_default_format():
         (_TEST_UUID_STR[0], None),
         (_TEST_UUID_STR[:-1] + 'g', None),
         (_TEST_UUID_STR.replace('-', '_'), None),
-    ],
+        prefix='uuid',
+    ),
 )
 def test_uuid_converter(value, expected):
     c = converters.UUIDConverter()

--- a/tests/test_uri_templates.py
+++ b/tests/test_uri_templates.py
@@ -15,7 +15,7 @@ import falcon
 from falcon import testing
 from falcon.routing.util import SuffixedMethodNotFoundError
 
-from _util import create_app  # NOQA
+from _util import as_params, create_app  # NOQA
 
 
 _TEST_UUID = uuid.uuid4()
@@ -314,7 +314,7 @@ def test_datetime_converter(client, resource, uri_template, path, dt_expected):
 
 @pytest.mark.parametrize(
     'uri_template, path, expected',
-    [
+    as_params(
         (
             '/widgets/{widget_id:uuid}',
             '/widgets/' + _TEST_UUID_STR,
@@ -354,7 +354,8 @@ def test_datetime_converter(client, resource, uri_template, path, dt_expected):
             '/widgets/' + _TEST_UUID_STR_SANS_HYPHENS[:-1] + '/orders',
             None,
         ),
-    ],
+        prefix='uuid_converter',
+    ),
 )
 def test_uuid_converter(client, resource, uri_template, path, expected):
     client.app.add_route(uri_template, resource)


### PR DESCRIPTION
Trying to run `pytest .\tests\ -n 6 --dist=worksteal` on master it results in an error since different test are collected.
This is mostly because we parametrize the test on random uuid, that result in the test signature to be different.

This fixes that by creating a deterministic id for the parametrized test where needed