### PR TITLE
Introducing Falcon Framework Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
    :target: https://falconframework.org/
    :width: 100 %
 
-|Build status| |Docs| |codecov.io| |PyPI package| |Python versions|
+|Build status| |Docs| |codecov.io| |PyPI package| |Python versions| |Gurubase|
 
 The Falcon Web Framework
 ========================
@@ -998,4 +998,5 @@ limitations under the License.
     :height: 60px
     :target: https://sentry.io
 .. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Falcon%20Framework%20Guru-006BFF
+    :alt: Falcon Guru on Gurubase.io
     :target: https://gurubase.io/g/falcon-framework

--- a/README.rst
+++ b/README.rst
@@ -997,3 +997,5 @@ limitations under the License.
     :alt: Sentry
     :height: 60px
     :target: https://sentry.io
+.. |Gurubase| image:: https://img.shields.io/badge/Gurubase-Ask%20Falcon%20Framework%20Guru-006BFF
+    :target: https://gurubase.io/g/falcon-framework


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Falcon Framework Guru](https://gurubase.io/g/falcon-framework) to Gurubase. Falcon Framework Guru uses the data from this repo and data from the [docs](https://falcon.readthedocs.io/en/stable) to answer questions by leveraging the LLM.

In this PR, I showcased the "Falcon Framework Guru", which highlights that Falcon Framework now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Falcon Framework Guru in Gurubase, just let me know that's totally fine.
