### PR TITLE
chore(requirements): unpin some test dependencies

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,6 +81,8 @@ jobs:
           - env: "e2e_chrome"
           # TODO(vytas): Something is not working correctly with the
           #   newly released Firefox 131.0, SeleniumBase, and our tests.
+          # NOTE(vytas,cycloctane): Apparently, it seems that the issue is
+          #   caused by a segfault in Uvicorn, but it happens only in Actions.
           # - env: "e2e_firefox"
 
     steps:

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,14 +1,14 @@
 coverage >= 4.1
-pytest >= 8.3
+pytest >= 7.0
 pyyaml
 requests
 testtools
 
-# ASGI Specific (Daphne is installed in its own tox env)
+# ASGI Specific (Daphne & Hypercorn are installed in their own tox env)
 aiofiles
 httpx
 uvicorn >= 0.17.0
-websockets >= 13.1, < 14.2
+websockets >= 13.1
 
 # Handler Specific
 cbor2

--- a/requirements/tests
+++ b/requirements/tests
@@ -1,15 +1,10 @@
 coverage >= 4.1
-# TODO(vytas): Our use of testtools breaks under pytest 8.2 along the lines of
-#   https://github.com/pytest-dev/pytest/issues/12263, unpin when fixed
-#   (or drop support for testtools altogether?)
-pytest >= 7.0, < 8.2
+pytest >= 8.3
 pyyaml
 requests
-# TODO(vytas): Check if testtools still brings anything to the table, and
-#   re-enable if/when unittest2 is adjusted to support CPython 3.10.
-testtools; python_version < '3.10'
+testtools
 
-# ASGI Specific (daphne is installed on a its own tox env)
+# ASGI Specific (Daphne is installed in its own tox env)
 aiofiles
 httpx
 uvicorn >= 0.17.0

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -330,9 +330,13 @@ class TestWebSocket:
         except websockets.exceptions.NegotiationError as ex:
             assert 'unsupported subprotocol: xmpp' in str(ex)
 
-        # Daphne, Hypercorn
+        # Daphne, Hypercorn with websockets<14.2
         except EOFError:
             pass
+
+        # Daphne, Hypercorn with websockets>=14.2
+        except websockets.exceptions.InvalidMessage as ex:
+            assert isinstance(ex.__cause__, EOFError)
 
     # NOTE(kgriffs): When executing this test under pytest with the -s
     #   argument, one should be able to see the message


### PR DESCRIPTION
Also addressing the recent failure with `websockets==14.2`.