### PR TITLE
chore: remove python 3.7 support

### DIFF
--- a/.github/workflows/create-wheels.yaml
+++ b/.github/workflows/create-wheels.yaml
@@ -24,8 +24,6 @@ jobs:
           - "windows-latest"
           - "macos-latest"
         python-version:
-          - "3.6"
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -95,7 +93,6 @@ jobs:
           - "ubuntu-latest"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
-          - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310
@@ -227,7 +224,6 @@ jobs:
           - "ubuntu-latest"
         python-version:
           # the versions are <python tag>-<abi tag> as specified in PEP 425.
-          - cp37-cp37m
           - cp38-cp38
           - cp39-cp39
           - cp310-cp310

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,9 +52,6 @@ jobs:
           - python-version: pypy3.9
             os: ubuntu-latest
             toxenv: pypy3
-          - python-version: "3.7"
-            os: ubuntu-latest
-            toxenv: py37
           - python-version: "3.8"
             os: ubuntu-latest
             toxenv: py38

--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic HTTP error responses
 - Straightforward exception handling
 - Snappy testing with WSGI/ASGI helpers and mocks
-- CPython 3.7+ and PyPy 3.7+ support
+- CPython 3.8+ and PyPy 3.8+ support
 
 .. Patron list starts here. For Python package, we substitute this section with:
    Support Falcon Development
@@ -210,7 +210,7 @@ PyPy
 ^^^^
 
 `PyPy <http://pypy.org/>`__ is the fastest way to run your Falcon app.
-PyPy3.7+ is supported as of PyPy v7.3.4+.
+PyPy3.8+ is supported as of PyPy v7.3.7+.
 
 .. code:: bash
 
@@ -226,7 +226,7 @@ CPython
 ^^^^^^^
 
 Falcon also fully supports
-`CPython <https://www.python.org/downloads/>`__ 3.7+.
+`CPython <https://www.python.org/downloads/>`__ 3.8+.
 
 The latest stable version of Falcon can be installed directly from PyPI:
 

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ clean design that embraces HTTP and the REST architectural style.
 
 Falcon apps work with any `WSGI <https://www.python.org/dev/peps/pep-3333/>`_
 or `ASGI <https://asgi.readthedocs.io/en/latest/>`_ server, and run like a
-champ under CPython 3.7+ and PyPy 3.7+.
+champ under CPython 3.8+ and PyPy 3.8+.
 
 Quick Links
 -----------

--- a/docs/changes/4.0.0.rst
+++ b/docs/changes/4.0.0.rst
@@ -15,10 +15,9 @@ Changes to Supported Platforms
 - CPython 3.11 is now fully supported. (`#2072 <https://github.com/falconry/falcon/issues/2072>`__)
 - CPython 3.12 is now fully supported. (`#2196 <https://github.com/falconry/falcon/issues/2196>`__)
 - CPython 3.13 is now fully supported. (`#2258 <https://github.com/falconry/falcon/issues/2258>`__)
-- End-of-life Python 3.5 & 3.6 are no longer supported. (`#2074 <https://github.com/falconry/falcon/pull/2074>`__)
-- End-of-life Python 3.7 and (soon end-of-life) 3.8 are no longer actively
-  supported, but the framework should still continue to install from source and
-  function.
+- End-of-life Python 3.5 & 3.6 & 3.7 are no longer supported. (`#2074 <https://github.com/falconry/falcon/pull/2074>`__, `#2273 <https://github.com/falconry/falcon/pull/2273>`__)
+- Soon end-of-life Python 3.8 is no longer actively supported, but
+  the framework should still continue to install from source and function.
 - The Falcon 4.x series is guaranteed to support CPython 3.10 and
   PyPy3.10 (v7.3.16).
   This means that we may drop the support for Python 3.7-3.9 altogether in a

--- a/docs/changes/4.0.0.rst
+++ b/docs/changes/4.0.0.rst
@@ -15,12 +15,12 @@ Changes to Supported Platforms
 - CPython 3.11 is now fully supported. (`#2072 <https://github.com/falconry/falcon/issues/2072>`__)
 - CPython 3.12 is now fully supported. (`#2196 <https://github.com/falconry/falcon/issues/2196>`__)
 - CPython 3.13 is now fully supported. (`#2258 <https://github.com/falconry/falcon/issues/2258>`__)
-- End-of-life Python 3.5 & 3.6 & 3.7 are no longer supported. (`#2074 <https://github.com/falconry/falcon/pull/2074>`__, `#2273 <https://github.com/falconry/falcon/pull/2273>`__)
+- End-of-life Python 3.5, 3.6 & 3.7 are no longer supported. (`#2074 <https://github.com/falconry/falcon/pull/2074>`__, `#2273 <https://github.com/falconry/falcon/pull/2273>`__)
 - Soon end-of-life Python 3.8 is no longer actively supported, but
   the framework should still continue to install from source and function.
 - The Falcon 4.x series is guaranteed to support CPython 3.10 and
   PyPy3.10 (v7.3.16).
-  This means that we may drop the support for Python 3.7-3.9 altogether in a
+  This means that we may drop the support for Python 3.8 & 3.9 altogether in a
   later 4.x release, especially if we are faced with incompatible ecosystem
   changes in typing, Cython, etc.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,7 +94,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic :ref:`HTTP error <errors>` responses
 - Straightforward exception handling
 - Snappy :ref:`testing <testing>` with WSGI/ASGI helpers and mocks
-- CPython 3.7+ and PyPy 3.7+ support
+- CPython 3.8+ and PyPy 3.8+ support
 
 Who's Using Falcon?
 -------------------

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -7,7 +7,7 @@ PyPy
 ----
 
 `PyPy <http://pypy.org/>`__ is the fastest way to run your Falcon app.
-PyPy3.7+ is supported as of PyPy v7.3.4.
+PyPy3.8+ is supported as of PyPy v7.3.7.
 
 .. code:: bash
 
@@ -23,7 +23,7 @@ CPython
 -------
 
 Falcon fully supports
-`CPython <https://www.python.org/downloads/>`__ 3.7+.
+`CPython <https://www.python.org/downloads/>`__ 3.8+.
 
 The latest stable version of Falcon can be installed directly from PyPI:
 

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -15,7 +15,7 @@ architectural style, and tries to do as little as possible while
 remaining highly effective.
 
 Falcon apps work with any WSGI server, and run like a champ under
-CPython 3.7+ and PyPy 3.7+.
+CPython 3.8+ and PyPy 3.8+.
 
 Features
 --------
@@ -35,7 +35,7 @@ Falcon tries to do as little as possible while remaining highly effective.
 - Idiomatic :ref:`HTTP error <errors>` responses
 - Straightforward exception handling
 - Snappy :ref:`testing <testing>` with WSGI/ASGI helpers and mocks
-- CPython 3.7+ and PyPy 3.7+ support
+- CPython 3.8+ and PyPy 3.8+ support
 
 How is Falcon different?
 ------------------------

--- a/docs/user/recipes/request-id.rst
+++ b/docs/user/recipes/request-id.rst
@@ -48,4 +48,4 @@ In a pinch, you can also output the request ID directly:
 .. literalinclude:: ../../../examples/recipes/request_id_log.py
     :language: python
 
-.. _thread-local: https://docs.python.org/3.7/library/threading.html#thread-local-data
+.. _thread-local: https://docs.python.org/3/library/threading.html#thread-local-data

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -32,7 +32,7 @@ WSGI tutorial::
       └── app.py
 
 We'll create a *virtualenv* using the ``venv`` module from the standard library
-(Falcon requires Python 3.7+)::
+(Falcon requires Python 3.8+)::
 
   $ mkdir asgilook
   $ python3 -m venv asgilook/.venv

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -30,12 +30,12 @@ PYPY = sys.implementation.name == 'pypy'
 PYTHON_VERSION = tuple(sys.version_info[:3])
 """Python version information triplet: (major, minor, micro)."""
 
-FALCON_SUPPORTED = PYTHON_VERSION >= (3, 7, 0)
+FALCON_SUPPORTED = PYTHON_VERSION >= (3, 8, 0)
 """Whether this version of Falcon supports the current Python version."""
 
 if not FALCON_SUPPORTED:  # pragma: nocover
     raise ImportError(
-        'Falcon requires Python 3.7+. '
+        'Falcon requires Python 3.8+. '
         '(Recent Pip should automatically pick a suitable Falcon version.)'
     )
 

--- a/falcon/cyutil/misc.pyx
+++ b/falcon/cyutil/misc.pyx
@@ -13,33 +13,6 @@
 # limitations under the License.
 
 
-def isascii(unicode string not None):
-    """Return ``True`` if all characters in the string are ASCII.
-
-    ASCII characters have code points in the range U+0000-U+007F.
-
-    Note:
-        On Python 3.7+, this function is just aliased to ``str.isascii``.
-
-    This is a Cython fallback for older CPython versions. For longer strings,
-    it is slightly less performant than the built-in ``str.isascii``.
-
-    Args:
-        string (str): A string to test.
-
-    Returns:
-        ``True`` if all characters are ASCII, ``False`` otherwise.
-    """
-
-    cdef Py_UCS4 ch
-
-    for ch in string:
-        if ch > 0x007F:
-            return False
-
-    return True
-
-
 def encode_items_to_latin1(dict data not None):
     cdef list result = []
     cdef unicode key

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -32,7 +32,6 @@ from falcon.media import Handlers
 from falcon.media.json import _DEFAULT_JSON_HANDLER
 from falcon.stream import BoundedStream
 from falcon.util import structures
-from falcon.util.misc import isascii
 from falcon.util.uri import parse_host
 from falcon.util.uri import parse_query_string
 from falcon.vendor import mimeparse
@@ -489,7 +488,7 @@ class Request:
 
         # perf(vytas): Only decode the tunnelled path in case it is not ASCII.
         #   For ASCII-strings, the below decoding chain is a no-op.
-        if not isascii(path):
+        if not path.isascii():
             path = path.encode('iso-8859-1').decode('utf-8', 'replace')
 
         if (

--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -15,7 +15,6 @@
 """Utilities for the Response class."""
 
 from falcon.util import uri
-from falcon.util.misc import isascii
 from falcon.util.misc import secure_filename
 
 
@@ -91,7 +90,7 @@ def format_content_disposition(value, disposition_type='attachment'):
     # NOTE(vytas): RFC 6266, Appendix D.
     #   Include a "filename" parameter when US-ASCII ([US-ASCII]) is
     #   sufficiently expressive.
-    if isascii(value):
+    if value.isascii():
         return '%s; filename="%s"' % (disposition_type, value)
 
     # NOTE(vytas): RFC 6266, Appendix D.

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -44,12 +44,6 @@ try:
 except ImportError:
     _cy_encode_items_to_latin1 = None
 
-try:
-    from falcon.cyutil.misc import isascii as _cy_isascii
-except ImportError:
-    _cy_isascii = None
-
-
 __all__ = (
     'is_python_func',
     'deprecated',
@@ -506,30 +500,8 @@ def _encode_items_to_latin1(data: Dict[str, str]) -> List[Tuple[bytes, bytes]]:
     return result
 
 
-def _isascii(string: str) -> bool:
-    """Return ``True`` if all characters in the string are ASCII.
-
-    ASCII characters have code points in the range U+0000-U+007F.
-
-    Note:
-        On Python 3.7+, this function is just aliased to ``str.isascii``.
-
-    This is a pure-Python fallback for older CPython (where Cython is
-    unavailable) and PyPy versions.
-
-    Args:
-        string (str): A string to test.
-
-    Returns:
-        ``True`` if all characters are ASCII, ``False`` otherwise.
-    """
-
-    try:
-        string.encode('ascii')
-        return True
-    except ValueError:
-        return False
-
-
 _encode_items_to_latin1 = _cy_encode_items_to_latin1 or _encode_items_to_latin1
-isascii = getattr(str, 'isascii', _cy_isascii or _isascii)
+
+isascii = deprecated('This will be removed in V5. Please use `str.isascii`')(
+    str.isascii
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@
 [tool.black]
     # this is kept to avoid reformatting all the code if one were to
     # inadvertently run black on the project
-    target-version = ["py37"]
+    target-version = ["py38"]
     skip-string-normalization = true
     line-length = 88
     extend-exclude = "falcon/vendor"
@@ -100,12 +100,12 @@
     # NOTE(vytas): Before switching to Ruff, Falcon used the Blue formatter.
     #   With the below settings, accidentally running blue should yield
     #   only minor cosmetic changes in a handful of files.
-    target-version = ["py37"]
+    target-version = ["py38"]
     line-length = 88
     extend-exclude = "falcon/vendor"
 
 [tool.ruff]
-    target-version = "py37"
+    target-version = "py38"
     format.quote-style = "single"
     line-length = 88
     extend-exclude = ["falcon/vendor"]

--- a/requirements/tests
+++ b/requirements/tests
@@ -28,6 +28,3 @@ python-rapidjson; platform_machine != 's390x' and platform_machine != 'aarch64'
 
 # wheels are missing some EoL interpreters and non-x86 platforms; build would fail unless rust is available
 orjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
-
-# Images for 3.7 on emulated architectures seem to only have OpenSSL 1.0.2
-urllib3 < 2.0; python_version <= '3.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -53,7 +52,7 @@ project_urls =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
 tests_require =
     testtools

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ project_urls =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >=3.8
+python_requires = 3.8
 install_requires =
 tests_require =
     testtools

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ project_urls =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = 3.8
+python_requires = >=3.8
 install_requires =
 tests_require =
     testtools

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -645,25 +645,9 @@ class TestFalconUtils:
         with pytest.raises(ValueError):
             misc.secure_filename('')
 
-    @pytest.mark.parametrize(
-        'string,expected_ascii',
-        [
-            ('', True),
-            ('/', True),
-            ('/api', True),
-            ('/data/items/something?query=apples%20and%20oranges', True),
-            ('/food?item=ð\x9f\x8d\x94', False),
-            ('\x00\x00\x7f\x00\x00\x7f\x00', True),
-            ('\x00\x00\x7f\x00\x00\x80\x00', False),
-        ],
-    )
-    @pytest.mark.parametrize('method', ['isascii', '_isascii'])
-    def test_misc_isascii(self, string, expected_ascii, method):
-        isascii = getattr(misc, method)
-        if expected_ascii:
-            assert isascii(string)
-        else:
-            assert not isascii(string)
+    def test_misc_isascii(self):
+        with pytest.warns(DeprecationWarning):
+            assert misc.isascii('foobar')
 
 
 @pytest.mark.parametrize(
@@ -1427,9 +1411,6 @@ class TestDeprecatedArgs:
         assert 'a_function(...)' in str(recwarn[0].message)
 
 
-@pytest.mark.skipif(
-    falcon.PYTHON_VERSION < (3, 7), reason='module __getattr__ requires python 3.7'
-)
 def test_json_deprecation():
     with pytest.warns(deprecation.DeprecatedWarning, match='json'):
         util.json

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -646,7 +646,7 @@ class TestFalconUtils:
             misc.secure_filename('')
 
     def test_misc_isascii(self):
-        with pytest.warns(DeprecationWarning):
+        with pytest.warns(deprecation.DeprecatedWarning):
             assert misc.isascii('foobar')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -182,12 +182,6 @@ setenv =
     PYTHONASYNCIODEBUG=1
 commands = pytest tests []
 
-[testenv:py37_cython]
-basepython = python3.7
-deps = {[with-cython]deps}
-setenv = {[with-cython]setenv}
-commands = {[with-cython]commands}
-
 [testenv:py38_cython]
 basepython = python3.8
 deps = {[with-cython]deps}
@@ -471,7 +465,7 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:hug]
-basepython = python3.7
+basepython = python3.8
 deps = virtualenv
 commands =
      {toxinidir}/tools/testing/install_hug.sh


### PR DESCRIPTION
Drop python 3.7. The main reason is the lack of typing.Protocol, complicating typing introduction