### PR TITLE
Add FAQ entry for error tracebacks in ASGI applications and update tutorial for logging

### DIFF
--- a/docs/_newsfragments/2387.misc.rst
+++ b/docs/_newsfragments/2387.misc.rst
@@ -1,7 +1,0 @@
-Running mypy on code that uses parts of ``falcon.testing`` naively
-would lead to errors like::
-
-  Name "falcon.testing.TestClient" is not defined
-
-This has been fixed by explicitly exporting the names that are
-imported in the ``falcon.testing`` namespace.

--- a/docs/changes/4.1.0.rst
+++ b/docs/changes/4.1.0.rst
@@ -14,8 +14,27 @@ Changes to Supported Platforms
 
 .. NOTE(vytas): No changes to the supported platforms (yet).
 
-
 .. towncrier release notes start
+
+
+Misc
+----
+
+- Running mypy on code that uses parts of ``falcon.testing`` naively
+  would lead to errors like::
+
+    Name "falcon.testing.TestClient" is not defined
+
+  This has been fixed by explicitly exporting the names that are
+  imported in the ``falcon.testing`` namespace. (`#2387 <https://github.com/falconry/falcon/issues/2387>`__)
+- New FAQ Entry on Error Tracebacks in ASGI Applications
+  -----------------------------------------------------
+
+  Added a new FAQ entry explaining why error tracebacks do not appear 
+  in ASGI applications by default when using Falcon. The ASGI tutorial 
+  has been updated to include instructions on configuring logging to 
+  capture error tracebacks. (`#2393 <https://github.com/falconry/falcon/issues/2393>`__) (`#2393 <https://github.com/falconry/falcon/issues/2393>`__)
+
 
 Contributors to this Release
 ----------------------------

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -1347,3 +1347,47 @@ Alternatively, you can set the Cookie header directly as demonstrated in this ve
 To include multiple values, simply use ``"; "`` to separate each name-value
 pair. For example, if you were to pass ``{'Cookie': 'xxx=yyy; hello=world'}``,
 you would get ``{'cookies': {'xxx': 'yyy', 'hello': 'world'}}``.
+
+.. _why-do-i-not-see-error-tracebacks-in-asgi-applications:
+
+Why do I not see error tracebacks in ASGI applications?
+-------------------------------------------------------
+
+When using Falcon with ASGI servers like Uvicorn,
+you might notice that server errors do not display a traceback by default.
+This behavior differs from WSGI applications, where errors are logged to `stderr`,
+providing detailed tracebacks.
+
+The reason for this is that ASGI does not define a standardized way to log errors back to the application server,
+unlike WSGI. Therefore, you need to configure logging manually to see these tracebacks.
+
+Here’s how to set up logging in your ASGI Falcon application to capture error tracebacks:
+
+.. code:: python
+
+    import logging
+    import falcon
+    import falcon.asgi
+
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)s] %(message)s", 
+        level=logging.INFO
+    )
+
+    class ThingsResource:
+        async def on_get(self, req, resp):
+            raise ValueError('foo')
+
+    app = falcon.asgi.App()
+    things = ThingsResource()
+    app.add_route('/things', things)
+
+By adding the above logging configuration, you will see tracebacks like this in your console:
+
+.. code-block:: none
+
+    [ERROR] [FALCON] Unhandled exception in ASGI app
+    Traceback (most recent call last):
+    File "<...>", line 12, in on_get
+        raise ValueError('foo')
+    ValueError: foo

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -979,9 +979,7 @@ your ASGI Falcon application:
 .. code:: python
 
     import logging
-
     import falcon
-
 
     logging.basicConfig(level=logging.INFO)
 
@@ -991,7 +989,6 @@ your ASGI Falcon application:
 
     app = falcon.App()
     app.add_route('/error', ErrorResource())
-
 
 When the above route is accessed, Falcon will catch the unhandled exception and
 automatically log an error message. Below is an example of what the log output
@@ -1006,6 +1003,9 @@ might look like:
       File "/path/to/your/app.py", line 7, in on_get
         raise Exception("Something went wrong!")
     Exception: Something went wrong!
+
+For additional details on this topic, 
+please refer to :ref:`why-do-i-not-see-error-tracebacks-in-asgi-applications`.
 
 
 .. note::


### PR DESCRIPTION
# Summary of Changes

Added a new FAQ entry explaining why error tracebacks do not appear in ASGI applications by default when using Falcon. Updated the tutorial on ASGI applications to include instructions on configuring logging to capture error tracebacks.

# Related Issues

Closes #2393

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).  
*(Note: Confirm that the changes are relevant to both interfaces.)*
- [x] Added **tests** for changed code.  
*(Note: Ensure that you have written tests for any new functionality introduced.)*
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.  
*(Note: Ensure all comments are correctly prefixed.)*
- [x] Coding style is consistent with the rest of the framework.  
*(Note: Run `ruff format` to ensure compliance.)*
- [x] Updated **documentation** for changed code.  
    - [x] Added docstrings for any new classes, functions, or modules.  
    - [x] Updated docstrings for any modifications to existing code.  
    - [x] Updated both WSGI and ASGI docs (where applicable).  
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.  
    - [x] Updated all relevant supporting documentation files under `docs/`.  
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).  
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` directives.  
    *(Note: Add these directives where necessary.)*
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`.  
*(Note: Make sure to create a news fragment if your changes are substantial.)*