### PR TITLE
chore(alabaster): disable GitHub banner

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,7 +168,7 @@ html_theme_options = {
     'github_user': 'falconry',
     'github_repo': 'falcon',
     'github_button': False,
-    'github_banner': not dash_build,
+    'github_banner': False,
     'fixed_sidebar': False,
     'show_powered_by': False,
     'extra_nav_links': OrderedDict(


### PR DESCRIPTION
(As it links to a removed S3 object.)

See also: https://github.com/sphinx-doc/alabaster/issues/166.