### PR TITLE
feat(routing): override default responders via on_request()

### DIFF
--- a/docs/_newsfragments/2071.newandimproved.rst
+++ b/docs/_newsfragments/2071.newandimproved.rst
@@ -1,0 +1,6 @@
+Added the :attr:`~.CompiledRouterOptions.allow_on_request` router option that
+allows for providing a default responder by defining `on_request()` on the 
+resource. This option is disabled by default. If enabled, `on_request()` is
+set as the responder for every unimplemented method except for `on_options()`. 
+If the option is disabled or `on_request()` is not provided in the resource,
+the default responder for "405 Method Not Allowed" is used.

--- a/tests/test_default_router.py
+++ b/tests/test_default_router.py
@@ -103,6 +103,14 @@ class ResourceWithId:
         resp.text = self.resource_id
 
 
+class ResourceWithDefaultResponder:
+    def on_get(self, req, resp):
+        pass
+
+    def on_request(self, req, resp):
+        pass
+
+
 class SpamConverter:
     def __init__(self, times, eggs=False):
         self._times = times
@@ -693,6 +701,30 @@ def test_options_converters_invalid_name_on_update(router):
                 '7eleven': SpamConverter,
             }
         )
+
+
+def test_options_allow_on_request_disabled():
+    router = DefaultRouter()
+    router.add_route('/default', ResourceWithDefaultResponder())
+
+    resource, method_map, __, __ = router.find('/default')
+
+    for method, responder in method_map.items():
+        assert responder != resource.on_request
+
+
+def test_options_allow_on_request_enabled():
+    router = DefaultRouter()
+    router.options.allow_on_request = True
+    router.add_route('/default', ResourceWithDefaultResponder())
+
+    resource, method_map, __, __ = router.find('/default')
+
+    for method, responder in method_map.items():
+        if method not in ('GET', 'OPTIONS'):
+            assert responder == resource.on_request
+        else:
+            assert responder != resource.on_request
 
 
 @pytest.fixture


### PR DESCRIPTION
Add an option to CompiledRouterOptions that allows for overriding the default responders by implementing `on_request()` in the resource class

Closes #2071

# Summary of Changes

Added a new router option (`allow_on_request`) in `falcon.routing.compiled.CompiledRouterOptions` that allows for providing a default responder by defining `on_request()` on the  resource. This option is disabled by default. If enabled, `on_request()` is set as the responder for every unimplemented method except for `on_options()`. If the option is disabled or `on_request()` is not provided in the resource, the default responder for "405 Method Not Allowed" is used.

# Related Issues
- #2071 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
