### PR TITLE
chore: publish sdist & pure-Python wheel without waiting for binaries

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -52,6 +52,54 @@ jobs:
           name: cibw-sdist
           path: dist/falcon-*
 
+  publish-sdist:
+    name: publish-sdist
+    needs:
+      - build-sdist
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-sdist
+          path: dist
+          merge-multiple: true
+
+      - name: Check collected artifacts
+        run: |
+          tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
+
+      - name: Upload sdist to release
+        uses: AButler/upload-release-assets@v3.0
+        if: github.event_name == 'release'
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          files: 'dist/*.tar.gz'
+
+      - name: Publish sdist and pure-Python wheel to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish sdist and pure-Python wheel to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'release'
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+
   build-wheels:
     name: ${{ matrix.python }}-${{ matrix.platform.name }}
     needs: build-sdist
@@ -123,59 +171,9 @@ jobs:
           name: cibw-wheel-${{ matrix.python }}-${{ matrix.platform.name }}
           path: wheelhouse/falcon-*.whl
 
-  publish-sdist:
-    name: publish-sdist
-    needs:
-      - build-sdist
-      - build-wheels
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: cibw-sdist
-          path: dist
-          merge-multiple: true
-
-      - name: Check collected artifacts
-        run: |
-          tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
-
-      - name: Upload sdist to release
-        uses: AButler/upload-release-assets@v3.0
-        if: github.event_name == 'release'
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          files: 'dist/*.tar.gz'
-
-      - name: Publish sdist and pure-Python wheel to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'workflow_dispatch'
-        with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
-      - name: Publish sdist and pure-Python wheel to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'release'
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-
   publish-wheels:
     name: publish-wheels
     needs:
-      - build-sdist
       - build-wheels
       - publish-sdist
     runs-on: ubuntu-latest


### PR DESCRIPTION
For 4.0, the setup was the opposite, and that was deliberate -- we waited for all wheels in order to publish anything to PyPI.

However, now that we have a CI gate testing a representative selection of wheels, we should afford to publish sdist first, and then hope that the binary builds succeed too.
