### PR TITLE
feat(add_error_handler): deprecate the Falcon 1.x signature shim

### DIFF
--- a/falcon/app.py
+++ b/falcon/app.py
@@ -20,6 +20,7 @@ import pathlib
 import re
 import traceback
 from typing import Callable, Iterable, Optional, Tuple, Type, Union
+import warnings
 
 from falcon import app_helpers as helpers
 from falcon import constants
@@ -828,6 +829,12 @@ class App:
             ('ex',),
             ('exception',),
         ) or arg_names[1:3] in (('req', 'resp'), ('request', 'response')):
+            warnings.warn(
+                f'handler is using a deprecated signature; please order its '
+                f'arguments as {handler.__qualname__}(req, resp, ex, params). '
+                f'This compatibility shim will be removed in Falcon 5.0.',
+                deprecation.DeprecatedWarning,
+            )
             handler = wrap_old_handler(handler)
 
         exception_tuple: tuple

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -3,6 +3,7 @@ import pytest
 import falcon
 from falcon import constants, testing
 import falcon.asgi
+from falcon.util.deprecation import DeprecatedWarning
 
 from _util import create_app, disable_asgi_non_coroutine_wrapping  # NOQA
 
@@ -212,9 +213,12 @@ class TestErrorHandler:
         app.add_route('/', ErroredClassResource())
         client = testing.TestClient(app)
 
-        client.app.add_error_handler(Exception, legacy_handler1)
-        client.app.add_error_handler(CustomBaseException, legacy_handler2)
-        client.app.add_error_handler(CustomException, legacy_handler3)
+        with pytest.warns(DeprecatedWarning, match='deprecated signature'):
+            client.app.add_error_handler(Exception, legacy_handler1)
+        with pytest.warns(DeprecatedWarning, match='deprecated signature'):
+            client.app.add_error_handler(CustomBaseException, legacy_handler2)
+        with pytest.warns(DeprecatedWarning, match='deprecated signature'):
+            client.app.add_error_handler(CustomException, legacy_handler3)
 
         client.simulate_delete()
         client.simulate_get()


### PR DESCRIPTION
We should have added this warning already in 2.0, but the invocation of that shim is still silent :slightly_frowning_face: This PR aims to rectify that, and warn users about using an support call signature.