### PR TITLE
refactor: restore `AttributeRemovedError` for `resp.body`

### DIFF
--- a/falcon/response.py
+++ b/falcon/response.py
@@ -210,6 +210,20 @@ class Response:
         self.status = value
 
     @property
+    def body(self) -> NoReturn:
+        raise AttributeRemovedError(
+            'The body attribute is no longer supported. '
+            'Please use the text attribute instead.'
+        )
+
+    @body.setter
+    def body(self, value: str) -> NoReturn:
+        raise AttributeRemovedError(
+            'The body attribute is no longer supported. '
+            'Please use the text attribute instead.'
+        )
+
+    @property
     def data(self) -> Optional[bytes]:
         """Byte string representing response content.
 

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -47,6 +47,17 @@ def test_add_link_removed(resp):
             resp.add_link('/things/1337', 'next')
 
 
+def test_body_removed(resp):
+    # NOTE(kgriffs): Ensure AttributeRemovedError inherits from AttributeError
+    for exc_type in (AttributeError, AttributeRemovedError):
+        with pytest.raises(exc_type):
+            resp.body = '{"message": "Hello, World!"}'
+
+    for exc_type in (AttributeError, AttributeRemovedError):
+        with pytest.raises(exc_type):
+            resp.body
+
+
 def test_response_attempt_to_set_read_only_headers(resp):
     resp.append_header('x-things1', 'thing-1')
     resp.append_header('x-things2', 'thing-2')


### PR DESCRIPTION
The blocked `resp.body` property was introduced in #2090, and then removed later in the 4.0 cycle by oversight.

It is extremely useful to have it, since otherwise setting `resp.body` in legacy code silently does nothing, and it is very hard to understand what is going on.
