### PR TITLE
refactor: tweak type annotations to make Pyright pass

### DIFF
--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -23,6 +23,8 @@ the framework's classes, functions, and variables::
     app = falcon.App()
 """
 
+import logging as _logging
+
 __all__ = (
     # API interface
     'API',
@@ -407,11 +409,6 @@ from falcon.hooks import after
 from falcon.hooks import before
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
-
-# NOTE(jkmnt): Moved logger to leaf module to avoid possible circular imports.
-# the _logging symbol is reexported too - maybe it was used by test or smth.
-from falcon.logger import _logger
-from falcon.logger import logging as _logging
 from falcon.middleware import CORSMiddleware
 from falcon.redirects import HTTPFound
 from falcon.redirects import HTTPMovedPermanently
@@ -644,3 +641,8 @@ from falcon.util import wrap_sync_to_async_unsafe
 
 # Package version
 from falcon.version import __version__  # NOQA: F401
+
+# NOTE(kgriffs): Only to be used internally on the rare occasion that we
+#   need to log something that we can't communicate any other way.
+_logger = _logging.getLogger('falcon')
+_logger.addHandler(_logging.NullHandler())

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -407,6 +407,11 @@ from falcon.hooks import after
 from falcon.hooks import before
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
+
+# NOTE(jkmnt): Moved logger to leaf module to avoid possible circular imports.
+# the _logging symbol is reexported too - maybe it was used by test or smth.
+from falcon.logger import _logger
+from falcon.logger import logging as _logging
 from falcon.middleware import CORSMiddleware
 from falcon.redirects import HTTPFound
 from falcon.redirects import HTTPMovedPermanently
@@ -637,10 +642,5 @@ from falcon.util import uri
 from falcon.util import wrap_sync_to_async
 from falcon.util import wrap_sync_to_async_unsafe
 
-# NOTE(jkmnt): Moved logger to leaf module to avoid possible circular imports.
-# the _logging symbol is reexported too - maybe it was used by test or smth.
-from falcon.logger import _logger, logging as _logging
-
 # Package version
 from falcon.version import __version__  # NOQA: F401
-

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -23,8 +23,6 @@ the framework's classes, functions, and variables::
     app = falcon.App()
 """
 
-import logging as _logging
-
 __all__ = (
     # API interface
     'API',
@@ -639,10 +637,10 @@ from falcon.util import uri
 from falcon.util import wrap_sync_to_async
 from falcon.util import wrap_sync_to_async_unsafe
 
+# NOTE(jkmnt): Moved logger to leaf module to avoid possible circular imports.
+# the _logging symbol is reexported too - maybe it was used by test or smth.
+from falcon.logger import _logger, logging as _logging
+
 # Package version
 from falcon.version import __version__  # NOQA: F401
 
-# NOTE(kgriffs): Only to be used internally on the rare occasion that we
-#   need to log something that we can't communicate any other way.
-_logger = _logging.getLogger('falcon')
-_logger.addHandler(_logging.NullHandler())

--- a/falcon/_typing.py
+++ b/falcon/_typing.py
@@ -164,6 +164,9 @@ AsgiProcessResourceMethod = Callable[
 AsgiProcessResponseMethod = Callable[
     ['AsgiRequest', 'AsgiResponse', Resource, bool], Awaitable[None]
 ]
+AsgiProcessStartupMethod = Callable[[Dict[str, Any], 'AsgiEvent'], Awaitable[None]]
+AsgiProcessShutdownMethod = Callable[[Dict[str, Any], 'AsgiEvent'], Awaitable[None]]
+
 AsgiProcessRequestWsMethod = Callable[['AsgiRequest', 'WebSocket'], Awaitable[None]]
 AsgiProcessResourceWsMethod = Callable[
     ['AsgiRequest', 'WebSocket', Resource, Dict[str, Any]], Awaitable[None]
@@ -172,7 +175,6 @@ ResponseCallbacks = Union[
     Tuple[Callable[[], None], Literal[False]],
     Tuple[Callable[[], Awaitable[None]], Literal[True]],
 ]
-
 
 # Routing
 

--- a/falcon/_typing.py
+++ b/falcon/_typing.py
@@ -104,6 +104,9 @@ class AsgiSinkCallable(Protocol):
 HeaderMapping = Mapping[str, str]
 HeaderIter = Iterable[Tuple[str, str]]
 HeaderArg = Union[HeaderMapping, HeaderIter]
+
+NarrowHeaderArg = Union[Dict[str,str], List[Tuple[str, str]]]
+
 ResponseStatus = Union[http.HTTPStatus, str, int]
 StoreArg = Optional[Dict[str, Any]]
 Resource = object
@@ -192,7 +195,7 @@ class FindMethod(Protocol):
 
 # Media
 class SerializeSync(Protocol):
-    def __call__(self, media: Any, content_type: Optional[str] = ...) -> bytes: ...
+    def __call__(self, media: object, content_type: Optional[str] = ...) -> bytes: ...
 
 
 DeserializeSync = Callable[[bytes], Any]

--- a/falcon/_typing.py
+++ b/falcon/_typing.py
@@ -32,6 +32,7 @@ from typing import (
     Optional,
     Pattern,
     Protocol,
+    Sequence,
     Tuple,
     TYPE_CHECKING,
     TypeVar,
@@ -105,7 +106,7 @@ HeaderMapping = Mapping[str, str]
 HeaderIter = Iterable[Tuple[str, str]]
 HeaderArg = Union[HeaderMapping, HeaderIter]
 
-NarrowHeaderArg = Union[Dict[str,str], List[Tuple[str, str]]]
+NarrowHeaderArg = Union[Mapping[str, str], Sequence[Tuple[str, str]]]
 
 ResponseStatus = Union[http.HTTPStatus, str, int]
 StoreArg = Optional[Dict[str, Any]]

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -1237,6 +1237,13 @@ class App:
             # NOTE(kgriffs): Heuristic to quickly check if stream is
             # file-like. Not perfect, but should be good enough until
             # proven otherwise.
+            #
+            # TODO(jkmnt): The checks like these are a perfect candidates for the Python 3.13 TypeIs guard.
+            # The TypeGuard of Python 3.10+ seems to fit too, though it narrows type only for the 'if' branch.
+            # Something like:
+            # def is_readable_io(stream) -> TypeIs[ReadableStream]:
+            #       return hasattr(stream, 'read')
+            #
             if hasattr(stream, 'read'):
                 if wsgi_file_wrapper is not None:
                     # TODO(kgriffs): Make block size configurable at the
@@ -1251,7 +1258,7 @@ class App:
                         self._STREAM_BLOCK_SIZE,
                     )
             else:
-                iterable = stream
+                iterable = cast(Iterable[bytes], stream)
 
             return iterable, None
 
@@ -1259,9 +1266,9 @@ class App:
 
     def _update_sink_and_static_routes(self) -> None:
         if self._sink_before_static_route:
-            self._sink_and_static_routes = tuple(self._sinks + self._static_routes)  # type: ignore[operator]
+            self._sink_and_static_routes = (*self._sinks, *self._static_routes)
         else:
-            self._sink_and_static_routes = tuple(self._static_routes + self._sinks)  # type: ignore[operator]
+            self._sink_and_static_routes = (*self._static_routes, *self._sinks)
 
 
 # TODO(myusko): This class is a compatibility alias, and should be removed

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -1237,9 +1237,9 @@ class App:
             # NOTE(kgriffs): Heuristic to quickly check if stream is
             # file-like. Not perfect, but should be good enough until
             # proven otherwise.
-            #
-            # TODO(jkmnt): The checks like these are a perfect candidates for the Python 3.13 TypeIs guard.
-            # The TypeGuard of Python 3.10+ seems to fit too, though it narrows type only for the 'if' branch.
+            # TODO(jkmnt): The checks like these are a perfect candidates for the
+            # Python 3.13 TypeIs guard. The TypeGuard of Python 3.10+ seems to fit too,
+            # though it narrows type only for the 'if' branch.
             # Something like:
             # def is_readable_io(stream) -> TypeIs[ReadableStream]:
             #       return hasattr(stream, 'read')

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -386,13 +386,13 @@ class CloseableStreamIterator:
     def close(self) -> None:
         close_maybe(self._stream)
 
-
-def close_maybe(stream: Any):
+# TODO(jkmnt): Move these to some other module, they don't belong here
+def close_maybe(stream: Any) -> None:
     close: Callable[[], None] | None = getattr(stream, 'close', None)
     if close:
         close()
 
-async def async_close_maybe(stream: Any):
+async def async_close_maybe(stream: Any) -> None:
     close: Callable[[], Awaitable[None]] | None = getattr(stream, 'close', None)
     if close:
         await close()

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -18,8 +18,6 @@ from __future__ import annotations
 
 from inspect import iscoroutinefunction
 from typing import (
-    Any,
-    Awaitable,
     Callable,
     Iterable,
     List,
@@ -395,17 +393,6 @@ class CloseableStreamIterator:
             return data
 
     def close(self) -> None:
-        close_maybe(self._stream)
-
-
-# TODO(jkmnt): Move these to some other module, they don't belong here
-def close_maybe(stream: Any) -> None:
-    close: Optional[Callable[[], None]] = getattr(stream, 'close', None)
-    if close:
-        close()
-
-
-async def async_close_maybe(stream: Any) -> None:
-    close: Optional[Callable[[], Awaitable[None]]] = getattr(stream, 'close', None)
-    if close:
-        await close()
+        close: Optional[Callable[[], None]] = getattr(self._stream, 'close', None)
+        if close:
+            close()

--- a/falcon/app_helpers.py
+++ b/falcon/app_helpers.py
@@ -17,7 +17,18 @@
 from __future__ import annotations
 
 from inspect import iscoroutinefunction
-from typing import Any, Awaitable, Callable, Iterable, List, Literal, Optional, overload, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    overload,
+    Tuple,
+    Union,
+)
 
 from falcon import util
 from falcon._typing import AsgiProcessRequestMethod as APRequest
@@ -386,13 +397,15 @@ class CloseableStreamIterator:
     def close(self) -> None:
         close_maybe(self._stream)
 
+
 # TODO(jkmnt): Move these to some other module, they don't belong here
 def close_maybe(stream: Any) -> None:
-    close: Callable[[], None] | None = getattr(stream, 'close', None)
+    close: Optional[Callable[[], None]] = getattr(stream, 'close', None)
     if close:
         close()
 
+
 async def async_close_maybe(stream: Any) -> None:
-    close: Callable[[], Awaitable[None]] | None = getattr(stream, 'close', None)
+    close: Optional[Callable[[], Awaitable[None]]] = getattr(stream, 'close', None)
     if close:
         await close()

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -37,6 +37,7 @@ from typing import (
     Union,
 )
 
+from falcon import _logger
 from falcon import constants
 from falcon import responders
 from falcon import routing
@@ -66,7 +67,6 @@ from falcon.errors import HTTPInternalServerError
 from falcon.errors import WebSocketDisconnected
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
-from falcon.logger import _logger
 from falcon.media.multipart import MultipartFormHandler
 from falcon.util import get_argnames
 from falcon.util.misc import is_python_func

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -773,10 +773,11 @@ class App(falcon.app.App):
             #   (c) async iterator
             #
 
-            if hasattr(stream, 'read'):
+            read_meth: Callable[[int], Awaitable[bytes]] | None = getattr(stream, 'read')
+            if read_meth:
                 try:
                     while True:
-                        data = await stream.read(self._STREAM_BLOCK_SIZE)
+                        data = await read_meth(self._STREAM_BLOCK_SIZE)
                         if data == b'':
                             break
                         else:
@@ -1006,6 +1007,7 @@ class App(falcon.app.App):
                 'The handler must be an awaitable coroutine function in order '
                 'to be used safely with an ASGI app.'
             )
+        assert handler
         handler_callable: AsgiErrorHandler = handler
 
         exception_tuple: Tuple[type[BaseException], ...]

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -773,7 +773,7 @@ class App(falcon.app.App):
             #   (c) async iterator
             #
 
-            read_meth: Callable[[int], Awaitable[bytes]] | None = getattr(stream, 'read')
+            read_meth: Callable[[int], Awaitable[bytes]] | None = getattr(stream, 'read', None)
             if read_meth:
                 try:
                     while True:

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -628,7 +628,7 @@ class WebSocketOptions:
 
     @classmethod
     def _init_default_close_reasons(cls) -> Dict[int, str]:
-        reasons = dict(cls._STANDARD_CLOSE_REASONS)
+        reasons: dict[int, str] = dict(cls._STANDARD_CLOSE_REASONS)
         for status_constant in dir(status_codes):
             if 'HTTP_100' <= status_constant < 'HTTP_599':
                 status_line = getattr(status_codes, status_constant)

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -19,6 +19,7 @@ from falcon.asgi_spec import EventType
 from falcon.asgi_spec import WSCloseCode
 from falcon.constants import WebSocketPayloadType
 from falcon.util import misc
+from falcon.response_helpers import _headers_to_items
 
 __all__ = ('WebSocket',)
 
@@ -210,15 +211,9 @@ class WebSocket:
                     'does not support accept headers.'
                 )
 
-            header_items = getattr(headers, 'items', None)
-            if callable(header_items):
-                headers_iterable: Iterable[tuple[str, str]] = header_items()
-            else:
-                headers_iterable = headers  # type: ignore[assignment]
-
             event['headers'] = parsed_headers = [
                 (name.lower().encode('ascii'), value.encode('ascii'))
-                for name, value in headers_iterable
+                for name, value in _headers_to_items(headers)
             ]
 
             for name, __ in parsed_headers:

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -5,7 +5,7 @@ import collections
 from enum import auto
 from enum import Enum
 import re
-from typing import Any, Deque, Dict, Iterable, Mapping, Optional, Tuple, Union
+from typing import Any, Deque, Dict, Mapping, Optional, Tuple, Union
 
 from falcon import errors
 from falcon import media
@@ -18,8 +18,8 @@ from falcon.asgi_spec import AsgiSendMsg
 from falcon.asgi_spec import EventType
 from falcon.asgi_spec import WSCloseCode
 from falcon.constants import WebSocketPayloadType
-from falcon.util import misc
 from falcon.response_helpers import _headers_to_items
+from falcon.util import misc
 
 __all__ = ('WebSocket',)
 

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -45,7 +45,7 @@ from falcon.util import deprecation
 from falcon.util.misc import dt_to_http
 
 if TYPE_CHECKING:
-    from falcon._typing import HeaderArg
+    from falcon._typing import NarrowHeaderArg
     from falcon.typing import Headers
 
 
@@ -270,7 +270,7 @@ class HTTPBadRequest(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ) -> None:
         super().__init__(
@@ -350,7 +350,7 @@ class HTTPUnauthorized(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         challenges: Optional[Iterable[str]] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
@@ -425,7 +425,7 @@ class HTTPForbidden(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -493,7 +493,7 @@ class HTTPNotFound(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -614,7 +614,7 @@ class HTTPMethodNotAllowed(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         headers = _load_headers(headers)
@@ -682,7 +682,7 @@ class HTTPNotAcceptable(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -752,7 +752,7 @@ class HTTPConflict(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -828,7 +828,7 @@ class HTTPGone(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -889,7 +889,7 @@ class HTTPLengthRequired(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -951,7 +951,7 @@ class HTTPPreconditionFailed(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1026,7 +1026,7 @@ class HTTPContentTooLarge(HTTPError):
         title: Optional[str] = None,
         description: Optional[str] = None,
         retry_after: RetryAfter = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ) -> None:
         super().__init__(
@@ -1104,7 +1104,7 @@ class HTTPUriTooLong(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1166,7 +1166,7 @@ class HTTPUnsupportedMediaType(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1242,7 +1242,7 @@ class HTTPRangeNotSatisfiable(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         headers = _load_headers(headers)
@@ -1309,7 +1309,7 @@ class HTTPUnprocessableEntity(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1368,7 +1368,7 @@ class HTTPLocked(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1426,7 +1426,7 @@ class HTTPFailedDependency(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1492,7 +1492,7 @@ class HTTPPreconditionRequired(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1563,7 +1563,7 @@ class HTTPTooManyRequests(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         retry_after: RetryAfter = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
@@ -1629,7 +1629,7 @@ class HTTPRequestHeaderFieldsTooLarge(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1701,7 +1701,7 @@ class HTTPUnavailableForLegalReasons(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1759,7 +1759,7 @@ class HTTPInternalServerError(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1824,7 +1824,7 @@ class HTTPNotImplemented(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1882,7 +1882,7 @@ class HTTPBadGateway(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -1956,7 +1956,7 @@ class HTTPServiceUnavailable(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         retry_after: RetryAfter = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
@@ -2016,7 +2016,7 @@ class HTTPGatewayTimeout(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -2080,7 +2080,7 @@ class HTTPVersionNotSupported(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -2142,7 +2142,7 @@ class HTTPInsufficientStorage(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -2201,7 +2201,7 @@ class HTTPLoopDetected(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -2272,7 +2272,7 @@ class HTTPNetworkAuthenticationRequired(HTTPError):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         super().__init__(
@@ -2328,7 +2328,7 @@ class HTTPInvalidHeader(HTTPBadRequest):
         msg: str,
         header_name: str,
         *,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         description = 'The value provided for the "{0}" header is invalid. {1}'
@@ -2384,7 +2384,7 @@ class HTTPMissingHeader(HTTPBadRequest):
         self,
         header_name: str,
         *,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ):
         description = 'The "{0}" header is required.'
@@ -2444,7 +2444,7 @@ class HTTPInvalidParam(HTTPBadRequest):
         msg: str,
         param_name: str,
         *,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ) -> None:
         description = 'The "{0}" parameter is invalid. {1}'
@@ -2502,7 +2502,7 @@ class HTTPMissingParam(HTTPBadRequest):
         self,
         param_name: str,
         *,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ) -> None:
         description = 'The "{0}" parameter is required.'
@@ -2601,7 +2601,7 @@ class MediaMalformedError(HTTPBadRequest):
     """
 
     def __init__(
-        self, media_type: str, **kwargs: Union[HeaderArg, HTTPErrorKeywordArguments]
+        self, media_type: str, **kwargs: Union[NarrowHeaderArg, HTTPErrorKeywordArguments]
     ):
         super().__init__(
             title='Invalid {0}'.format(media_type),
@@ -2672,7 +2672,7 @@ class MediaValidationError(HTTPBadRequest):
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
-        headers: Optional[HeaderArg] = None,
+        headers: Optional[NarrowHeaderArg] = None,
         **kwargs: HTTPErrorKeywordArguments,
     ) -> None:
         super().__init__(
@@ -2701,13 +2701,13 @@ class MultipartParseError(MediaMalformedError):
     """
 
     # NOTE(caselit): remove the description @property in MediaMalformedError
-    description = None
+    description = None # pyright: ignore[reportAssignmentType, reportGeneralTypeIssues]
 
     def __init__(
         self,
         *,
         description: Optional[str] = None,
-        **kwargs: Union[HeaderArg, HTTPErrorKeywordArguments],
+        **kwargs: Union[NarrowHeaderArg, HTTPErrorKeywordArguments],
     ) -> None:
         HTTPBadRequest.__init__(
             self,
@@ -2722,7 +2722,7 @@ class MultipartParseError(MediaMalformedError):
 # -----------------------------------------------------------------------------
 
 
-def _load_headers(headers: Optional[HeaderArg]) -> Headers:
+def _load_headers(headers: Optional[NarrowHeaderArg]) -> Headers:
     """Transform the headers to dict."""
     if headers is None:
         return {}
@@ -2732,9 +2732,9 @@ def _load_headers(headers: Optional[HeaderArg]) -> Headers:
 
 
 def _parse_retry_after(
-    headers: Optional[HeaderArg],
+    headers: Optional[NarrowHeaderArg],
     retry_after: RetryAfter,
-) -> Optional[HeaderArg]:
+) -> Optional[NarrowHeaderArg]:
     """Set the Retry-After to the headers when required."""
     if retry_after is None:
         return headers

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -2601,7 +2601,9 @@ class MediaMalformedError(HTTPBadRequest):
     """
 
     def __init__(
-        self, media_type: str, **kwargs: Union[NarrowHeaderArg, HTTPErrorKeywordArguments]
+        self,
+        media_type: str,
+        **kwargs: Union[NarrowHeaderArg, HTTPErrorKeywordArguments],
     ):
         super().__init__(
             title='Invalid {0}'.format(media_type),
@@ -2701,7 +2703,7 @@ class MultipartParseError(MediaMalformedError):
     """
 
     # NOTE(caselit): remove the description @property in MediaMalformedError
-    description = None # pyright: ignore[reportAssignmentType, reportGeneralTypeIssues]
+    description = None  # pyright: ignore[reportAssignmentType, reportGeneralTypeIssues]
 
     def __init__(
         self,

--- a/falcon/hooks.py
+++ b/falcon/hooks.py
@@ -233,7 +233,7 @@ def _wrap_with_after(
         async_responder = cast('AsgiResponderMethod', responder)
 
         @wraps(async_responder)
-        async def do_after(
+        async def do_after_async(
             self: Resource,
             req: asgi.Request,
             resp: asgi.Response,
@@ -246,7 +246,7 @@ def _wrap_with_after(
             await async_responder(self, req, resp, **kwargs)
             await async_action(req, resp, self, *action_args, **action_kwargs)
 
-        do_after_responder = cast('AsgiResponderMethod', do_after)
+        do_after_responder = cast('AsgiResponderMethod', do_after_async)
     else:
         sync_action = cast('SyncAfterFn', action)
         sync_responder = cast('ResponderMethod', responder)
@@ -294,7 +294,7 @@ def _wrap_with_before(
         async_responder = cast('AsgiResponderMethod', responder)
 
         @wraps(async_responder)
-        async def do_before(
+        async def do_before_async(
             self: Resource,
             req: asgi.Request,
             resp: asgi.Response,
@@ -307,7 +307,7 @@ def _wrap_with_before(
             await async_action(req, resp, self, kwargs, *action_args, **action_kwargs)
             await async_responder(self, req, resp, **kwargs)
 
-        do_before_responder = cast('AsgiResponderMethod', do_before)
+        do_before_responder = cast('AsgiResponderMethod', do_before_async)
     else:
         sync_action = cast('SyncBeforeFn', action)
         sync_responder = cast('ResponderMethod', responder)

--- a/falcon/inspect.py
+++ b/falcon/inspect.py
@@ -248,7 +248,10 @@ def inspect_compiled_router(router: CompiledRouter) -> 'List[RouteInfo]':
                             'info will always be a string'
                         )
                         method_info = RouteMethodInfo(
-                            method, source_info, getattr(real_func, '__name__', '?'), internal
+                            method,
+                            source_info,
+                            getattr(real_func, '__name__', '?'),
+                            internal,
                         )
                         methods.append(method_info)
                 source_info, class_name = _get_source_info_and_name(root.resource)

--- a/falcon/inspect.py
+++ b/falcon/inspect.py
@@ -248,7 +248,7 @@ def inspect_compiled_router(router: CompiledRouter) -> 'List[RouteInfo]':
                             'info will always be a string'
                         )
                         method_info = RouteMethodInfo(
-                            method, source_info, real_func.__name__, internal
+                            method, source_info, getattr(real_func, '__name__', '?'), internal
                         )
                         methods.append(method_info)
                 source_info, class_name = _get_source_info_and_name(root.resource)

--- a/falcon/media/base.py
+++ b/falcon/media/base.py
@@ -28,7 +28,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
     """Override to provide a synchronous deserialization method that
     takes a byte string."""
 
-    def serialize(self, media: object, content_type: str) -> bytes:
+    def serialize(self, media: object, content_type: Optional[str] = None) -> bytes:
         """Serialize the media object on a :any:`falcon.Response`.
 
         By default, this method raises an instance of
@@ -51,7 +51,7 @@ class BaseHandler(metaclass=abc.ABCMeta):
         Returns:
             bytes: The resulting serialized bytes from the input object.
         """
-        if MEDIA_JSON in content_type:
+        if content_type is not None and MEDIA_JSON in content_type:
             raise NotImplementedError(
                 'The JSON media handler requires the sync interface to be '
                 "implemented even in ASGI applications, because it's used "

--- a/falcon/media/msgpack.py
+++ b/falcon/media/msgpack.py
@@ -72,7 +72,7 @@ class MessagePackHandler(BaseHandler):
     ) -> Any:
         return self._deserialize(await stream.read())
 
-    def serialize(self, media: Any, content_type: Optional[str]) -> bytes:
+    def serialize(self, media: Any, content_type: Optional[str] = None) -> bytes:
         return self._pack(media)
 
     async def serialize_async(self, media: Any, content_type: Optional[str]) -> bytes:

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -549,7 +549,7 @@ class MultipartFormHandler(BaseHandler):
             stream, content_type, content_length, form_cls=self._ASGI_MULTIPART_FORM
         )
 
-    def serialize(self, media: object, content_type: str) -> NoReturn:
+    def serialize(self, media: object, content_type: Optional[str] = None) -> NoReturn:
         raise NotImplementedError('multipart form serialization unsupported')
 
 

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -22,6 +22,7 @@ import functools
 import mimetypes
 from typing import (
     Any,
+    Callable,
     ClassVar,
     Dict,
     Iterable,
@@ -29,6 +30,7 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
+    cast,
     overload,
     Tuple,
     Type,
@@ -39,6 +41,7 @@ from typing import (
 from falcon._typing import _UNSET
 from falcon._typing import RangeSetHeader
 from falcon._typing import UnsetOr
+from falcon._typing import HeaderIter
 from falcon.constants import _DEFAULT_STATIC_MEDIA_TYPES
 from falcon.constants import DEFAULT_MEDIA_TYPE
 from falcon.errors import HeaderNotSupported
@@ -48,6 +51,7 @@ from falcon.response_helpers import _format_etag_header
 from falcon.response_helpers import _format_header_value_list
 from falcon.response_helpers import _format_range
 from falcon.response_helpers import _header_property
+from falcon.response_helpers import _headers_to_items
 from falcon.response_helpers import _is_ascii_encodable
 from falcon.typing import Headers
 from falcon.typing import ReadableIO
@@ -826,16 +830,11 @@ class Response:
                          or ``Iterable[[str, str]]``.
         """
 
-        header_items = getattr(headers, 'items', None)
-
-        if callable(header_items):
-            headers = header_items()
-
         # NOTE(kgriffs): We can't use dict.update because we have to
         # normalize the header names.
         _headers = self._headers
 
-        for name, value in headers:  # type: ignore[misc]
+        for name, value in _headers_to_items(headers):
             # NOTE(kgriffs): uwsgi fails with a TypeError if any header
             # is not a str, so do the conversion here. It's actually
             # faster to not do an isinstance check. str() will encode

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -22,7 +22,6 @@ import functools
 import mimetypes
 from typing import (
     Any,
-    Callable,
     ClassVar,
     Dict,
     Iterable,
@@ -30,7 +29,6 @@ from typing import (
     Mapping,
     NoReturn,
     Optional,
-    cast,
     overload,
     Tuple,
     Type,
@@ -41,7 +39,6 @@ from typing import (
 from falcon._typing import _UNSET
 from falcon._typing import RangeSetHeader
 from falcon._typing import UnsetOr
-from falcon._typing import HeaderIter
 from falcon.constants import _DEFAULT_STATIC_MEDIA_TYPES
 from falcon.constants import DEFAULT_MEDIA_TYPE
 from falcon.errors import HeaderNotSupported

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -26,7 +26,6 @@ from typing import (
     Dict,
     Iterable,
     List,
-    Mapping,
     NoReturn,
     Optional,
     overload,
@@ -37,6 +36,7 @@ from typing import (
 )
 
 from falcon._typing import _UNSET
+from falcon._typing import HeaderArg
 from falcon._typing import RangeSetHeader
 from falcon._typing import UnsetOr
 from falcon.constants import _DEFAULT_STATIC_MEDIA_TYPES
@@ -793,9 +793,7 @@ class Response:
 
             self._headers[name] = value
 
-    def set_headers(
-        self, headers: Union[Mapping[str, str], Iterable[Tuple[str, str]]]
-    ) -> None:
+    def set_headers(self, headers: HeaderArg) -> None:
         """Set several headers at once.
 
         This method can be used to set a collection of raw header names and

--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -18,9 +18,9 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable, Optional, TYPE_CHECKING
 
-from falcon._typing import RangeSetHeader
 from falcon._typing import HeaderArg
 from falcon._typing import HeaderIter
+from falcon._typing import RangeSetHeader
 from falcon.util import uri
 from falcon.util.misc import secure_filename
 
@@ -148,8 +148,9 @@ def _is_ascii_encodable(s: str) -> bool:
         return False
     return True
 
+
 def _headers_to_items(headers: HeaderArg) -> HeaderIter:
-    header_items: Callable[[], HeaderIter] | None = getattr(headers, 'items', None)
+    header_items: Optional[Callable[[], HeaderIter]] = getattr(headers, 'items', None)
     if callable(header_items):
         return header_items()
     return headers  # type: ignore[return-value]

--- a/falcon/response_helpers.py
+++ b/falcon/response_helpers.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Optional, TYPE_CHECKING
 
 from falcon._typing import RangeSetHeader
+from falcon._typing import HeaderArg
+from falcon._typing import HeaderIter
 from falcon.util import uri
 from falcon.util.misc import secure_filename
 
@@ -145,3 +147,9 @@ def _is_ascii_encodable(s: str) -> bool:
         # NOTE(tbug): s is probably not a string type
         return False
     return True
+
+def _headers_to_items(headers: HeaderArg) -> HeaderIter:
+    header_items: Callable[[], HeaderIter] | None = getattr(headers, 'items', None)
+    if callable(header_items):
+        return header_items()
+    return headers  # type: ignore[return-value]

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -435,7 +435,7 @@ class CompiledRouter:
         nodes: List[CompiledRouterNode],
         parent: _CxParent,
         return_values: List[CompiledRouterNode],
-        patterns: List[Pattern],
+        patterns: List[Pattern[str]],
         params_stack: List[_CxElement],
         level: int = 0,
         fast_return: bool = True,

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -570,6 +570,8 @@ class CompiledRouter:
                 # return the relevant information.
                 resource_idx = len(return_values)
                 return_values.append(node)
+            else:
+                resource_idx = None
 
             assert not (consume_multiple_segments and node.children)
 
@@ -583,7 +585,7 @@ class CompiledRouter:
                 fast_return,
             )
 
-            if node.resource is None:
+            if resource_idx is None:
                 if fast_return:
                     parent.append_child(_CxReturnNone())
             else:

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -59,6 +59,7 @@ from falcon import errors as falcon_errors
 from falcon._typing import CookieArg
 from falcon._typing import HeaderArg
 from falcon._typing import ResponseStatus
+from falcon.app_helpers import close_maybe
 import falcon.asgi
 from falcon.asgi_spec import AsgiEvent
 from falcon.asgi_spec import EventType
@@ -69,7 +70,6 @@ import falcon.request
 from falcon.util import code_to_http_status
 from falcon.util import uri
 from falcon.util.mediatypes import parse_header
-from falcon.app_helpers import close_maybe
 
 # NOTE(kgriffs): Changed in 3.0 from 'curl/7.24.0 (x86_64-apple-darwin12.0)'
 DEFAULT_UA = 'falcon-client/' + falcon.__version__

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -59,7 +59,6 @@ from falcon import errors as falcon_errors
 from falcon._typing import CookieArg
 from falcon._typing import HeaderArg
 from falcon._typing import ResponseStatus
-from falcon.app_helpers import close_maybe
 import falcon.asgi
 from falcon.asgi_spec import AsgiEvent
 from falcon.asgi_spec import EventType
@@ -1410,7 +1409,9 @@ def closed_wsgi_iterable(iterable: Iterable[bytes]) -> Iterable[bytes]:
             for item in iterable:
                 yield item
         finally:
-            close_maybe(iterable)
+            close: Optional[Callable[[], None]] = getattr(iterable, 'close', None)
+            if close:
+                close()
 
     wrapped = wrapper()
     head: Tuple[bytes, ...]

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -169,7 +169,7 @@ class ASGIRequestEventEmitter:
         if chunk_size is None:
             chunk_size = 4096
 
-        self._body = memoryview(body)
+        self._body: Optional[memoryview] = memoryview(body)
         self._chunk_size = chunk_size
         self._emit_empty_chunks = True
         self._disconnect_at = disconnect_at

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -70,7 +70,9 @@ IS_64_BITS = sys.maxsize > 2**32
 from falcon.util.reader import BufferedReader as _PyBufferedReader  # NOQA
 
 try:
-    from falcon.cyutil.reader import BufferedReader as _CyBufferedReader # pyright: ignore[reportMissingImports]
+    from falcon.cyutil.reader import (  # pyright: ignore[reportMissingImports]
+        BufferedReader as _CyBufferedReader,
+    )
 except ImportError:
     _CyBufferedReader = None
 

--- a/falcon/util/__init__.py
+++ b/falcon/util/__init__.py
@@ -70,7 +70,7 @@ IS_64_BITS = sys.maxsize > 2**32
 from falcon.util.reader import BufferedReader as _PyBufferedReader  # NOQA
 
 try:
-    from falcon.cyutil.reader import BufferedReader as _CyBufferedReader
+    from falcon.cyutil.reader import BufferedReader as _CyBufferedReader # pyright: ignore[reportMissingImports]
 except ImportError:
     _CyBufferedReader = None
 

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -42,7 +42,9 @@ from falcon.uri import encode_value
 from .deprecation import deprecated
 
 try:
-    from falcon.cyutil.misc import encode_items_to_latin1 as _cy_encode_items_to_latin1 # pyright: ignore[reportMissingImports]
+    from falcon.cyutil.misc import (  # pyright: ignore[reportMissingImports]
+        encode_items_to_latin1 as _cy_encode_items_to_latin1,
+    )
 except ImportError:
     _cy_encode_items_to_latin1 = None
 

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -42,7 +42,7 @@ from falcon.uri import encode_value
 from .deprecation import deprecated
 
 try:
-    from falcon.cyutil.misc import encode_items_to_latin1 as _cy_encode_items_to_latin1
+    from falcon.cyutil.misc import encode_items_to_latin1 as _cy_encode_items_to_latin1 # pyright: ignore[reportMissingImports]
 except ImportError:
     _cy_encode_items_to_latin1 = None
 


### PR DESCRIPTION
# Summary of Changes

This is not intended to be merged as is, I'm not that familiar with the falcon codebase.

The code is passing the Pyright checks in basic mode. 

In standard mode there are a few more errors. These are mostly related to the unbound variables defined only in some branch of if/else. Pyright is strict here and insist for variables to be always defined. I "fixed" one of these errors in CompiledRouter.

I run the tests. All of them are either green or skipped (?).

The type for headers of falcon.errors was made more strict: `dict[str,str] | list[tuple[str, str]` instead of `Mapping[str, str] | Iterable[tuple[str, str]]`. The catch is that dict is iterable too, so dict keyed by tuple of two strings (i.e. `dict[tuple[str, str], Any]`) is accepted, while should not.

I moved _logger to the separate module. The _logger was used in falcon.asgi/app, but root falcon module was never imported there.

I replaced `hasattr()` applied to some optional methods with `getattr()`. Pyright is strict here too: `hasattr` success means nothing :-)
