### PR TITLE
chore(CI): pin `pytest` + ASGI tutorial fixes

### DIFF
--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -180,13 +180,12 @@ We can now implement a basic async image store. Save the following code as
 
 
     class Image:
-
         def __init__(self, config, image_id, size):
             self._config = config
 
             self.image_id = image_id
             self.size = size
-            self.modified = datetime.datetime.utcnow()
+            self.modified = datetime.datetime.now(datetime.timezone.utc)
 
         @property
         def path(self):
@@ -206,7 +205,6 @@ We can now implement a basic async image store. Save the following code as
 
 
     class Store:
-
         def __init__(self, config):
             self._config = config
             self._images = {}
@@ -272,7 +270,6 @@ of images. Place the code below in a file named ``images.py``:
 
 
     class Images:
-
         def __init__(self, config, store):
             self._config = config
             self._store = store

--- a/examples/asgilook/asgilook/store.py
+++ b/examples/asgilook/asgilook/store.py
@@ -13,7 +13,7 @@ class Image:
 
         self.image_id = image_id
         self.size = size
-        self.modified = datetime.datetime.utcnow()
+        self.modified = datetime.datetime.now(datetime.timezone.utc)
 
     @property
     def path(self):

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,5 +1,8 @@
 coverage >= 4.1
-pytest
+# TODO(vytas): Our use of testtools breaks under pytest 8.2 along the lines of
+#   https://github.com/pytest-dev/pytest/issues/12263, unpin when fixed
+#   (or drop support for testtools altogether?)
+pytest >= 7.0, < 8.2
 pyyaml
 requests
 # TODO(vytas): Check if testtools still brings anything to the table, and

--- a/tox.ini
+++ b/tox.ini
@@ -435,7 +435,6 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:look]
-basepython = python3.10
 deps =
     -r{toxinidir}/examples/look/requirements/test
 commands =
@@ -446,7 +445,7 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:asgilook]
-basepython = python3.10
+basepython = python3.12
 deps =
     -r{toxinidir}/examples/asgilook/requirements/asgilook
     -r{toxinidir}/examples/asgilook/requirements/test


### PR DESCRIPTION
It seems that something breaks when using `testtools.TestCase` under `pytest` 8.2.x along the lines of https://github.com/pytest-dev/pytest/issues/12263. This PR temporarily pins `pytest` until the issue is resolved upstream, or we decide on how we want to move forward with this. An alternative is to drop active support for `testtools` altogether: #2156.

Also patched is some typing import issue in ASGI tutorial tests. The issue seems to also stem from third party packages (`fakeredis`) under Python 3.10 that we had hardwired in the tox env by mistake. I'll file a followup issue, because this also means that our tutorial is not fully usable on 3.10 or older.