### PR TITLE
chore(emulated): simplify emulated tests by reusing `cibuildwheel`

### DIFF
--- a/.github/workflows/tests-emulated.yaml
+++ b/.github/workflows/tests-emulated.yaml
@@ -6,17 +6,21 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove when review passes.
+  pull_request:
+    branches:
+      - master
 
 jobs:
-  run_tox_emulate:
-    name: tox -e py310_cython (${{ matrix.architecture }})
+  test-emulated:
+    name: "cibuildwheel: ${{ matrix.platform }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        architecture:
-          - s390x
-          - arm64v8
+        platform:
+          - "cp312-manylinux_aarch64"
+          - "cp312-manylinux_s390x"
 
     steps:
       - name: Checkout repo
@@ -24,60 +28,13 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Cache PIP
-        uses: actions/cache@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
         with:
-          path: |
-            .pip
-          key: python-${{ matrix.architecture }}-${{ hashFiles('requirements/tests') }}
+          platforms: all
 
-      - name: Set up emulation
-        run: |
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-
-      # TODO(vytas): Revisit second half of 2021 to see if we still need to pin tox
-      #
-      #   See also: https://github.com/tox-dev/tox/issues/1777
-      #
-      - name: Run tox s390x
-        if: ${{ matrix.architecture == 's390x' }}
-        uses: docker://s390x/python:3.10-buster
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.20.0
         env:
-          PIP_CACHE_DIR: /github/workspace/.pip/
-        with:
-          # NOTE: without 'pip install ujson' tox fails to install it with "Requested ujson from <url> has different version in metadata: '0.0.0'"
-          # NOTE(vytas): installing fixtures/pbr because otherwise pip install
-          # inside tox fails with an import error on some older CPythons
-          args: |
-            /bin/bash -c "
-            lscpu &&
-            mkdir -p $PIP_CACHE_DIR &&
-            chown -R $(whoami) $PIP_CACHE_DIR &&
-            pip install -U fixtures pip tox &&
-            python --version &&
-            pip --version &&
-            tox --version &&
-            pip install ujson &&
-            tox -e py310_cython"
-
-      - name: Run tox arm64v8
-        if: ${{ matrix.architecture == 'arm64v8' }}
-        uses: docker://arm64v8/python:3.10-buster
-        env:
-          PIP_CACHE_DIR: /github/workspace/.pip/
-        with:
-          args: |
-            /bin/bash -c "
-            lscpu &&
-            mkdir -p $PIP_CACHE_DIR &&
-            chown -R $(whoami) $PIP_CACHE_DIR &&
-            pip install -U fixtures pip tox &&
-            python --version &&
-            pip --version &&
-            tox --version &&
-            tox -e py310_cython"
-
-      - name: Fix cache permission
-        run: |
-          sudo chmod -R 777 .pip
-          sudo chmod -R 777 .tox
+          CIBW_ARCHS_LINUX: all
+          CIBW_BUILD: ${{ matrix.platform }}

--- a/.github/workflows/tests-emulated.yaml
+++ b/.github/workflows/tests-emulated.yaml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove when review passes.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:


### PR DESCRIPTION
A successful run has been demonstrated here: https://github.com/falconry/falcon/actions/runs/10465472709.