### PR TITLE
chore(typing): add more descriptive typing to `Context`

### DIFF
--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -147,19 +147,13 @@ class Context:
     if TYPE_CHECKING:
 
         def __getattr__(self, name: str) -> Any:
-            try:
-                return self.__dict__[name]
-            except KeyError:
-                raise AttributeError(name) from None
+            ...
 
         def __setattr__(self, name: str, value: Any) -> None:
-            self.__dict__[name] = value
+            ...
 
         def __delattr__(self, name: str) -> None:
-            try:
-                del self.__dict__[name]
-            except KeyError:
-                raise AttributeError(name) from None
+            ...
 
     def __contains__(self, key: str) -> bool:
         return self.__dict__.__contains__(key)

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -37,6 +37,7 @@ from typing import Iterator
 from typing import KeysView
 from typing import Optional
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import ValuesView
 
 
@@ -140,6 +141,25 @@ class Context:
     >>> 'cache_strategy' in context
     True
     """
+
+    # NOTE(vytas): Define synthetic attr access methods (under TYPE_CHECKING)
+    #   merely to let mypy know this is a namespace object.
+    if TYPE_CHECKING:
+
+        def __getattr__(self, name: str) -> Any:
+            try:
+                return self.__dict__[name]
+            except KeyError:
+                raise AttributeError(name) from None
+
+        def __setattr__(self, name: str, value: Any) -> None:
+            self.__dict__[name] = value
+
+        def __delattr__(self, name: str) -> None:
+            try:
+                del self.__dict__[name]
+            except KeyError:
+                raise AttributeError(name) from None
 
     def __contains__(self, key: str) -> bool:
         return self.__dict__.__contains__(key)


### PR DESCRIPTION
This change affords arbitrary attribute access for `req.context` & `resp.context` in typed code without having to mask Mypy warnings similar to `error: "Context" has no attribute "..."`.