### PR TITLE
 chore(CI): comment out one failing doctest for Mailman

### DIFF
--- a/.github/workflows/test-mailman.yaml
+++ b/.github/workflows/test-mailman.yaml
@@ -8,6 +8,10 @@ on:
   # push:
   #   branches:
   #     - master
+  # TODO(vytas): Remove from PRs when demonstrated to pass.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run_tox:

--- a/.github/workflows/test-mailman.yaml
+++ b/.github/workflows/test-mailman.yaml
@@ -4,12 +4,7 @@ name: test-mailman
 on:
   # Trigger the workflow on master but also allow it to run manually.
   workflow_dispatch:
-  # TODO(vytas): Re-enable when the digests.rst doctest is passing again.
-  # push:
-  #   branches:
-  #     - master
-  # TODO(vytas): Remove from PRs when demonstrated to pass.
-  pull_request:
+  push:
     branches:
       - master
 

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -36,8 +36,8 @@ EOT
 sed -i s/test_uheader_multiline/skip_test_uheader_multiline/ \
     src/mailman/handlers/tests/test_cook_headers.py
 
-# NOTE(vytas): I cannot understand how this passes in the upstream's CI.
+# NOTE(vytas): I cannot understand how this passes in the upstream's CI...
 # TODO(vytas): Remove the below patch when the issue is resolved upstream:
 #   https://gitlab.com/mailman/mailman/-/issues/1203
-sed -i "s/-h, --help       Show/--help           Show/" \
+sed -i "s/>>>/TODO: restore doctest  #/g" \
     src/mailman/commands/docs/digests.rst

--- a/tools/testing/fetch_mailman.sh
+++ b/tools/testing/fetch_mailman.sh
@@ -35,3 +35,9 @@ EOT
 #   (but it works on other platforms).
 sed -i s/test_uheader_multiline/skip_test_uheader_multiline/ \
     src/mailman/handlers/tests/test_cook_headers.py
+
+# NOTE(vytas): I cannot understand how this passes in the upstream's CI.
+# TODO(vytas): Remove the below patch when the issue is resolved upstream:
+#   https://gitlab.com/mailman/mailman/-/issues/1203
+sed -i "s/-h, --help       Show/--help           Show/" \
+    src/mailman/commands/docs/digests.rst


### PR DESCRIPTION
I cannot understand how this can possibly pass upstream. One explanation could be that the upstream's gate selection actually doesn't include the same `nocov` environment that we piggyback on.

See also: https://gitlab.com/mailman/mailman/-/issues/1203 (that I filed upstream).