### PR TITLE
feat(testing): add rich repr to testing.Result

### DIFF
--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -34,6 +34,7 @@ from typing import (
     Coroutine,
     Dict,
     Iterable,
+    List,
     Literal,
     Mapping,
     Optional,
@@ -379,6 +380,32 @@ class Result(_ResultBase):
         return json_module.loads(self.text)
 
     def __repr__(self) -> str:
+        repr_result = ' '.join(filter(None, self._prepare_repr_args()))
+
+        return 'Result<{}>'.format(repr_result)
+
+    def __rich__(self) -> str:
+        status, content_type, content = self._prepare_repr_args()
+
+        status_color: str
+
+        for prefix, color in (
+            ('1', 'blue'),
+            ('2', 'green'),
+            ('3', 'yellow'),
+            ('4', 'magenta'),
+            ('5', 'red'),
+        ):
+            if status.startswith(prefix):
+                status_color = color
+
+        result_template = (
+            '[bold]Result[/]<[bold {}]{}[/] [italic dark_cyan]{}[/] [grey50]{}[/]>'
+        )
+
+        return result_template.format(status_color, status, content_type, content)
+
+    def _prepare_repr_args(self) -> List[str]:
         content_type = self.content_type or ''
 
         if len(self.content) > 40:
@@ -386,10 +413,9 @@ class Result(_ResultBase):
         else:
             content = self.content
 
-        args = [self.status, content_type, str(content)]
+        repr_args = [self.status, content_type, str(content)]
 
-        repr_result = ' '.join(filter(None, args))
-        return 'Result<{}>'.format(repr_result)
+        return repr_args
 
 
 class StreamedResult(_ResultBase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -838,6 +838,116 @@ class TestFalconTestingUtils:
         expected_result = 'Result<200 OK {}>'.format(value)
         assert str(result) == expected_result
 
+    @pytest.mark.parametrize(
+        'simulate',
+        [
+            testing.simulate_get,
+            testing.simulate_post,
+        ],
+    )
+    @pytest.mark.parametrize(
+        'value',
+        (
+            'd\xff\xff\x00',
+            'quick fox jumps over the lazy dog',
+            '{"hello": "WORLD!"}',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praese',
+            '{"hello": "WORLD!", "greetings": "fellow traveller"}',
+            '\xe9\xe8',
+        ),
+    )
+    def test_rich_repr_result_when_body_varies(self, asgi, util, value, simulate):
+        if isinstance(value, str):
+            value = bytes(value, 'UTF-8')
+
+        if asgi:
+            resource = testing.SimpleTestResourceAsync(body=value)
+        else:
+            resource = testing.SimpleTestResource(body=value)
+
+        app = util.create_app(asgi)
+        app.add_route('/hello', resource)
+
+        result: falcon.testing.Result = simulate(app, '/hello')
+        captured_resp = resource.captured_resp
+        content = captured_resp.text
+
+        if len(value) > 40:
+            content = value[:20] + b'...' + value[-20:]
+        else:
+            content = value
+
+        args = [
+            captured_resp.status,
+            captured_resp.headers['content-type'],
+            str(content),
+        ]
+
+        status_color: str
+
+        for prefix, color in (
+            ('1', 'blue'),
+            ('2', 'green'),
+            ('3', 'yellow'),
+            ('4', 'magenta'),
+            ('5', 'red'),
+        ):
+            if captured_resp.status.startswith(prefix):
+                status_color = color
+
+        result_template = (
+            '[bold]Result[/]<[bold {}]{}[/] [italic dark_cyan]{}[/] [grey50]{}[/]>'
+        )
+        expected_result = result_template.format(status_color, *args)
+
+        assert result.__rich__() == expected_result
+
+    @pytest.mark.parametrize(
+        'value',
+        (
+            'd\xff\xff\x00',
+            'quick fox jumps over the lazy dog',
+            '{"hello": "WORLD!"}',
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praese',
+            '{"hello": "WORLD!", "greetings": "fellow traveller"}',
+            '\xe9\xe8',
+        ),
+    )
+    @pytest.mark.parametrize(
+        'status_color_pair',
+        (
+            (falcon.HTTP_101, 'blue'),
+            (falcon.HTTP_200, 'green'),
+            (falcon.HTTP_301, 'yellow'),
+            (falcon.HTTP_404, 'magenta'),
+            (falcon.HTTP_500, 'red'),
+        ),
+    )
+    def test_rich_repr_with_different_statuses(self, asgi, status_color_pair, value):
+        expected_status, expected_color = status_color_pair
+
+        if isinstance(value, str):
+            value = bytes(value, 'UTF-8')
+
+        result = falcon.testing.Result(
+            [value], expected_status, [('content-type', 'dummy')]
+        )
+
+        if len(value) > 40:
+            content = value[:20] + b'...' + value[-20:]
+        else:
+            content = value
+
+        expected_result_template = (
+            '[bold]Result[/]<[bold {}]{}[/] [italic dark_cyan]{}[/] [grey50]{}[/]>'
+        )
+
+        expected_result = expected_result_template.format(
+            expected_color, expected_status, 'dummy', content
+        )
+
+        assert result.__rich__() == expected_result
+
     def test_wsgi_iterable_not_closeable(self):
         result = testing.Result([], falcon.HTTP_200, [])
         assert not result.content


### PR DESCRIPTION
# Summary of Changes

Hello! This PR implements `__rich__` method for `testing.Result` which can be used with [rich](https://github.com/Textualize/rich) console/terminal library. 

Improvised a bit, status code and color mapping as following: `1xx` - blue, `2xx` -  green, `3xx` - yellow, `4xx` - magenta, `5xx` - red (rich standard [colors](https://rich.readthedocs.io/en/stable/appendix/colors.html)).

Did some refactoring related to reusability, where some part of the code is used in both `__repr__` and `__rich__`.

![image](https://github.com/user-attachments/assets/6beed771-003b-489a-b4c0-cc07566aa07a)

<details>
<summary>Code</summary>

```python
from rich import print

import falcon
import falcon.testing

statuses = [
    falcon.HTTP_101,
    falcon.HTTP_200,
    falcon.HTTP_301,
    falcon.HTTP_404,
    falcon.HTTP_500,
]

for status in statuses:
    result = falcon.testing.Result(
        [b'salom!'],
        status,
        [('content-type', 'application/falcon')],
    )
    print(result)
```
</details>


# Related Issues

Fixes #2457

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
