### PR TITLE
chore(sync): use `asyncio.Runner` for `async_to_sync()` on py311+

### DIFF
--- a/falcon/util/sync.py
+++ b/falcon/util/sync.py
@@ -236,11 +236,12 @@ def async_to_sync(
     Keyword Args:
         **kwargs: Additional args are passed through to the coroutine function.
     """
+    global _runner
     # NOTE(vytas): Sometimes our runner's loop can get picked and consumed by
     #   other utilities and test methods. If that happens, recreate the runner.
-    global _runner
     if _runner.get_loop().is_closed():
-        _runner = _runner_cls()
+        # NOTE(vytas): This condition is never hit on _DummyRunner.
+        _runner = _runner_cls()  # pragma: nocover
     return _runner.run(coroutine(*args, **kwargs))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ filterwarnings = [
     "ignore:.cgi. is deprecated and slated for removal:DeprecationWarning",
     "ignore:path is deprecated\\. Use files\\(\\) instead:DeprecationWarning",
     "ignore:This process \\(.+\\) is multi-threaded",
-    "ignore:There is no current event loop",
 ]
 testpaths = [
     "tests"

--- a/requirements/tests
+++ b/requirements/tests
@@ -11,8 +11,7 @@ testtools; python_version < '3.10'
 pytest-asyncio < 0.22.0
 aiofiles
 httpx
-# TODO(vytas): Investigate: uvicorn 0.29.0 starts but then catches SIGTERM (?)
-uvicorn < 0.29.0
+uvicorn >= 0.17.0
 websockets
 
 # Handler Specific

--- a/requirements/tests
+++ b/requirements/tests
@@ -11,7 +11,8 @@ testtools; python_version < '3.10'
 pytest-asyncio < 0.22.0
 aiofiles
 httpx
-uvicorn >= 0.17.0
+# TODO(vytas): Investigate: uvicorn 0.29.0 starts but then catches SIGTERM (?)
+uvicorn < 0.29.0
 websockets
 
 # Handler Specific

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -28,7 +28,9 @@ _WIN32 = sys.platform.startswith('win')
 _SERVER_HOST = '127.0.0.1'
 _SIZE_1_KB = 1024
 _SIZE_1_MB = _SIZE_1_KB**2
-
+# NOTE(vytas): Windows specific: {Application Exit by CTRL+C}.
+#   The application terminated as a result of a CTRL+C.
+_STATUS_CONTROL_C_EXIT = 0xC000013A
 
 _REQUEST_TIMEOUT = 10
 
@@ -624,10 +626,7 @@ def server_base_url(request):
         # NOTE(vytas): Starting with 0.29.0, Uvicorn will propagate signal
         #   values into the return code (which is a good practice in Unix);
         #   see also https://github.com/encode/uvicorn/pull/1600
-        # TODO(vytas): Return codes are bananas on Windows, skip for now;
-        #   is there a reliable way to know which code to expect?
-        if not _WIN32:
-            assert server.returncode in (0, -signal.SIGTERM)
+        assert server.returncode in (0, -signal.SIGTERM, _STATUS_CONTROL_C_EXIT)
 
         break
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -4,6 +4,7 @@ import hashlib
 import os
 import platform
 import random
+import signal
 import subprocess
 import sys
 import time
@@ -620,7 +621,10 @@ def server_base_url(request):
 
             yield base_url
 
-        assert server.returncode == 0
+        # NOTE(vytas): Starting with 0.29.0, Uvicorn will propagate signal
+        #   values into the return code (which is a good practice in Unix);
+        #   see also https://github.com/encode/uvicorn/pull/1600
+        assert server.returncode in (0, -signal.SIGTERM)
 
         break
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -624,7 +624,10 @@ def server_base_url(request):
         # NOTE(vytas): Starting with 0.29.0, Uvicorn will propagate signal
         #   values into the return code (which is a good practice in Unix);
         #   see also https://github.com/encode/uvicorn/pull/1600
-        assert server.returncode in (0, -signal.SIGTERM)
+        # TODO(vytas): Return codes are bananas on Windows, skip for now;
+        #   is there a reliable way to know which code to expect?
+        if not _WIN32:
+            assert server.returncode in (0, -signal.SIGTERM)
 
         break
 

--- a/tests/asgi/test_scope.py
+++ b/tests/asgi/test_scope.py
@@ -70,7 +70,7 @@ def test_supported_asgi_version(version, supported):
     resp_event_collector = testing.ASGIResponseEventCollector()
 
     async def task():
-        coro = asyncio.get_event_loop().create_task(
+        coro = asyncio.get_running_loop().create_task(
             app(scope, req_event_emitter, resp_event_collector)
         )
 
@@ -142,7 +142,7 @@ def test_lifespan_scope_default_version():
     scope = {'type': 'lifespan'}
 
     async def t():
-        t = asyncio.get_event_loop().create_task(
+        t = asyncio.get_running_loop().create_task(
             app(scope, req_event_emitter, resp_event_collector)
         )
 
@@ -196,7 +196,7 @@ def test_lifespan_scope_version(spec_version, supported):
         return
 
     async def t():
-        t = asyncio.get_event_loop().create_task(
+        t = asyncio.get_running_loop().create_task(
             app(scope, req_event_emitter, resp_event_collector)
         )
 

--- a/tests/dump_asgi.py
+++ b/tests/dump_asgi.py
@@ -23,5 +23,5 @@ async def app(scope, receive, send):
         }
     )
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     loop.create_task(_say_hi())


### PR DESCRIPTION
Fixes #2178