### PR TITLE
chore: implement initial support for CPython 3.14

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,6 +59,8 @@ jobs:
             python-version: "3.13"
           - env: py313_cython
             python-version: "3.13"
+          - env: py314
+            python-version: "3.14.0-alpha.2 - 3.14.0"
           - env: py312_nocover
             os: macos-latest
             platform-label: ' (macos)'

--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -155,13 +155,6 @@ at least set this attribute to ``'Lax'`` in order to mitigate
 Currently, :meth:`~falcon.Response.set_cookie` does not set `SameSite` by
 default, although this may change in a future release.
 
-.. note::
-
-    The standard ``http.cookies`` module does not support the `SameSite`
-    attribute in versions prior to Python 3.8. Therefore, Falcon performs a
-    simple monkey-patch on the standard library module to backport this
-    feature for apps running on older Python versions.
-
 .. _RFC 6265, Section 4.1.2.5:
     https://tools.ietf.org/html/rfc6265#section-4.1.2.5
 
@@ -172,7 +165,7 @@ by setting the 'samesite' kwarg.
 The Partitioned Attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Starting from Q1 2024, Google Chrome will start to
+Starting from Q1 2024, Google Chrome started to
 `phase out support for third-party cookies
 <https://developers.google.com/privacy-sandbox/3pcd/prepare/prepare-for-phaseout>`__.
 If your site is relying on cross-site cookies, it might be necessary to set the
@@ -187,7 +180,7 @@ automatically depending on other attributes (like ``SameSite``),
 although this may change in a future release.
 
 .. note::
-    Similar to ``SameSite`` on older Python versions, the standard
-    :mod:`http.cookies` module does not support the ``Partitioned`` attribute
-    yet, and Falcon performs the same monkey-patching as it did for
-    ``SameSite``.
+    The standard :mod:`http.cookies` module does not support the `Partitioned`
+    attribute in versions prior to Python 3.14. Therefore, Falcon performs a
+    simple monkey-patch on the standard library module to backport this
+    feature for apps running on older Python versions.

--- a/requirements/tests
+++ b/requirements/tests
@@ -26,4 +26,5 @@ ujson
 python-rapidjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
 
 # wheels are missing some EoL interpreters and non-x86 platforms; build would fail unless rust is available
-orjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
+# (not available for CPython 3.14 either yet)
+orjson; python_version < '3.14' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'


### PR DESCRIPTION
This PR implements rudimentary support for CPython 3.14, adapting our monkey-patching of `Morsel` attributes to a new optimization in 3.14 stdlib.
In addition, the monkey patching of the `SameSite` attribute was removed, since it is no longer needed on 3.8+.

(See also Red Hat Bugzilla: [Bug 2328020](https://bugzilla.redhat.com/show_bug.cgi?id=2328020). @befeleme @carlwgeorge)