### PR TITLE
chore(CI): port legacy gates to Ubuntu 24.04

### DIFF
--- a/.github/workflows/test-other.yaml
+++ b/.github/workflows/test-other.yaml
@@ -6,11 +6,6 @@ on:
     branches:
       - "*"
 
-  # TODO(vytas): Remove once demonstrated to pass.
-  pull_request:
-    branches:
-      - master
-
 jobs:
   run-tox:
     name: tox -e ${{ matrix.toxenv }}

--- a/.github/workflows/test-other.yaml
+++ b/.github/workflows/test-other.yaml
@@ -6,10 +6,15 @@ on:
     branches:
       - "*"
 
+  # TODO(vytas): Remove once demonstrated to pass.
+  pull_request:
+    branches:
+      - master
+
 jobs:
   run-tox:
     name: tox -e ${{ matrix.toxenv }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Seems to run just fine, provided we are using an older version of Python (leaving this on 3.8 while we still support it): https://github.com/falconry/falcon/actions/runs/14591904670.