### PR TITLE
feat(Response): support Partitioned cookie attribute

### DIFF
--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -168,3 +168,23 @@ default, although this may change in a future release.
 When unsetting a cookie, :py:meth:`~falcon.Response.unset_cookie`,
 the default `SameSite` setting of the unset cookie is ``'Lax'``, but can be changed
 by setting the 'samesite' kwarg.
+
+The Partitioned Attribute
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Starting from Q1 2024, Google Chrome will start to `phaseout support for third-party
+cookies <https://developers.google.com/privacy-sandbox/3pcd/prepare/prepare-for-phaseout>`_.
+If your site is relying on cross-site cookies, it might be necessary to set the
+`Partitioned` attribute. `Partitioned` usually requires the `Secure` attribute
+to be set, but this is not enforced by Falcon.
+
+Currently, :py:meth:`~falcon.Response.set_cookie` does not set `Partitioned` automatically
+depending on other attributes (like `SameSite`), although this may change in a future release.
+
+.. note::
+
+    Similar to `SameSite`, the standard ``http.cookies`` module does not
+    support the `Partitioned` attribute yet and Falcon performs the same
+    monkey-patch as for `SameSite`.
+
+

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -347,6 +347,7 @@ class Response:
         secure=None,
         http_only=True,
         same_site=None,
+        partitioned=False,
     ):
         """Set a response cookie.
 
@@ -447,6 +448,14 @@ class Response:
 
                 (See also: `Same-Site RFC Draft`_)
 
+            partitioned (bool): Prevents cookies from being accessed from other
+                subdomains. With partitioned enabled, a cookie set by
+                https://3rd-party.example which is embedded inside
+                https://site-a.example can no longer be accessed by
+                https://site-b.example. While this attribute is not yet
+                standardized, it is already used by Chrome.
+
+                (See also: `Partitioned RFC Draft`_)
         Raises:
             KeyError: `name` is not a valid cookie name.
             ValueError: `value` is not a valid cookie value.
@@ -456,6 +465,9 @@ class Response:
 
         .. _Same-Site RFC Draft:
             https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1.2.7
+
+        .. _Partitioned RFC Draft:
+            https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies#section-2.1
 
         """
 
@@ -527,6 +539,9 @@ class Response:
                 )
 
             self._cookies[name]['samesite'] = same_site.capitalize()
+
+        if partitioned:
+            self._cookies[name]['partitioned'] = True
 
     def unset_cookie(self, name, samesite='Lax', domain=None, path=None):
         """Unset a cookie in the response.

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -99,6 +99,11 @@ class Cookie:
             transmitted from the client via HTTPS.
         http_only (bool): Whether or not the cookie may only be
             included in unscripted requests from the client.
+        same_site (str): Specifies whether cookies are send in
+            cross-site requests. Possible values are 'Lax', 'Strict'
+            and 'None'. ``None`` if not specified.
+        partitioned (bool): Whether third-party cookies should be stored
+            with 2 keys.
     """
 
     def __init__(self, morsel):
@@ -113,6 +118,7 @@ class Cookie:
             'secure',
             'httponly',
             'samesite',
+            'partitioned',
         ):
             value = morsel[name.replace('_', '-')] or None
             setattr(self, '_' + name, value)
@@ -153,8 +159,12 @@ class Cookie:
         return bool(self._httponly)  # type: ignore[attr-defined]
 
     @property
-    def same_site(self) -> Optional[int]:
+    def same_site(self) -> Optional[str]:
         return self._samesite if self._samesite else None  # type: ignore[attr-defined]
+
+    @property
+    def partitioned(self) -> bool:
+        return bool(self._partitioned)  # type: ignore[attr-defined]
 
 
 class _ResultBase:

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -61,6 +61,10 @@ from falcon.util.time import TimezoneGMT
 _reserved_cookie_attrs = http_cookies.Morsel._reserved  # type: ignore
 if 'samesite' not in _reserved_cookie_attrs:  # pragma: no cover
     _reserved_cookie_attrs['samesite'] = 'SameSite'  # type: ignore
+# NOTE(m-mueller): Same for the 'partitioned' attribute that will
+#   probably be added in Python 3.13.
+if 'partitioned' not in _reserved_cookie_attrs:  # pragma: no cover
+    _reserved_cookie_attrs['partitioned'] = 'Partitioned'
 
 
 IS_64_BITS = sys.maxsize > 2**32

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -74,6 +74,13 @@ class CookieResourceSameSite:
         resp.set_cookie('baz', 'foo', same_site='')
 
 
+class CookieResourcePartitioned:
+    def on_get(self, req, resp):
+        resp.set_cookie('foo', 'bar', secure=True, partitioned=True)
+        resp.set_cookie('bar', 'baz', secure=True, partitioned=False)
+        resp.set_cookie('baz', 'foo', secure=True)
+
+
 class CookieUnset:
     def on_get(self, req, resp):
         resp.unset_cookie('foo')
@@ -103,6 +110,7 @@ def client(asgi):
     app.add_route('/', CookieResource())
     app.add_route('/test-convert', CookieResourceMaxAgeFloatString())
     app.add_route('/same-site', CookieResourceSameSite())
+    app.add_route('/partitioned', CookieResourcePartitioned())
     app.add_route('/unset-cookie', CookieUnset())
     app.add_route('/unset-cookie-same-site', CookieUnsetSameSite())
 
@@ -160,6 +168,7 @@ def test_response_complex_case(client):
     assert cookie.max_age == 300
     assert cookie.path is None
     assert cookie.secure
+    assert not cookie.partitioned
 
     cookie = result.cookies['bar']
     assert cookie.value == 'baz'
@@ -169,6 +178,7 @@ def test_response_complex_case(client):
     assert cookie.max_age is None
     assert cookie.path is None
     assert cookie.secure
+    assert not cookie.partitioned
 
     cookie = result.cookies['bad']
     assert cookie.value == ''  # An unset cookie has an empty value
@@ -511,3 +521,16 @@ def test_invalid_same_site_value(same_site):
 
     with pytest.raises(ValueError):
         resp.set_cookie('foo', 'bar', same_site=same_site)
+
+
+def test_partitioned_value(client):
+    result = client.simulate_get('/partitioned')
+
+    cookie = result.cookies['foo']
+    assert cookie.partitioned
+
+    cookie = result.cookies['bar']
+    assert not cookie.partitioned
+
+    cookie = result.cookies['baz']
+    assert not cookie.partitioned


### PR DESCRIPTION
# Summary of Changes

Allow to set the Partitioned attribute in cookies. Default is not setting it.
The changes are very similar to the changes required for the SameSite attribute.

# Related Issues

#2213

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
