### PR TITLE
chore(CI): restore GNU Mailman integration tests gate

### DIFF
--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -3,15 +3,7 @@ name: Run tests (GNU Mailman 3)
 on:
   # Trigger the workflow on master but also allow it to run manually.
   workflow_dispatch:
-
-  # NOTE(vytas): Disabled as it is failing as of 2023-09.
-  #   Maybe @maxking just needs to update the Docker image (?)
-  # push:
-  #   branches:
-  #     - master
-
-  # TODO(vytas): Remove once we are happy with the PR.
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/tests-mailman.yaml
+++ b/.github/workflows/tests-mailman.yaml
@@ -10,6 +10,11 @@ on:
   #   branches:
   #     - master
 
+  # TODO(vytas): Remove once we are happy with the PR.
+  pull_request:
+    branches:
+      - master
+
 jobs:
   run_tox:
     name: tox -e falcon-nocov

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -19,14 +19,11 @@ cd $MAILMAN_PATH
 # git checkout tags/$MAILMAN_VERSION
 
 # NOTE(vytas): Patch tox.ini to introduce a new Falcon environment.
-# TODO(vytas): Remove the shim pinning importlib-resources once
-#   https://gitlab.com/mailman/mailman/-/merge_requests/1130 is merged upstream.
 cat <<EOT >> tox.ini
 
 [testenv:falcon-nocov]
-basepython = python3.10
+basepython = python3.12
 commands_pre =
-    pip install "importlib-resources < 6.0"
     pip uninstall -y falcon
     pip install $FALCON_ROOT
 EOT

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -24,7 +24,7 @@ cd $MAILMAN_PATH
 cat <<EOT >> tox.ini
 
 [testenv:falcon-nocov]
-basepython = python3.8
+basepython = python3.10
 commands_pre =
     pip install "importlib-resources < 6.0"
     pip uninstall -y falcon


### PR DESCRIPTION
Thanks @maxking for maintaining a special Docker image for us. The gate is green again now.