### PR TITLE
docs(community): document release maintenance policy

### DIFF
--- a/.github/workflows/test-dist.yaml
+++ b/.github/workflows/test-dist.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - "*"
+  # TODO(vytas): Remove when demonstrated to pass.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-dist:
@@ -38,9 +42,11 @@ jobs:
       - name: Test sdist
         if: matrix.build == 'sdist'
         run: |
+          tools/check_dist.py
           tools/test_dist.py dist/*.tar.gz
 
       - name: Test pure-Python wheel
         if: matrix.build == 'wheel'
         run: |
+          tools/check_dist.py
           tools/test_dist.py dist/*.whl

--- a/.github/workflows/test-dist.yaml
+++ b/.github/workflows/test-dist.yaml
@@ -5,10 +5,6 @@ on:
   push:
     branches:
       - "*"
-  # TODO(vytas): Remove when demonstrated to pass.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-dist:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,15 +2,16 @@
 
 Release Process:
 
-1. Bump version (including the suffix for pre-release, if applicable).
-2. Update changelog and render towncrier fragments.
-3. Release beta or rc.
-4. Run benchmark and check for regressions.
-5. Review and edit doc changes since the last release for clarity and consistency.
-6. Publish final version and add a release note.
-7. Run benchmark and update falconframework.org with latest numbers.
-8. Announce the new version in Gitter channels and on the socials.
-9. Improve this document.
+1.  Bump version (including the suffix for pre-release, if applicable).
+2.  Update changelog and render towncrier fragments.
+3.  Release beta or rc.
+4.  Run benchmark and check for regressions.
+5.  Review and edit doc changes since the last release for clarity and consistency.
+6.  Publish final version and add a release note.
+7.  Run benchmark and update falconframework.org with latest numbers.
+8.  Announce the new version in Gitter channels and on the socials.
+9.  Incorporate the tag into the current stable series branch
+10. Improve this document.
 
 ### Bump version
 
@@ -131,6 +132,16 @@ TODO: Replace with CI gate
 
 ### Review and edit doc changes since the last release for clarity and consistency
 
+Make sure to add a release date to the changelog file in the form of (use the
+actual date of the release):
+
+```rst
+.. falcon-release: 2025-05-05
+```
+
+These comments are used to aggregate the table of stable releases in
+`docs/community/releases.rst`.
+
 ### Publish final version and add a release note
 
 Be sure to install and test from PyPI as a sanity check afterwards.
@@ -138,6 +149,24 @@ Be sure to install and test from PyPI as a sanity check afterwards.
 ### Run benchmark and update falconframework.org with latest numbers
 
 ### Announce the new version in Gitter channels and on the socials
+
+### Incorporate the tag into the current stable series branch
+
+Merge the stable tag into the maintenance branch of the current Falcon series,
+e.g., `falcon-4.x`.
+
+Normally, the following should suffice, but please verify and address
+conflicts, if any:
+
+```sh
+git checkout falcon-4.x
+git merge 4.$YOUR_MINOR.$YOUR_PATCH
+# E.g., git merge 4.2.3
+git push
+```
+
+If you are releasing a new major version of the framework, create a new branch,
+e.g., `falcon-5.x`.
 
 ### Improve this document
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ Release Process:
 6.  Publish final version and add a release note.
 7.  Run benchmark and update falconframework.org with latest numbers.
 8.  Announce the new version in Gitter channels and on the socials.
-9.  Incorporate the tag into the current stable series branch
+9.  Incorporate the tag into the current stable series branch.
 10. Improve this document.
 
 ### Bump version
@@ -164,6 +164,12 @@ git merge 4.$YOUR_MINOR.$YOUR_PATCH
 # E.g., git merge 4.2.3
 git push
 ```
+
+At the time of writing, the repository contains these stable series branches:
+* `falcon-1.x`: https://github.com/falconry/falcon/tree/falcon-1.x
+* `falcon-2.x`: https://github.com/falconry/falcon/tree/falcon-2.x
+* `falcon-3.x`: https://github.com/falconry/falcon/tree/falcon-3.x
+* `falcon-4.x`: https://github.com/falconry/falcon/tree/falcon-4.x
 
 If you are releasing a new major version of the framework, create a new branch,
 e.g., `falcon-5.x`.

--- a/docs/changes/1.0.0.rst
+++ b/docs/changes/1.0.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.0.0
 ==========================
 
+.. falcon-release: 2016-05-11
+
 Breaking Changes
 ----------------
 - The deprecated global hooks feature has been removed.

--- a/docs/changes/1.1.0.rst
+++ b/docs/changes/1.1.0.rst
@@ -106,3 +106,4 @@ Fixed
 - When running under Python 3, :meth:`inspect.signature()` is used
   instead of :meth:`inspect.getargspec()` to provide compatibility with
   annotated functions.
+

--- a/docs/changes/1.1.0.rst
+++ b/docs/changes/1.1.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.1.0
 ==========================
 
+.. falcon-release: 2016-10-27
+
 Breaking Changes
 ----------------
 
@@ -104,4 +106,3 @@ Fixed
 - When running under Python 3, :meth:`inspect.signature()` is used
   instead of :meth:`inspect.getargspec()` to provide compatibility with
   annotated functions.
-

--- a/docs/changes/1.2.0.rst
+++ b/docs/changes/1.2.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.2.0
 ==========================
 
+.. falcon-release: 2017-05-02
+
 Breaking Changes
 ----------------
 

--- a/docs/changes/1.3.0.rst
+++ b/docs/changes/1.3.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.3.0
 ==========================
 
+.. falcon-release: 2017-09-06
+
 Breaking Changes
 ----------------
 

--- a/docs/changes/1.4.0.rst
+++ b/docs/changes/1.4.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.4.0
 ==========================
 
+.. falcon-release: 2018-01-16
+
 Breaking Changes
 ----------------
 

--- a/docs/changes/1.4.1.rst
+++ b/docs/changes/1.4.1.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 1.4.1
 ==========================
 
+.. falcon-release: 2018-01-16
+
 Breaking Changes
 ----------------
 

--- a/docs/changes/2.0.0.rst
+++ b/docs/changes/2.0.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 2.0.0
 ==========================
 
+.. falcon-release: 2019-04-26
+
 Summary
 -------
 

--- a/docs/changes/3.0.0.rst
+++ b/docs/changes/3.0.0.rst
@@ -1,6 +1,7 @@
 Changelog for Falcon 3.0.0
 ==========================
 
+.. falcon-release: 2021-04-05
 
 Summary
 -------

--- a/docs/changes/3.0.1.rst
+++ b/docs/changes/3.0.1.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 3.0.1
 ==========================
 
+.. falcon-release: 2021-05-11
+
 Summary
 -------
 

--- a/docs/changes/3.1.0.rst
+++ b/docs/changes/3.1.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 3.1.0
 ==========================
 
+.. falcon-release: 2022-03-25
+
 
 Summary
 -------

--- a/docs/changes/3.1.1.rst
+++ b/docs/changes/3.1.1.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 3.1.1
 ==========================
 
+.. falcon-release: 2022-11-18
+
 Summary
 -------
 

--- a/docs/changes/3.1.2.rst
+++ b/docs/changes/3.1.2.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 3.1.2
 ==========================
 
+.. falcon-release: 2023-12-04
+
 Summary
 -------
 

--- a/docs/changes/3.1.3.rst
+++ b/docs/changes/3.1.3.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 3.1.3
 ==========================
 
+.. falcon-release: 2023-12-05
+
 Summary
 -------
 

--- a/docs/changes/4.0.0.rst
+++ b/docs/changes/4.0.0.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 4.0.0
 ==========================
 
+.. falcon-release: 2024-10-18
+
 Summary
 -------
 

--- a/docs/changes/4.0.1.rst
+++ b/docs/changes/4.0.1.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 4.0.1
 ==========================
 
+.. falcon-release: 2024-10-22
+
 Summary
 -------
 

--- a/docs/changes/4.0.2.rst
+++ b/docs/changes/4.0.2.rst
@@ -1,6 +1,8 @@
 Changelog for Falcon 4.0.2
 ==========================
 
+.. falcon-release: 2024-11-06
+
 Summary
 -------
 

--- a/docs/community/coc.md
+++ b/docs/community/coc.md
@@ -1,0 +1,8 @@
+% NOTE(vytas): This document is in MyST markdown (unlike others) in order to be
+%   able to share CODEOFCONDUCT.md verbatim.
+
+(coc)=
+
+```{include} ../../CODEOFCONDUCT.md
+
+```

--- a/docs/community/help.rst
+++ b/docs/community/help.rst
@@ -29,8 +29,7 @@ In addition to Gitter, we are also evaluating the popular GitHub
 `Discussions <https://github.com/falconry/falcon/discussions>`_ for less
 "realtime" communication such as usage questions or open-ended design ideas.
 
-Per our
-`Code of Conduct <https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md>`_,
+Per our :ref:`coc`,
 we expect everyone who participates in community discussions to act
 professionally, and lead by example in encouraging constructive
 discussions. Each individual in the community is responsible for
@@ -62,6 +61,4 @@ We'd love to have your help!
 
 Code of Conduct
 ---------------
-All contributors and maintainers of this project are subject to our `Code
-of Conduct <https://github.com/falconry/falcon/blob/master/CODEOFCONDUCT.md>`_.
-
+All contributors and maintainers of this project are subject to our :ref:`coc`.

--- a/docs/community/index.rst
+++ b/docs/community/index.rst
@@ -8,4 +8,5 @@ Community Guide
    contributing
    releases
    packaging
+   coc
    ../user/faq

--- a/docs/community/index.rst
+++ b/docs/community/index.rst
@@ -6,5 +6,6 @@ Community Guide
 
    help
    contributing
+   releases
    packaging
    ../user/faq

--- a/docs/community/packaging.rst
+++ b/docs/community/packaging.rst
@@ -32,6 +32,10 @@ Obtaining Release
 In order to package a specific Falcon release, you first need to obtain its
 source archive.
 
+.. tip::
+    Maintaining older versions of Falcon packages?
+    See what we support on our side: :ref:`supported_releases`.
+
 It is up to you which authoritative source to use.
 The most common alternatives are:
 
@@ -79,25 +83,21 @@ The most common alternatives are:
 Semantic Versioning
 -------------------
 
-Falcon strictly adheres to `SemVer <https://semver.org/>`__ -- incompatible API
-changes are only introduced in conjunction with a major version increment.
+Falcon strictly adheres to :ref:`SemVer <semver>` -- incompatible API changes
+are only introduced in conjunction with a major version increment.
 
 When updating your Falcon package, you should always carefully review
 :doc:`the changelog </changes/index>` for the new release that you targeting,
 especially if you are moving up to a new SemVer major version.
-(In that case, the release notes will include a "Breaking Changes" section.)
+(In that case, the release notes will include a **"Breaking Changes"**
+section.)
 
 For a packager, another section worth checking is called
-"Changes to Supported Platforms", where we announce support for new Python
+**"Changes to Supported Platforms"**, where we announce support for new Python
 interpreter versions (or even new implementations), as well as deprecate or
 remove the old ones.
-While there seems to be
-`no clear consensus <https://github.com/semver/semver/issues/716>`__ on whether
-removing platform support constitutes a SemVer breaking change, Falcon assumes
-that it does (unless we have communicated otherwise in advance, e.g., the
-:doc:`Falcon 4.x series </changes/4.0.0>` only guarantees Python 3.10+ support).
 
-.. note::
+.. attention::
     The SemVer guarantees primarily cover the publicly documented API from the
     framework user's perspective, so even a minor release may contain important
     changes to the build process, tests, and project tooling.

--- a/docs/community/releases.rst
+++ b/docs/community/releases.rst
@@ -1,0 +1,33 @@
+Releases and Versioning
+=======================
+
+Falcon is developed in the open (yes, You can :doc:`contribute <contributing>`
+too!) primarily using the
+`falconry/falcon <https://github.com/falconry/falcon>`__ GitHub repository.
+Newer releases are available from our GitHub
+`release page <https://github.com/falconry/falcon/releases>`__.
+Unless noted otherwise in specific files, Falcon releases are covered by the
+:ref:`Apache 2.0 License <falcon_license>`.
+
+
+.. _semver:
+
+Semantic Versioning
+-------------------
+
+Falcon strictly adheres to `SemVer <https://semver.org/>`__ -- incompatible API
+changes are only introduced in conjunction with a major version increment.
+
+
+Stable Release Status
+---------------------
+
+.. falcon-releases:: changes/
+
+TODO: write...
+
+
+Pre-releases and Development Versions
+-------------------------------------
+
+TODO: write...

--- a/docs/community/releases.rst
+++ b/docs/community/releases.rst
@@ -19,22 +19,44 @@ Falcon strictly adheres to `SemVer <https://semver.org/>`__ -- incompatible API
 changes are only introduced in conjunction with a major version increment.
 
 
+Supported Releases
+------------------
+
+.. _stable_release_current:
+
+.. rubric:: Current Release
+
+As Falcon is a relatively small project with limited resources and funding, we
+only actively support the current SemVer major/minor release.
+
+Although older minor releases from the current Falcon series are formally
+considered :ref:`stable_release_eol`, the upgrade path to the current release
+ought to be effortless thanks to Falcon's strict :ref:`SemVer <semver>`
+guarantees.
+
+.. _stable_release_security:
+
+.. rubric:: Security Maintenance
+
+We also provide limited security maintenance for the latest release of the old
+stable SemVer major series, until *(1)* it falls back two major releases
+behind, or *(2)* 730 days (two years bar the possibility of a leap year) pass
+from the first release of the current stable series
+(whichever comes first).
+
+.. _stable_release_eol:
+
+.. rubric:: EOL
+
+Other Falcon versions are considered End of Life (**EOL**).
+
 Stable Release Status
 ---------------------
 
-As Falcon is a relatively small project with limited resources and funding, ...
-(**Current Release**).
-
-We also provide limited security support for the latest release of the old
-stable SemVer major series until it either falls back two major releases
-behind, or two years pass from the first release of the current stable series,
-whichever comes first (**Security Maintenance**).
-
-Other versions are considered End of Life (**EOL**).
-
-The table below summarizes the history of Falcon stable (1.0+) releases
-alongside their maintenance status. (You can find even older release history in
-our repository's commit tree, or PyPI.)
+The below table summarizes the history of Falcon stable (1.0+) releases
+alongside their maintenance status.
+(You can find even older (0.x) release history in our repository's commit tree,
+or PyPI.)
 
 .. falcon-releases:: changes/
 

--- a/docs/community/releases.rst
+++ b/docs/community/releases.rst
@@ -22,6 +22,20 @@ changes are only introduced in conjunction with a major version increment.
 Stable Release Status
 ---------------------
 
+As Falcon is a relatively small project with limited resources and funding, ...
+(**Current Release**).
+
+We also provide limited security support for the latest release of the old
+stable SemVer major series until it either falls back two major releases
+behind, or two years pass from the first release of the current stable series,
+whichever comes first (**Security Maintenance**).
+
+Other versions are considered End of Life (**EOL**).
+
+The table below summarizes the history of Falcon stable (1.0+) releases
+alongside their maintenance status. (You can find even older release history in
+our repository's commit tree, or PyPI.)
+
 .. falcon-releases:: changes/
 
 TODO: write...
@@ -31,3 +45,8 @@ Pre-releases and Development Versions
 -------------------------------------
 
 TODO: write...
+
+That being said, we do try to keep the main development branch in good shape at
+all times; our Continuous Integration gates ensure that both ``master``
+commits, and pull requests being merged, pass all tests on all supported
+platforms.

--- a/docs/community/releases.rst
+++ b/docs/community/releases.rst
@@ -17,7 +17,20 @@ Semantic Versioning
 
 Falcon strictly adheres to `SemVer <https://semver.org/>`__ -- incompatible API
 changes are only introduced in conjunction with a major version increment.
+Furthermore, when we make breaking changes in a new major version of the
+framework, the old behavior or feature removal is deprecated in advance at
+least one minor release leading to the change. In addition to documenting
+deprecations, we do our best to emit deprecation :mod:`warnings`
+(where feasible).
 
+While there seems to be
+`no clear consensus <https://github.com/semver/semver/issues/716>`__ on whether
+removing platform support constitutes a SemVer breaking change, Falcon assumes
+that it does (unless we have communicated otherwise in advance, e.g., the
+:doc:`Falcon 4.x series </changes/4.0.0>` only guarantees Python 3.10+
+support).
+
+.. _supported_releases:
 
 Supported Releases
 ------------------
@@ -39,10 +52,17 @@ guarantees.
 .. rubric:: Security Maintenance
 
 We also provide limited security maintenance for the latest release of the old
-stable SemVer major series, until *(1)* it falls back two major releases
+stable SemVer major series until *(1)* it falls back two major releases
 behind, or *(2)* 730 days (two years bar the possibility of a leap year) pass
 from the first release of the current stable series
 (whichever comes first).
+
+"Security maintenance" of an old stable release here means providing new patch
+versions in response to security vulnerabilities. Other bugs (regardless of
+their impact) and compatibility with new Python versions are only addressed in
+the :ref:`stable_release_current`. Reported security vulnerabilities are
+evaluated on a case by case basis, with the Common Vulnerability Scoring System
+(CVSS) score reaching at least "Medium" (4.0+) as a starting point.
 
 .. _stable_release_eol:
 
@@ -50,25 +70,39 @@ from the first release of the current stable series
 
 Other Falcon versions are considered End of Life (**EOL**).
 
+If you are stuck on an old Falcon version, you are still welcome to
+:ref:`ask for help <help>`! However, while we may be able to advise how to work
+around a specific issue, we will not ship new patch versions to
+EOL Falcon releases.
+
+
 Stable Release Status
 ---------------------
 
 The below table summarizes the history of Falcon stable (1.0+) releases
-alongside their maintenance status.
-(You can find even older (0.x) release history in our repository's commit tree,
-or PyPI.)
+alongside their maintenance status:
 
 .. falcon-releases:: changes/
 
-TODO: write...
+(You can find even older (0.x) release history in our repository's commit tree,
+or PyPI.)
 
 
 Pre-releases and Development Versions
 -------------------------------------
 
-TODO: write...
-
+The upcoming Falcon version release normally lives in our main development
+branch (``master``). If you absolutely need a new unreleased feature or fix,
+You can :ref:`install <install>` it directly from GitHub, however, we strongly
+recommend to deploy only stable Falcon releases to production.
 That being said, we do try to keep the main development branch in good shape at
 all times; our Continuous Integration gates ensure that both ``master``
-commits, and pull requests being merged, pass all tests on all supported
+commits, and pull requests being merged, pass all tests on the supported
 platforms.
+
+Prior to a new stable release, we normally cut several alphas, betas, and
+release candidates. Falcon has no fixed pre-release schedule (unlike, e.g.,
+CPython), and the exact number of pre-releases depends on many factors, such as
+the scope of the impending stable release, the extent of issues found in beta
+testing, and ultimately, it is decided at the discretion of the release manager
+and the core maintainer team.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ extensions = [
     'ext.autodoc_customizations',
     'ext.cibuildwheel',
     'ext.doorway',
+    'ext.falcon_releases',
     'ext.private_args',
     'ext.rfc',
 ]

--- a/docs/ext/cibuildwheel.py
+++ b/docs/ext/cibuildwheel.py
@@ -57,9 +57,9 @@ class WheelsDirective(sphinx.util.docutils.SphinxDirective):
     @classmethod
     def _emit_table(cls, data):
         columns = len(data[0])
-        assert all(
-            len(row) == columns for row in data
-        ), 'All rows must have the same number of columns'
+        assert all(len(row) == columns for row in data), (
+            'All rows must have the same number of columns'
+        )
         # NOTE(vytas): +2 is padding inside cell borders.
         width = max(len(cell) for cell in itertools.chain(*data)) + 2
         hline = ('+' + '-' * width) * columns + '+\n'

--- a/docs/ext/falcon_releases.py
+++ b/docs/ext/falcon_releases.py
@@ -1,0 +1,62 @@
+# Copyright 2025 by Vytautas Liuolia.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Information on stable Falcon releases.
+
+This extension aggregates a table of maintained and EOL Falcon releases from
+the provided path containing changelogs.
+"""
+
+import pathlib
+import re
+
+import sphinx.util.docutils
+
+FALCON_DOCS_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+class FalconReleasesDirective(sphinx.util.docutils.SphinxDirective):
+    """Directive to tabulate the summary of stable Falcon releases."""
+
+    required_arguments = 1
+    has_content = True
+
+    _CHANGELOG_PATTERN = re.compile(r'^(\d+)\.(\d+).(\d+)\.rst$')
+
+    def run(self):
+        changelog_path = pathlib.Path(self.arguments[0])
+        if not changelog_path.is_absolute():
+            changelog_path = FALCON_DOCS_ROOT / changelog_path
+
+        releases = []
+        for path in changelog_path.iterdir():
+            if not (mt := self._CHANGELOG_PATTERN.match(path.name)):
+                continue
+            version = tuple(map(int, mt.groups()))
+            releases.append(version)
+
+        releases.sort()
+        content = '\n'.join(f'* ``{version=}``' for version in releases)
+        return self.parse_text_to_nodes(content)
+
+
+def setup(app):
+    app.add_directive('falcon-releases', FalconReleasesDirective)
+
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/ext/falcon_releases.py
+++ b/docs/ext/falcon_releases.py
@@ -19,6 +19,10 @@ This extension aggregates a table of maintained and EOL Falcon releases from
 the provided path containing changelogs.
 """
 
+import collections
+import datetime
+import enum
+import itertools
 import pathlib
 import re
 
@@ -27,29 +31,186 @@ import sphinx.util.docutils
 FALCON_DOCS_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
+class _FalconRelease:
+    """A stable Falcon release."""
+
+    _CHANGELOG_PATTERN = re.compile(r'^(\d+)\.(\d+).(\d+)\.rst$')
+    _RELEASE_META_PATTERN = re.compile(r'\.\.\s+falcon-release\:\s+([\d-]+)')
+
+    _PYPI_API_URL = 'https://pypi.org/pypi/falcon/{version}/json'
+
+    @classmethod
+    def from_changelog(cls, path):
+        if not (mt := cls._CHANGELOG_PATTERN.match(path.name)):
+            return None
+
+        version = tuple(map(int, mt.groups()))
+        if mt := cls._RELEASE_META_PATTERN.search(path.read_text()):
+            date = datetime.date.fromisoformat(mt.group(1))
+        else:
+            date = None
+
+        return cls(version, date)
+
+    @classmethod
+    def gather(cls, changelog_path):
+        releases = [cls.from_changelog(path) for path in changelog_path.iterdir()]
+        return sorted(
+            release
+            for release in releases
+            if release is not None and not release.is_zerover
+        )
+
+    @property
+    def is_zerover(self):
+        return self.major == 0
+
+    @property
+    def major(self):
+        return self.version[0]
+
+    @property
+    def version_str(self):
+        return '.'.join(map(str, self.version))
+
+    @property
+    def version_major_minor(self):
+        return '.'.join(map(str, self.version[:2]))
+
+    def __init__(self, version, date=None):
+        self.version = version
+        self.date = date
+
+    @property
+    def doc_link(self):
+        return f':doc:`{self.version_str} </changes/{self.version_str}>`'
+
+    @property
+    def doc_link_major_minor(self):
+        return f':doc:`{self.version_major_minor} </changes/{self.version_str}>`'
+
+    @property
+    def rst_repr(self):
+        return f'{self.doc_link} ({self.date})'
+
+    def __eq__(self, other):
+        return self.version == other.version
+
+    def __lt__(self, other):
+        return self.version < other.version
+
+    def __repr__(self):
+        return f'<falcon-{self.version_str} {self.date}>'
+
+    def _load_date_from_pypi(self):
+        # NOTE(vytas): This is not really used, but it is handy to verify the
+        #   dates of historical releases, and other types of debugging.
+        import requests
+
+        resp = requests.get(self._PYPI_API_URL.format(version=self.version_str))
+        if resp.status_code == 200:
+            artifact, *_ = resp.json()['urls']
+            upload_date, _, _ = artifact['upload_time'].partition('T')
+            self.date = datetime.date.fromisoformat(upload_date)
+        return self.date
+
+
+_FalconMajorMinor = collections.namedtuple('_FalconMajorMinor', ('first', 'latest'))
+
+
+class _ReleaseStatus(enum.Enum):
+    current = 'current'
+    security = 'security'
+    eol = 'eol'
+
+    @property
+    def ref(self):
+        return f':ref:`stable_release_{self.value}`'
+
+
 class FalconReleasesDirective(sphinx.util.docutils.SphinxDirective):
     """Directive to tabulate the summary of stable Falcon releases."""
 
+    _OLDSTABLE_MAINTENANCE_PERIOD = datetime.timedelta(days=365 * 2)
+
     required_arguments = 1
     has_content = True
-
-    _CHANGELOG_PATTERN = re.compile(r'^(\d+)\.(\d+).(\d+)\.rst$')
 
     def run(self):
         changelog_path = pathlib.Path(self.arguments[0])
         if not changelog_path.is_absolute():
             changelog_path = FALCON_DOCS_ROOT / changelog_path
 
-        releases = []
-        for path in changelog_path.iterdir():
-            if not (mt := self._CHANGELOG_PATTERN.match(path.name)):
-                continue
-            version = tuple(map(int, mt.groups()))
-            releases.append(version)
+        releases = _FalconRelease.gather(changelog_path)
+        for release in releases[:-1]:
+            assert release.date is not None, (
+                f'{release} has no release date metadata (and is not latest)'
+            )
 
-        releases.sort()
-        content = '\n'.join(f'* ``{version=}``' for version in releases)
-        return self.parse_text_to_nodes(content)
+        releases[-1].date = datetime.date(2025, 6, 6)
+        if releases[-1].date is None:
+            releases.pop()
+
+        stable_releases = []
+        for _, group in itertools.groupby(
+            reversed(releases), lambda rel: rel.version_major_minor
+        ):
+            series = list(group)
+            stable_releases.append(
+                _FalconMajorMinor(first=min(series), latest=max(series))
+            )
+
+        current = stable_releases[0]
+        current_series = sorted(
+            rel for rel in stable_releases if rel.first.major == current.first.major
+        )
+        oldstable = max(
+            rel for rel in stable_releases if rel.first.major == current.first.major - 1
+        )
+
+        header = '.. list-table::\n    :header-rows: 1\n\n'
+        rows = [
+            (
+                'Major/Minor Version',
+                'First Point Release',
+                'Latest Point Release',
+                'Release Status',
+            )
+        ]
+
+        for first, latest in stable_releases:
+            eol_label = ''
+            if latest == current.latest:
+                status = _ReleaseStatus.current
+            elif latest == oldstable.latest:
+                eol_date = (
+                    current_series[0].first.date + self._OLDSTABLE_MAINTENANCE_PERIOD
+                )
+                if datetime.date.today() < eol_date:
+                    status = _ReleaseStatus.security
+                    # NOTE(vytas): Move to a new line because otherwise table
+                    #   layout gets messed up in an unpleasant way.
+                    eol_label = f'\n\n        (until {eol_date})'
+                else:
+                    status = _ReleaseStatus.eol
+                    eol_label = f'(since {eol_date})'
+            else:
+                status = _ReleaseStatus.eol
+
+            rows.append(
+                (
+                    first.doc_link_major_minor,
+                    first.rst_repr,
+                    latest.rst_repr,
+                    f'{status.ref} {eol_label}',
+                )
+            )
+
+        content = '\n\n'.join(
+            '    * ' + '\n      '.join(f'- {cell}' for cell in row) for row in rows
+        )
+
+        return self.parse_text_to_nodes(header + content)
 
 
 def setup(app):

--- a/docs/ext/falcon_releases.py
+++ b/docs/ext/falcon_releases.py
@@ -146,8 +146,6 @@ class FalconReleasesDirective(sphinx.util.docutils.SphinxDirective):
             assert release.date is not None, (
                 f'{release} has no release date metadata (and is not latest)'
             )
-
-        releases[-1].date = datetime.date(2025, 6, 6)
         if releases[-1].date is None:
             releases.pop()
 

--- a/docs/ext/falcon_releases.py
+++ b/docs/ext/falcon_releases.py
@@ -170,8 +170,8 @@ class FalconReleasesDirective(sphinx.util.docutils.SphinxDirective):
         rows = [
             (
                 'Major/Minor Version',
-                'First Point Release',
-                'Latest Point Release',
+                'First Release',
+                'Latest Patch Release',
                 'Release Status',
             )
         ]
@@ -199,7 +199,7 @@ class FalconReleasesDirective(sphinx.util.docutils.SphinxDirective):
                 (
                     first.doc_link_major_minor,
                     first.rst_repr,
-                    latest.rst_repr,
+                    latest.version_str if latest == first else latest.rst_repr,
                     f'{status.ref} {eol_label}',
                 )
             )

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -148,7 +148,7 @@ courtesy of `cibuildwheel <https://cibuildwheel.pypa.io/>`__.
     :ref:`Let us know how it went <chat>`!
 
 While we believe that our build configuration covers the most common
-development and deployment scenarios, :ref:`let us known <chat>` if you are
+development and deployment scenarios, :ref:`let us know <chat>` if you are
 interested in any builds that are currently missing from our selection!
 
 Dependencies

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -54,8 +54,7 @@ Falcon + PyPy first.
 
 **Reliable.** We go to great lengths to avoid introducing
 breaking changes, and when we do they are fully documented and only
-introduced (in the spirit of
-`SemVer <https://semver.org/>`__) with a major version
+introduced (in the spirit of :ref:`SemVer <semver>`) with a major version
 increment. The code is rigorously tested with numerous inputs and we
 require 100% coverage at all times. Falcon does not depend on any
 external Python packages.

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -84,6 +84,8 @@ Now, if you do make changes to Falcon itself, please consider contributing your 
 
 .. _`Apache 2.0 License`: http://opensource.org/licenses/Apache-2.0
 
+.. _falcon_license:
+
 Falcon License
 --------------
 

--- a/tox.ini
+++ b/tox.ini
@@ -253,12 +253,12 @@ commands = {[smoke-test]commands}
 # --------------------------------------------------------------------
 
 [testenv:pep8]
-deps = ruff>=0.9.2
+deps = ruff>=0.11.6
 skip_install = True
 commands = ruff check []
 
 [testenv:pep8-docstrings]
-deps = ruff>=0.9.2
+deps = ruff>=0.11.6
 skip_install = True
 commands = ruff check \
              --exclude=.ecosystem,.eggs,.git,.tox,.venv,build,dist,docs,examples,tests,falcon/bench/nuts \
@@ -266,12 +266,12 @@ commands = ruff check \
              []
 
 [testenv:ruff]
-deps = ruff>=0.9.2
+deps = ruff>=0.11.6
 skip_install = True
 commands = ruff format --check . []
 
 [testenv:reformat]
-deps = ruff>=0.9.2
+deps = ruff>=0.11.6
 skip_install = True
 commands =
     ruff format . []


### PR DESCRIPTION
As discussed with @CaselIT, we formalized the security maintenance period of the "old stable" series (e.g., Falcon 3.x atm), currently defined as 2 years from the first stable release of the current series.

Closes #2410.