### PR TITLE
fix(typing): fix type definition to match __slots__ value

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -2436,7 +2436,7 @@ class RequestOptions:
     respectively.
     """
 
-    keep_black_qs_values: bool
+    keep_blank_qs_values: bool
     """Set to ``False`` to ignore query string params that have missing or blank
     values (default ``True``).
 


### PR DESCRIPTION
# Summary of Changes

fixed a typo ([PR](https://github.com/falconry/falcon/pull/2290), [diff](https://github.com/falconry/falcon/commit/a452a2d92ea81612b8f8232b3625a9f721dbaf70#diff-17cd1395bb55dc2d7ab7458044c8ded6617eff797edfdbd7dbb7c707753bab91R2007)) in a type annotation.  note that removing the unintended value here is not potentially breaking, because the class uses `__slots__` which prevents the assignment already.  Anyone that tried to assign to this value would hit an `AttributeError` before they accidentally starting using it.  Here's a quick validation of that:

```py
class Demo:
    unknown: int
    __slots__ = ['known']
    def __init__(self, known):
        self.known = known

h = Demo("ok")

#  raises AttributeError: 'Demo' object has no attribute 'unknown' and no __dict__ for setting new attributes
h.unknown = 3
```

here's the non-existent attribute on the stable version of the falcon docs:

https://falcon.readthedocs.io/en/stable/api/app.html#falcon.RequestOptions.keep_black_qs_values



# Related Issues

N/A - didn't file an issue since it's a quick fix.

# Pull Request Checklist


I didn't run any of the checks listed in the PR template, please let me know if they're still necessary for this change.

I'm not sure if there's a way to write a test to guard this - maybe something that checks if a class's type annotations includes a member not in `__slots__`?  But then subclassing could complicate things.