### PR TITLE
chore:  make contributor's checklist pass on CPython 3.12

### DIFF
--- a/.github/workflows/mintest.yaml
+++ b/.github/workflows/mintest.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U tox
+          pip install -U setuptools tox wheel
           python --version
           pip --version
           tox --version

--- a/.github/workflows/mintest.yaml
+++ b/.github/workflows/mintest.yaml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove once demonstrated in a PR.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   run_tox:

--- a/.github/workflows/mintest.yaml
+++ b/.github/workflows/mintest.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove once demonstrated in a PR.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run_tox:
@@ -18,6 +22,7 @@ jobs:
           - "3.8"
           - "3.10"
           - "3.11"
+          - "3.12"
 
     steps:
       - name: Checkout repo

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ copyright = '{year} Falcon Contributors'.format(year=datetime.now().year)
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-cfg = configparser.SafeConfigParser()
+cfg = configparser.ConfigParser()
 cfg.read('../setup.cfg')
 tag = cfg.get('egg_info', 'tag_build')
 

--- a/docs/ext/rfc.py
+++ b/docs/ext/rfc.py
@@ -23,7 +23,7 @@ formatted like this::
 import re
 
 
-RFC_PATTERN = re.compile('RFC (\d{4}), Section ([\d\.]+)')
+RFC_PATTERN = re.compile(r'RFC (\d{4}), Section ([\d\.]+)')
 
 
 def _render_section(section_number, rfc_number):

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -530,11 +530,13 @@ class WebSocketOptions:
 
     __slots__ = ['error_close_code', 'max_receive_queue', 'media_handlers']
 
-    def __init__(self):
+    def __init__(self) -> None:
         try:
             import msgpack
         except ImportError:
             msgpack = None
+
+        bin_handler: media.BinaryBaseHandlerWS
 
         if msgpack:
             bin_handler = media.MessagePackHandlerWS()

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -6,6 +6,7 @@ from falcon.constants import MEDIA_JSON
 from falcon.constants import MEDIA_MULTIPART
 from falcon.constants import MEDIA_URLENCODED
 from falcon.constants import PYPY
+from falcon.media.base import BinaryBaseHandlerWS
 from falcon.media.json import JSONHandler
 from falcon.media.multipart import MultipartFormHandler
 from falcon.media.multipart import MultipartParseOptions
@@ -15,7 +16,7 @@ from falcon.util import misc
 from falcon.vendor import mimeparse
 
 
-class MissingDependencyHandler:
+class MissingDependencyHandler(BinaryBaseHandlerWS):
     """Placeholder handler that always raises an error.
 
     This handler is used by the framework for media types that require an

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -451,12 +451,11 @@ class ASGIWebSocketSimulator:
             await asyncio.wait_for(self._event_handshake_complete.wait(), timeout)
         except asyncio.TimeoutError:
             msg = (
-                'Timed out after waiting {} seconds for '
-                'the WebSocket handshake to complete. Check the '
-                'on_websocket responder and '
-                'any middleware for any conditions that may be stalling the '
-                'request flow.'
-            ).format(timeout)
+                f'Timed out after waiting {timeout} seconds for the WebSocket '
+                f'handshake to complete. Check the on_websocket responder and '
+                f'any middleware for any conditions that may be stalling the '
+                f'request flow.'
+            )
             raise asyncio.TimeoutError(msg)
 
         self._require_accepted()

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -402,6 +402,8 @@ class ASGIWebSocketSimulator:
             ``None`` if the connection has not been accepted.
     """
 
+    _DEFAULT_WAIT_READY_TIMEOUT = 5
+
     def __init__(self):
         self.__msgpack = None
 
@@ -435,7 +437,7 @@ class ASGIWebSocketSimulator:
     def headers(self) -> Iterable[Iterable[bytes]]:
         return self._accepted_headers
 
-    async def wait_ready(self, timeout: Optional[int] = 5):
+    async def wait_ready(self, timeout: Optional[int] = None):
         """Wait until the connection has been accepted or denied.
 
         This coroutine can be awaited in order to pause execution until the
@@ -446,6 +448,8 @@ class ASGIWebSocketSimulator:
             timeout (int): Number of seconds to wait before giving up and
                 raising an error (default: ``5``).
         """
+
+        timeout = timeout or self._DEFAULT_WAIT_READY_TIMEOUT
 
         try:
             await asyncio.wait_for(self._event_handshake_complete.wait(), timeout)


### PR DESCRIPTION
Closes #2179

An example of a passing CI gate: https://github.com/falconry/falcon/actions/runs/7160503496/job/19494950553.
