### PR TITLE
fix(multipart): don't share MultipartParseOptions._DEFAULT_HANDLERS

### DIFF
--- a/docs/_newsfragments/2293.bugfix.rst
+++ b/docs/_newsfragments/2293.bugfix.rst
@@ -1,0 +1,10 @@
+Customizing
+:attr:`MultipartParseOptions.media_handlers
+<falcon.media.multipart.MultipartParseOptions.media_handlers>` could previously
+lead to unintentionally modifying a shared class variable.
+This has been fixed, and the
+:attr:`~falcon.media.multipart.MultipartParseOptions.media_handlers` attribute
+is now initialized to a fresh copy of handlers for every instance of
+:class:`~falcon.media.multipart.MultipartParseOptions`. To that end, a proper
+:meth:`~falcon.media.Handlers.copy` method has been implemented for the media
+:class:`~falcon.media.Handlers` class.

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -164,6 +164,20 @@ class Handlers(UserDict):
 
         return cast(ResolverMethod, resolve)
 
+    def copy(self) -> Handlers:
+        """Create a shallow copy of this instance of handlers.
+
+        The resulting copy contains the same keys and values, but it can be
+        customized separately without affecting the original object.
+
+        Returns:
+            A shallow copy of handlers.
+        """
+        # NOTE(vytas): In the unlikely case we are dealing with a subclass,
+        #   return the matching type.
+        handlers_cls = type(self)
+        return handlers_cls(self.data)
+
     @deprecation.deprecated(
         'This undocumented method is no longer supported as part of the public '
         'interface and will be removed in a future release.'

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -172,6 +172,8 @@ class Handlers(UserDict):
 
         Returns:
             A shallow copy of handlers.
+
+        .. versionadded:: 4.0
         """
         # NOTE(vytas): In the unlikely case we are dealing with a subclass,
         #   return the matching type.

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -610,4 +610,7 @@ class MultipartParseOptions:
         self.max_body_part_buffer_size = 1024 * 1024
         self.max_body_part_count = 64
         self.max_body_part_headers_size = 8192
+        # NOTE(myusko,vytas): Here we create a copy of _DEFAULT_HANDLERS in
+        #   order to prevent the modification of the class variable whenever
+        #   parse_options.media_handlers are customized.
         self.media_handlers = self._DEFAULT_HANDLERS.copy()

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -610,4 +610,4 @@ class MultipartParseOptions:
         self.max_body_part_buffer_size = 1024 * 1024
         self.max_body_part_count = 64
         self.max_body_part_headers_size = 8192
-        self.media_handlers = self._DEFAULT_HANDLERS
+        self.media_handlers = self._DEFAULT_HANDLERS.copy()

--- a/tests/test_media_multipart.py
+++ b/tests/test_media_multipart.py
@@ -858,6 +858,6 @@ def test_multipart_parse_options_default_handlers_unique():
 
     parse_options_one.media_handlers.pop(falcon.MEDIA_JSON)
 
-    assert id(parse_options_one.media_handlers) != id(parse_options_two.media_handlers)
+    assert parse_options_one.media_handlers is not parse_options_two.media_handlers
     assert len(parse_options_one.media_handlers) == 1
     assert len(parse_options_two.media_handlers) >= 2

--- a/tests/test_media_multipart.py
+++ b/tests/test_media_multipart.py
@@ -9,6 +9,7 @@ import falcon
 from falcon import media
 from falcon import testing
 from falcon.util import BufferedReader
+from falcon.media.multipart import MultipartParseOptions
 
 try:
     import msgpack
@@ -849,3 +850,14 @@ def test_deserialize_custom_media(custom_client):
 
     assert resp.status_code == 200
     assert resp.json == ['', '0x48']
+
+
+def test_multipart_parse_options_default_handlers_unique():
+    parse_options_one = MultipartParseOptions()
+    parse_options_two = MultipartParseOptions()
+
+    parse_options_one.media_handlers.pop(falcon.MEDIA_JSON)
+
+    assert id(parse_options_one.media_handlers) != id(parse_options_two.media_handlers)
+    assert len(parse_options_one.media_handlers) == 1
+    assert len(parse_options_two.media_handlers) >= 2

--- a/tests/test_media_multipart.py
+++ b/tests/test_media_multipart.py
@@ -8,8 +8,8 @@ import pytest
 import falcon
 from falcon import media
 from falcon import testing
-from falcon.util import BufferedReader
 from falcon.media.multipart import MultipartParseOptions
+from falcon.util import BufferedReader
 
 try:
     import msgpack


### PR DESCRIPTION
# Summary of Changes

Fix a problem, when MultipartParseOptions._DEFAULT_HANDLERS was shared between different instances

# Related Issues

Fixes #2293.

# Pull Request Checklist
- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
