### PR TITLE
feat(static): implement Etag and If-None-Match for static route

### DIFF
--- a/docs/_newsfragments/2243.newandimproved.rst
+++ b/docs/_newsfragments/2243.newandimproved.rst
@@ -1,0 +1,3 @@
+:class:`~falcon.routing.StaticRoute` now renders ``Etag`` headers. It also
+checks ``If-None-Match`` in requests and returns HTTP 304 response if
+appropriate.

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -91,9 +91,7 @@ def _set_range(
     return _BoundedFile(fh, length), length, (start, end, size)
 
 
-def _is_not_modified(
-    req: falcon.Request, etag: falcon.ETag, last_modified: datetime
-) -> bool:
+def _is_not_modified(req: falcon.Request, etag: str, last_modified: datetime) -> bool:
     """Check whether the requested resource can be served with 304 Not Modified."""
 
     # NOTE(Cycloctane): RFC 9110 Section 13.1.3: A recipient MUST ignore
@@ -268,7 +266,7 @@ class StaticRoute:
                 fh, st = _open_file(self._fallback_filename)
                 file_path = self._fallback_filename
 
-        etag = falcon.ETag(f'{int(st.st_mtime):x}-{st.st_size:x}')
+        etag = f'{int(st.st_mtime):x}-{st.st_size:x}'
         resp.etag = etag
 
         last_modified = datetime.fromtimestamp(st.st_mtime, timezone.utc)

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -94,6 +94,13 @@ def _set_range(
 def _is_not_modified(
     req: falcon.Request, etag: falcon.ETag, last_modified: datetime
 ) -> bool:
+    """Check whether the requested resource can be served with 304 Not Modified."""
+
+    # NOTE(Cycloctane): RFC 9110 Section 13.1.3: A recipient MUST ignore
+    #   If-Modified-Since if the request contains an If-None-Match header
+    #   field. See also:
+    #   https://www.rfc-editor.org/rfc/rfc9110#section-13.1.3-5
+    #   https://www.rfc-editor.org/rfc/rfc9110#section-13.2.2
     if req.if_none_match is not None:
         return (len(req.if_none_match) == 1 and req.if_none_match[0] == '*') or any(
             etag == i for i in req.if_none_match

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -247,11 +247,11 @@ class StaticRoute:
                 fh, st = _open_file(self._fallback_filename)
                 file_path = self._fallback_filename
 
-        etag = falcon.ETag(f"{int(st.st_mtime):x}-{st.st_size:x}")
+        etag = falcon.ETag(f'{int(st.st_mtime):x}-{st.st_size:x}')
         resp.etag = etag
 
         if req.if_none_match is not None and (
-            (len(req.if_none_match) == 1 and req.if_none_match[0] == "*")
+            (len(req.if_none_match) == 1 and req.if_none_match[0] == '*')
             or any(etag == i for i in req.if_none_match)
         ):
             fh.close()

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -91,7 +91,9 @@ def _set_range(
     return _BoundedFile(fh, length), length, (start, end, size)
 
 
-def _is_not_modified(req: falcon.Request, etag: str, last_modified: datetime) -> bool:
+def _is_not_modified(
+    req: falcon.Request, current_etag: str, last_modified: datetime
+) -> bool:
     """Check whether the requested resource can be served with 304 Not Modified."""
 
     # NOTE(Cycloctane): RFC 9110 Section 13.1.3: A recipient MUST ignore
@@ -101,7 +103,7 @@ def _is_not_modified(req: falcon.Request, etag: str, last_modified: datetime) ->
     #   https://www.rfc-editor.org/rfc/rfc9110#section-13.2.2
     if req.if_none_match is not None:
         return (len(req.if_none_match) == 1 and req.if_none_match[0] == '*') or any(
-            etag == i for i in req.if_none_match
+            current_etag == etag for etag in req.if_none_match
         )
 
     if req.if_modified_since is not None:

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -710,15 +710,14 @@ def test_etag(client, patch_open):
     'if_none_match, is_304',
     [
         ('*', True),
-        ('"6782afce-21"', True),
-        ('"6782afce-21", "foo"', True),
-        ('W/"6782afce-21"', True),
+        ('"6782afce-9"', True),
+        ('"6782afce-9", "foo"', True),
+        ('W/"6782afce-9"', True),
         ('"foo"', False),
     ],
 )
 def test_if_none_match(client, patch_open, if_none_match, is_304):
-    mtime = 1736617934.133701
-    patch_open(mtime=mtime)
+    patch_open(content=b'test_data', mtime=1736617934.133701)
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
     resp = client.simulate_request(
@@ -730,4 +729,4 @@ def test_if_none_match(client, patch_open, if_none_match, is_304):
         assert resp.text == ''
     else:
         assert resp.status == falcon.HTTP_200
-        assert resp.text == '/opt/somesite/assets/css/main.css'
+        assert resp.text == 'test_data'

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -703,18 +703,18 @@ def test_etag(client, patch_open):
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
     resp = client.simulate_request(path='/assets/css/main.css')
-    assert resp.headers['ETag'] == f"\"{int(mtime):x}-{len(resp.text):x}\""
+    assert resp.headers['ETag'] == f'"{int(mtime):x}-{len(resp.text):x}"'
 
 
 @pytest.mark.parametrize(
-    "if_none_match, is_304",
+    'if_none_match, is_304',
     [
-        ("*", True),
-        ("\"6782afce-21\"", True),
-        ("\"6782afce-21\", \"foo\"", True),
-        ("W/\"6782afce-21\"", True),
-        ("\"foo\"", False)
-    ]
+        ('*', True),
+        ('"6782afce-21"', True),
+        ('"6782afce-21", "foo"', True),
+        ('W/"6782afce-21"', True),
+        ('"foo"', False),
+    ],
 )
 def test_if_none_match(client, patch_open, if_none_match, is_304):
     mtime = 1736617934.133701
@@ -730,4 +730,4 @@ def test_if_none_match(client, patch_open, if_none_match, is_304):
         assert resp.text == ''
     else:
         assert resp.status == falcon.HTTP_200
-        assert resp.text == "/opt/somesite/assets/css/main.css"
+        assert resp.text == '/opt/somesite/assets/css/main.css'

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -711,7 +711,7 @@ def test_if_none_match(client, patch_open):
     patch_open(mtime=mtime)
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
-    etag = resp = client.simulate_request(path='/assets/css/main.css').headers['ETag']
+    etag = client.simulate_request(path='/assets/css/main.css').headers['ETag']
 
     resp1 = client.simulate_request(
         path='/assets/css/main.css',

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -706,35 +706,28 @@ def test_etag(client, patch_open):
     assert resp.headers['ETag'] == f'"{int(mtime):x}-{len(resp.text):x}"'
 
 
-def test_if_none_match(client, patch_open):
+@pytest.mark.parametrize(
+    'if_none_match, is_304',
+    [
+        ('*', True),
+        ('"6782afce-21"', True),
+        ('"6782afce-21", "foo"', True),
+        ('W/"6782afce-21"', True),
+        ('"foo"', False),
+    ],
+)
+def test_if_none_match(client, patch_open, if_none_match, is_304):
     mtime = 1736617934.133701
     patch_open(mtime=mtime)
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
-    etag = client.simulate_request(path='/assets/css/main.css').headers['ETag']
-
-    resp1 = client.simulate_request(
+    resp = client.simulate_request(
         path='/assets/css/main.css',
-        headers={'If-None-Match': etag},
+        headers={'If-None-Match': if_none_match},
     )
-    assert resp1.status == falcon.HTTP_304
-    assert resp1.text == ''
-
-    resp2 = client.simulate_request(
-        path='/assets/css/main.css',
-        headers={'If-None-Match': f'W/{etag}'},
-    )
-    assert resp2.status == falcon.HTTP_304
-
-    resp3 = client.simulate_request(
-        path='/assets/css/main.css',
-        headers={'If-None-Match': '*'},
-    )
-    assert resp3.status == falcon.HTTP_304
-
-    resp4 = client.simulate_request(
-        path='/assets/css/main.css',
-        headers={'If-None-Match': '"foo"'},
-    )
-    assert resp4.status == falcon.HTTP_200
-    assert resp4.text != ''
+    if is_304:
+        assert resp.status == falcon.HTTP_304
+        assert resp.text == ''
+    else:
+        assert resp.status == falcon.HTTP_200
+        assert resp.text == '/opt/somesite/assets/css/main.css'

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -706,28 +706,35 @@ def test_etag(client, patch_open):
     assert resp.headers['ETag'] == f'"{int(mtime):x}-{len(resp.text):x}"'
 
 
-@pytest.mark.parametrize(
-    'if_none_match, is_304',
-    [
-        ('*', True),
-        ('"6782afce-21"', True),
-        ('"6782afce-21", "foo"', True),
-        ('W/"6782afce-21"', True),
-        ('"foo"', False),
-    ],
-)
-def test_if_none_match(client, patch_open, if_none_match, is_304):
+def test_if_none_match(client, patch_open):
     mtime = 1736617934.133701
     patch_open(mtime=mtime)
 
     client.app.add_static_route('/assets/', '/opt/somesite/assets')
-    resp = client.simulate_request(
+    etag = resp = client.simulate_request(path='/assets/css/main.css').headers['ETag']
+
+    resp1 = client.simulate_request(
         path='/assets/css/main.css',
-        headers={'If-None-Match': if_none_match},
+        headers={'If-None-Match': etag},
     )
-    if is_304:
-        assert resp.status == falcon.HTTP_304
-        assert resp.text == ''
-    else:
-        assert resp.status == falcon.HTTP_200
-        assert resp.text == '/opt/somesite/assets/css/main.css'
+    assert resp1.status == falcon.HTTP_304
+    assert resp1.text == ''
+
+    resp2 = client.simulate_request(
+        path='/assets/css/main.css',
+        headers={'If-None-Match': f"W/{etag}"},
+    )
+    assert resp2.status == falcon.HTTP_304
+
+    resp3 = client.simulate_request(
+        path='/assets/css/main.css',
+        headers={'If-None-Match': '*'},
+    )
+    assert resp3.status == falcon.HTTP_304
+
+    resp4 = client.simulate_request(
+        path='/assets/css/main.css',
+        headers={'If-None-Match': '"foo"'},
+    )
+    assert resp4.status == falcon.HTTP_200
+    assert resp4.text != ''

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -722,7 +722,7 @@ def test_if_none_match(client, patch_open):
 
     resp2 = client.simulate_request(
         path='/assets/css/main.css',
-        headers={'If-None-Match': f"W/{etag}"},
+        headers={'If-None-Match': f'W/{etag}'},
     )
     assert resp2.status == falcon.HTTP_304
 


### PR DESCRIPTION
# Summary of Changes

- Render `Etag` header for static file responses
- Check requests' `If-None-Match` header and return 304 when appropriate.

# Related Issues

Fixes #2243 

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)
