### PR TITLE
feat(static): implement Last-Modified header for static route

### DIFF
--- a/docs/_newsfragments/2244.newandimproved.rst
+++ b/docs/_newsfragments/2244.newandimproved.rst
@@ -1,3 +1,4 @@
-:class:`falcon.routing.StaticRoute` now supports rendering ``Last-Modified``
-header when serving static files. It also checks ``If-Modified-Since``
-and return ``304 Not Modified`` if appropriate.
+:class:`~falcon.routing.StaticRoute` now sets the ``Last-Modified`` header when
+serving static files. The improved implementation also checks the value of the
+``If-Modified-Since`` header, and renders an HTTP 304 response when the
+requested file has not been modified.

--- a/docs/_newsfragments/2244.newandimproved.rst
+++ b/docs/_newsfragments/2244.newandimproved.rst
@@ -1,0 +1,3 @@
+:class:`falcon.routing.StaticRoute` now supports rendering ``Last-Modified``
+header when serving static files. It also checks ``If-Modified-Since``
+and return ``304 Not Modified`` if appropriate.

--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -483,6 +483,21 @@ be used by custom routing engines.
 .. autofunction:: falcon.app_helpers.prepare_middleware_ws
 
 
+Static File Routes
+------------------
+
+Falcon can serve static files directly from a WSGI or ASGI application
+using the below sink-like :class:`~falcon.routing.StaticRoute`.
+
+Instances of :class:`~falcon.routing.StaticRoute` are normally created via
+:meth:`falcon.App.add_static_route`
+(please see, however, the documentation of :meth:`~falcon.App.add_static_route`
+for the performance implications of serving files through a Python app).
+
+.. autoclass:: falcon.routing.StaticRoute
+    :members:
+
+
 Custom HTTP Methods
 -------------------
 

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 from functools import partial
 import io
 import os
@@ -21,7 +22,9 @@ _stat = os.stat
 
 
 def _open_range(
-    file_path: Union[Path, str], st: os.stat_result, req_range: Optional[Tuple[int, int]]
+    file_path: Union[Path, str],
+    st: os.stat_result,
+    req_range: Optional[Tuple[int, int]]
 ) -> Tuple[ReadableIO, int, Optional[Tuple[int, int, int]]]:
     """Open a file for a ranged request.
 
@@ -230,12 +233,11 @@ class StaticRoute:
                 raise falcon.HTTPNotFound()
             try:
                 st = _stat(self._fallback_filename)
+                file_path = self._fallback_filename
             except PermissionError:
                 raise falcon.HTTPForbidden()
             except IOError:
                 raise falcon.HTTPNotFound()
-            else:
-                file_path = self._fallback_filename
 
         last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)
         resp.last_modified = last_modified
@@ -246,7 +248,9 @@ class StaticRoute:
 
         req_range = req.range if req.range_unit == 'bytes' else None
         try:
-            stream, length, content_range = _open_range(file_path, st, req_range)
+            stream, length, content_range = _open_range(
+                file_path, st, req_range
+            )
             resp.set_stream(stream, length)
         except PermissionError:
             raise falcon.HTTPForbidden()

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -19,9 +19,7 @@ if TYPE_CHECKING:
     from falcon import Response
 
 
-def _open_file(
-    file_path: Union[str, Path]
-) -> Tuple[io.BufferedReader, os.stat_result]:
+def _open_file(file_path: Union[str, Path]) -> Tuple[io.BufferedReader, os.stat_result]:
     fh: Optional[io.BufferedReader] = None
     try:
         fh = io.open(file_path, 'rb')
@@ -38,9 +36,7 @@ def _open_file(
 
 
 def _set_range(
-    fh: io.BufferedReader,
-    st: os.stat_result,
-    req_range: Optional[Tuple[int, int]]
+    fh: io.BufferedReader, st: os.stat_result, req_range: Optional[Tuple[int, int]]
 ) -> Tuple[ReadableIO, int, Optional[Tuple[int, int, int]]]:
     """Process file handle for a ranged request.
 
@@ -250,8 +246,7 @@ class StaticRoute:
 
         last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)
         resp.last_modified = last_modified
-        if (req.if_modified_since is not None and
-                last_modified <= req.if_modified_since):
+        if req.if_modified_since is not None and last_modified <= req.if_modified_since:
             resp.status = falcon.HTTP_304
             return
 

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -24,7 +24,8 @@ def _open_range(
     """Open a file for a ranged request.
 
     Args:
-        file_path (str): Path to the file to open.
+        fh (io.BufferedReader): file handler of the file.
+        st (os.stat_result): fs stat result of the file.
         req_range (Optional[Tuple[int, int]]): Request.range value.
     Returns:
         tuple: Three-member tuple of (stream, content-length, content-range).

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -31,10 +31,6 @@ def _open_file(file_path: Union[str, Path]) -> Tuple[io.BufferedReader, os.stat_
     try:
         fh = io.open(file_path, 'rb')
         st = os.fstat(fh.fileno())
-    except PermissionError:
-        if fh is not None:
-            fh.close()
-        raise falcon.HTTPForbidden()
     except IOError:
         if fh is not None:
             fh.close()

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -20,6 +20,13 @@ if TYPE_CHECKING:
 
 
 def _open_file(file_path: Union[str, Path]) -> Tuple[io.BufferedReader, os.stat_result]:
+    """Open a file for a static file request and read file stat.
+
+    Args:
+        file_path (Union[str, Path]): Path to the file to open.
+    Returns:
+        tuple: Tuple of (BufferedReader, stat_result).
+    """
     fh: Optional[io.BufferedReader] = None
     try:
         fh = io.open(file_path, 'rb')

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -223,11 +223,15 @@ class StaticRoute:
 
         try:
             st = _stat(file_path)
+        except PermissionError:
+            raise falcon.HTTPForbidden()
         except IOError:
             if self._fallback_filename is None:
                 raise falcon.HTTPNotFound()
             try:
                 st = _stat(self._fallback_filename)
+            except PermissionError:
+                raise falcon.HTTPForbidden()
             except IOError:
                 raise falcon.HTTPNotFound()
             else:

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -237,9 +237,10 @@ class StaticRoute:
             else:
                 file_path = self._fallback_filename
 
-        resp.last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)
+        last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)
+        resp.last_modified = last_modified
         if (req.if_modified_since is not None and
-                resp.last_modified <= req.if_modified_since):
+                last_modified <= req.if_modified_since):
             resp.status = falcon.HTTP_304
             return
 

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -248,6 +248,10 @@ class StaticRoute:
                 file_path = self._fallback_filename
 
         last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)
+        # NOTE(vytas): Strip the microsecond part because that is not reflected
+        #   in HTTP date, and when the client passes a previous value via
+        #   If-Modified-Since, it will look as if our copy is ostensibly newer.
+        last_modified = last_modified.replace(microsecond=0)
         resp.last_modified = last_modified
         if req.if_modified_since is not None and last_modified <= req.if_modified_since:
             resp.status = falcon.HTTP_304

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -10,8 +10,8 @@ import pytest
 import falcon
 from falcon.routing import StaticRoute
 from falcon.routing import StaticRouteAsync
-from falcon.routing.static import _BoundedFile
 import falcon.routing.static
+from falcon.routing.static import _BoundedFile
 import falcon.testing as testing
 
 
@@ -686,7 +686,9 @@ def test_permission_error(
         raise PermissionError()
 
     patch_open(validate=validate)
-    monkeypatch.setattr('os.path.isfile', lambda file: file.endswith('fallback.css'))
+    monkeypatch.setattr(
+        'os.path.isfile', lambda file: file.endswith('fallback.css')
+    )
 
     client.app.add_static_route(
         '/assets/', '/opt/somesite/assets', fallback_filename='fallback.css'

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -3,13 +3,13 @@ import io
 import os
 import pathlib
 import posixpath
+from unittest import mock
 
 import pytest
 
 import falcon
 from falcon.routing import StaticRoute
 from falcon.routing import StaticRouteAsync
-import falcon.routing.static
 from falcon.routing.static import _BoundedFile
 import falcon.testing as testing
 
@@ -709,3 +709,36 @@ def test_ioerror(client, patch_open, monkeypatch):
     resp = client.simulate_request(path='/assets/css/main.css')
 
     assert resp.status == falcon.HTTP_404
+
+
+@pytest.mark.parametrize('error_type', [PermissionError, FileNotFoundError])
+def test_fstat_error(client, patch_open, error_type):
+    patch_open()
+
+    client.app.add_static_route('/assets/', '/opt/somesite/assets')
+
+    with mock.patch("os.fstat") as m:
+        m.side_effect = error_type()
+        resp = client.simulate_request(path='/assets/css/main.css')
+
+    if isinstance(error_type(), PermissionError):
+        assert resp.status == falcon.HTTP_403
+    else:
+        assert resp.status == falcon.HTTP_404
+
+    assert patch_open.current_file is not None
+    assert patch_open.current_file.closed
+
+
+def test_set_range_error(client, patch_open):
+    patch_open()
+
+    client.app.add_static_route('/assets/', '/opt/somesite/assets')
+
+    with mock.patch("falcon.routing.static._set_range") as m:
+        m.side_effect = IOError()
+        resp = client.simulate_request(path='/assets/css/main.css')
+
+    assert resp.status == falcon.HTTP_404
+    assert patch_open.current_file is not None
+    assert patch_open.current_file.closed

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -58,7 +58,6 @@ def patch_open(monkeypatch):
             def __init__(self, size, mtime):
                 self.st_size = size
                 self.st_mtime = mtime
-                self.st_mode = 0o100644
 
         def open(path, mode):
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -57,8 +57,9 @@ def patch_open(monkeypatch):
                 pass
 
             class FakeStat:
-                def __init__(self, size):
+                def __init__(self, size, mtime):
                     self.st_size = size
+                    self.st_mtime = mtime
 
             if validate:
                 validate(path)
@@ -66,7 +67,7 @@ def patch_open(monkeypatch):
             data = path.encode() if content is None else content
             fake_file = io.BytesIO(data)
             fd = FakeFD(1337)
-            fd._stat = FakeStat(len(data))
+            fd._stat = FakeStat(len(data), 1736617934)
             fake_file.fileno = lambda: fd
 
             patch.current_file = fake_file

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -704,7 +704,7 @@ def test_fstat_error(client, patch_open, error_type):
         m.side_effect = error_type()
         resp = client.simulate_request(path='/assets/css/main.css')
 
-    if error_type == PermissionError:
+    if error_type is PermissionError:
         assert resp.status == falcon.HTTP_403
     else:
         assert resp.status == falcon.HTTP_404

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -649,14 +649,14 @@ def test_last_modified(client, patch_open):
 
 
 def test_if_modified_since(client, patch_open):
-    mtime = (1736617934, 'Sat, 11 Jan 2025 17:52:14 GMT')
+    mtime = (1736617934.133701, 'Sat, 11 Jan 2025 17:52:14 GMT')
     patch_open(mtime=mtime[0])
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
 
     resp = client.simulate_request(
         path='/assets/css/main.css',
-        headers={'If-Modified-Since': 'Sat, 11 Jan 2025 17:52:15 GMT'},
+        headers={'If-Modified-Since': 'Sat, 11 Jan 2025 17:52:14 GMT'},
     )
     assert resp.status == falcon.HTTP_304
     assert resp.text == ''

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -669,7 +669,7 @@ def test_if_modified_since(client, patch_open):
     assert resp.text != ''
 
 
-def test_fstat_error(client, patch_open, error_type):
+def test_fstat_error(client, patch_open):
     patch_open()
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -638,7 +638,7 @@ def test_options_request(client, patch_open):
 
 
 def test_last_modified(client, patch_open):
-    mtime = (1736617934, "Sat, 11 Jan 2025 17:52:14 GMT")
+    mtime = (1736617934, 'Sat, 11 Jan 2025 17:52:14 GMT')
     patch_open(mtime=mtime[0])
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
@@ -649,42 +649,35 @@ def test_last_modified(client, patch_open):
 
 
 def test_if_modified_since(client, patch_open):
-    mtime = (1736617934, "Sat, 11 Jan 2025 17:52:14 GMT")
+    mtime = (1736617934, 'Sat, 11 Jan 2025 17:52:14 GMT')
     patch_open(mtime=mtime[0])
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
 
     resp = client.simulate_request(
         path='/assets/css/main.css',
-        headers={"If-Modified-Since": "Sat, 11 Jan 2025 17:52:15 GMT"},
+        headers={'If-Modified-Since': 'Sat, 11 Jan 2025 17:52:15 GMT'},
     )
     assert resp.status == falcon.HTTP_304
     assert resp.text == ''
 
     resp = client.simulate_request(
         path='/assets/css/main.css',
-        headers={"If-Modified-Since": "Sat, 11 Jan 2025 17:52:13 GMT"},
+        headers={'If-Modified-Since': 'Sat, 11 Jan 2025 17:52:13 GMT'},
     )
     assert resp.status == falcon.HTTP_200
     assert resp.text != ''
 
 
 @pytest.mark.parametrize('use_fallback', [True, False])
-def test_permission_error(
-    client,
-    patch_open,
-    use_fallback,
-    monkeypatch
-):
+def test_permission_error(client, patch_open, use_fallback, monkeypatch):
     def validate(path):
         if use_fallback and not path.endswith('fallback.css'):
             raise IOError()
         raise PermissionError()
 
     patch_open(validate=validate)
-    monkeypatch.setattr(
-        'os.path.isfile', lambda file: file.endswith('fallback.css')
-    )
+    monkeypatch.setattr('os.path.isfile', lambda file: file.endswith('fallback.css'))
 
     client.app.add_static_route(
         '/assets/', '/opt/somesite/assets', fallback_filename='fallback.css'
@@ -700,7 +693,7 @@ def test_fstat_error(client, patch_open, error_type):
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
 
-    with mock.patch("os.fstat") as m:
+    with mock.patch('os.fstat') as m:
         m.side_effect = error_type()
         resp = client.simulate_request(path='/assets/css/main.css')
 
@@ -718,7 +711,7 @@ def test_set_range_error(client, patch_open):
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
 
-    with mock.patch("falcon.routing.static._set_range") as m:
+    with mock.patch('falcon.routing.static._set_range') as m:
         m.side_effect = IOError()
         resp = client.simulate_request(path='/assets/css/main.css')
 


### PR DESCRIPTION
# Summary of Changes

- Render `Last-Modified` header for static file responses.
- Check request `If-Modified-Since` header and return 304 if date in this header is not earlier than mtime.

# Related Issues

Fixes #2244 

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/quickstart.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
