### PR TITLE
refactor(testing): deprecate httpnow

### DIFF
--- a/docs/_newsfragments/2389.misc.rst
+++ b/docs/_newsfragments/2389.misc.rst
@@ -1,0 +1,2 @@
+The :func:`falcon.testing.httpnow` function is deprecated and will be removed in 
+Falcon 5.0. Use the :func:`falcon.util.http_now` function instead.

--- a/docs/_newsfragments/2389.newandimproved.rst
+++ b/docs/_newsfragments/2389.newandimproved.rst
@@ -1,1 +1,0 @@
-Deprecate function :func:`~falcon.testing.httpnow`, recommend to use :func:`~falcon.util.http_now`.

--- a/docs/_newsfragments/2389.newandimproved.rst
+++ b/docs/_newsfragments/2389.newandimproved.rst
@@ -1,0 +1,1 @@
+Deprecate function :func:`~falcon.testing.httpnow`, recommend to use :func:`~falcon.util.http_now`.

--- a/falcon/testing/__init__.py
+++ b/falcon/testing/__init__.py
@@ -161,4 +161,7 @@ __all__ = (
 
 # NOTE(kgriffs): Alias for backwards-compatibility with Falcon 0.2
 # TODO(vytas): Remove in Falcon 5.0.
-httpnow = _util.http_now
+httpnow = _util.deprecated(
+    'This method is deprecated and will be removed in Falcon 5.0. '
+    'Use `falcon.util.http_now` instead.'
+)(_util.http_now)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -224,3 +224,11 @@ def test_client_simulate_aliases(asgi, method, util):
     assert result.status_code == 200
     expected = '' if method == 'HEAD' else method
     assert result.text == expected
+
+
+def test_deprecated_httpnow():
+    with pytest.warns(
+        falcon.util.DeprecatedWarning, match='Use `falcon.util.http_now` instead.'
+    ):
+        now = testing.httpnow()
+    assert now

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from datetime import timezone
 import functools
 import http
+import inspect
 import itertools
 import json
 import random
@@ -712,7 +713,11 @@ class TestFalconTestingUtils:
         assert response.json == falcon.HTTPNotFound().to_dict()
 
     def test_httpnow_alias_for_backwards_compat(self):
-        assert testing.httpnow is falcon.util.http_now
+        # Ensure that both the alias and decorated alias work
+        assert (
+            testing.httpnow is falcon.util.http_now
+            or inspect.unwrap(testing.httpnow) is falcon.util.http_now
+        )
 
     def test_default_headers(self, app):
         resource = testing.SimpleTestResource()


### PR DESCRIPTION
# Summary of Changes

Deprecate `falcon.testing.httpnow`.

# Related Issues

- fix https://github.com/falconry/falcon/issues/2389

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
