### PR TITLE
chore(tox): drop `--no-build-isolation` from Cython tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -170,60 +170,50 @@ commands = python "{toxinidir}/tools/clean.py" "{toxinidir}/falcon"
 # --------------------------------------------------------------------
 
 [with-cython]
+# NOTE(vytas): Specify Cython dep for tests/test_cython.py as PEP 517 build
+#   does not require it (although Tox seems to inject it in the current impl).
 deps = -r{toxinidir}/requirements/tests
        Cython
-       # NOTE(vytas): By using --no-build-isolation, we need to manage build
-       #   deps ourselves, and on CPython 3.12, it seems even setuptools
-       #   (our PEP 517 backend of choice) is not guaranteed to be there.
-       setuptools
-       wheel
 setenv =
     PIP_CONFIG_FILE={toxinidir}/pip.conf
     FALCON_DISABLE_CYTHON=
     FALCON_ASGI_WRAP_NON_COROUTINES=Y
     FALCON_TESTING_SESSION=Y
     PYTHONASYNCIODEBUG=1
-install_command = python -m pip install --no-build-isolation {opts} {packages}
 commands = pytest tests []
 
 [testenv:py37_cython]
 basepython = python3.7
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
 [testenv:py38_cython]
 basepython = python3.8
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
 [testenv:py39_cython]
 basepython = python3.9
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
 [testenv:py310_cython]
 basepython = python3.10
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
 [testenv:py311_cython]
 basepython = python3.11
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
 [testenv:py312_cython]
 basepython = python3.12
-install_command = {[with-cython]install_command}
 deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -214,7 +214,9 @@ commands = {[with-cython]commands}
 
 [testenv:py312_cython]
 basepython = python3.12
+# NOTE(vytas): pyximport relies on distutils.extension
 deps = {[with-cython]deps}
+       setuptools
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
@@ -223,7 +225,6 @@ commands = {[with-cython]commands}
 # --------------------------------------------------------------------
 
 [testenv:wsgi_servers]
-install_command = {[with-cython]install_command}
 setenv = {[with-cython]setenv}
 deps = {[with-cython]deps}
        gunicorn


### PR DESCRIPTION
Closes #2184
