### PR TITLE
chore: update to latest Redis (aioredis is deprecated)

### DIFF
--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -859,7 +859,7 @@ any problems with importing local utility modules or checking code coverage::
   $ mkdir -p tests
   $ touch tests/__init__.py
 
-Next, let's implement fixtures to replace ``uuid`` and ``aioredis``, and inject them
+Next, let's implement fixtures to replace ``uuid`` and ``redis``, and inject them
 into our tests via ``conftest.py`` (place your code in the newly created ``tests``
 directory):
 

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -685,10 +685,10 @@ small files littering our storage, it consumes CPU resources, and we would
 soon find our application crumbling under load.
 
 Let's mitigate this problem with response caching. We'll use Redis, taking
-advantage of `aioredis <https://github.com/aio-libs/aioredis>`_ for async
+advantage of `redis <https://redis.readthedocs.io/en/stable/examples/asyncio_examples.html>`_ for async
 support::
 
-  pip install aioredis
+  pip install redis
 
 We will also need to serialize response data (the ``Content-Type`` header and
 the body in the first version); ``msgpack`` should do::
@@ -700,7 +700,7 @@ installing Redis server on your machine, one could also:
 
 * Spin up Redis in Docker, eg::
 
-    docker run -p 6379:6379 redis
+    docker run -p 6379:6379 redis/redis-stack:latest
 
 * Assuming Redis is installed on the machine, one could also try
   `pifpaf <https://github.com/jd/pifpaf>`_ for spinning up Redis just
@@ -747,9 +747,8 @@ implementations for production and testing.
     ``self.redis_host``. Such a design might prove helpful for apps that
     need to create client connections in more than one place.
 
-Assuming we call our new :ref:`configuration <asgi_tutorial_config>` items
-``redis_host`` and ``redis_from_url()``, respectively, the final version of
-``config.py`` now reads:
+Assuming we call our new :ref:`configuration <asgi_tutorial_config>` item
+``redis_host`` the final version of ``config.py`` now reads:
 
 .. literalinclude:: ../../examples/asgilook/asgilook/config.py
     :language: python

--- a/examples/asgilook/asgilook/cache.py
+++ b/examples/asgilook/asgilook/cache.py
@@ -1,4 +1,5 @@
 import msgpack
+import redis.asyncio as redis
 
 
 class RedisCache:
@@ -24,7 +25,7 @@ class RedisCache:
         await self._redis.ping()
 
     async def process_shutdown(self, scope, event):
-        await self._redis.close()
+        await self._redis.aclose()
 
     async def process_request(self, req, resp):
         resp.context.cached = False

--- a/examples/asgilook/asgilook/config.py
+++ b/examples/asgilook/asgilook/config.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import uuid
 
+
 def from_url_wrapper(url):
     pool = redis.ConnectionPool.from_url(url)
     return redis.Redis.from_pool(pool)

--- a/examples/asgilook/asgilook/config.py
+++ b/examples/asgilook/asgilook/config.py
@@ -2,15 +2,17 @@ import os
 import pathlib
 import uuid
 
-import aioredis
+def from_url_wrapper(url):
+    pool = redis.ConnectionPool.from_url(url)
+    return redis.Redis.from_pool(pool)
 
 
 class Config:
     DEFAULT_CONFIG_PATH = '/tmp/asgilook'
     DEFAULT_MIN_THUMB_SIZE = 64
     DEFAULT_REDIS_HOST = 'redis://localhost'
-    DEFAULT_REDIS_FROM_URL = aioredis.from_url
     DEFAULT_UUID_GENERATOR = uuid.uuid4
+    DEFAULT_REDIS_FROM_URL = from_url_wrapper
 
     def __init__(self):
         self.storage_path = pathlib.Path(
@@ -18,7 +20,7 @@ class Config:
         )
         self.storage_path.mkdir(parents=True, exist_ok=True)
 
-        self.redis_from_url = Config.DEFAULT_REDIS_FROM_URL
         self.min_thumb_size = self.DEFAULT_MIN_THUMB_SIZE
+        self.redis_from_url = Config.DEFAULT_REDIS_FROM_URL
         self.redis_host = self.DEFAULT_REDIS_HOST
         self.uuid_generator = Config.DEFAULT_UUID_GENERATOR

--- a/examples/asgilook/asgilook/config.py
+++ b/examples/asgilook/asgilook/config.py
@@ -1,19 +1,15 @@
 import os
 import pathlib
+import redis.asyncio
 import uuid
-
-
-def from_url_wrapper(url):
-    pool = redis.ConnectionPool.from_url(url)
-    return redis.Redis.from_pool(pool)
 
 
 class Config:
     DEFAULT_CONFIG_PATH = '/tmp/asgilook'
     DEFAULT_MIN_THUMB_SIZE = 64
+    DEFAULT_REDIS_FROM_URL = redis.asyncio.from_url
     DEFAULT_REDIS_HOST = 'redis://localhost'
     DEFAULT_UUID_GENERATOR = uuid.uuid4
-    DEFAULT_REDIS_FROM_URL = from_url_wrapper
 
     def __init__(self):
         self.storage_path = pathlib.Path(

--- a/examples/asgilook/requirements/asgilook
+++ b/examples/asgilook/requirements/asgilook
@@ -1,4 +1,4 @@
 aiofiles>=0.4.0
-aioredis>=2.0
+redis>=5.0
 msgpack
 Pillow>=6.0.0


### PR DESCRIPTION
As of Feb 21, 2023 aioredis-py was archived. See the package repo here:
https://github.com/aio-libs-abandoned/aioredis-py

# Summary of Changes

A docs update to correct the ASGI doc to use the latest version of Redis and swap the `aioredis` package for the `redis` package since `aioredis` is now included within `redis`.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [X ] Added **tests** for changed code.
- [ X] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ X] Coding style is consistent with the rest of the framework.
- [ X] Updated **documentation** for changed code.
    - [X ] Added docstrings for any new classes, functions, or modules.
    - [ X] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ X] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

