### PR TITLE
chore(readthedocs): add `.readthedocs.yaml` as required

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+    - requirements: requirements/docs


### PR DESCRIPTION
It seams that our builds have stopped working completely, Read the Docs now [mandates having a config file](https://blog.readthedocs.com/migrate-configuration-v2/):

```
Error

Problem in your project's configuration. No default configuration file found at repository's root.
```