### PR TITLE
docs(user, util): address broken links

### DIFF
--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -56,7 +56,7 @@ However, as of Falcon 4.0+, these aliases are identical to their :mod:`asyncio`
 counterparts on all supported Python versions. (They are only kept for
 compatibility purposes.)
 
-Simply use :func:`asyncio.get_running_loop` & :func:`asyncio.create_task`
+Simply use :func:`asyncio.get_running_loop` or :func:`asyncio.create_task`
 directly in new code.
 
 Adapters

--- a/docs/api/util.rst
+++ b/docs/api/util.rst
@@ -45,11 +45,19 @@ Async
 Aliases
 ~~~~~~~
 
-These functions provide simple aliases for those implemented in :any:`asyncio`, with
-fallbacks for older versions of Python.
+Falcon used to provide aliases for the below functions implemented in
+:mod:`asyncio`, with fallbacks for older versions of Python:
 
-.. autofunction:: falcon.get_running_loop
-.. autofunction:: falcon.create_task
+* ``falcon.get_running_loop()`` → :func:`asyncio.get_running_loop`
+
+* ``falcon.create_task(coro, *, name=None)``  → :func:`asyncio.create_task`
+
+However, as of Falcon 4.0+, these aliases are identical to their :mod:`asyncio`
+counterparts on all supported Python versions. (They are only kept for
+compatibility purposes.)
+
+Simply use :func:`asyncio.get_running_loop` & :func:`asyncio.create_task`
+directly in new code.
 
 Adapters
 ~~~~~~~~

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -79,7 +79,7 @@ include:
 
 * `Uvicorn <https://www.uvicorn.org/>`_
 * `Daphne <https://github.com/django/daphne/>`_
-* `Hypercorn <https://pgjones.gitlab.io/hypercorn/>`_
+* `Hypercorn <https://github.com/pgjones/hypercorn/>`_
 
 For a simple tutorial application like ours, any of the above should do.
 Let's pick the popular ``uvicorn`` for now::


### PR DESCRIPTION
The broken link itself has been discovered by @e-io.
~~I haven't been able to find what inserts the `_asyncio` module in the index. But it isn't easy to find that index anyway, is it?~~
**Edit**: I've found the culprit for that `_asyncio` in the index. We had aliased functions directly from the stdlib, so I went on to soft-deprecate them for now. I'll create an issue to deprecate them (but there is probably no rush to do so.)