### PR TITLE
feat(cors): support for private networks in `CORSMiddleware`

### DIFF
--- a/docs/_newsfragments/2381.newandimproved.rst
+++ b/docs/_newsfragments/2381.newandimproved.rst
@@ -1,8 +1,4 @@
-Added support for private network requests in :class:`falcon.middleware.CORSMiddleware`.
-
-This feature is disabled by default and can be enabled by passing the ``allow_private_network=True`` keyword argument to :class:`falcon.middleware.CORSMiddleware`.
-
-Two optional parameters were also added:
-
-- ``private_network_access_name``: A human-readable name for the private network resource. This can be displayed in the browser prompt instead of an IP address.
-- ``private_network_access_id``: A unique and stable machine-readable identifier, such as a MAC address.
+Added support for private network requests in CORS middleware.
+This is off by default and can be enabled by passing the keyword argument 
+``allow_private_network=True`` to :class:`falcon.middleware.CORSMiddleware` 
+during initialization.

--- a/docs/_newsfragments/2381.newandimproved.rst
+++ b/docs/_newsfragments/2381.newandimproved.rst
@@ -1,0 +1,8 @@
+Added support for private network requests in :class:`falcon.middleware.CORSMiddleware`.
+
+This feature is disabled by default and can be enabled by passing the ``allow_private_network=True`` keyword argument to :class:`falcon.middleware.CORSMiddleware`.
+
+Two optional parameters were also added:
+
+- ``private_network_access_name``: A human-readable name for the private network resource. This can be displayed in the browser prompt instead of an IP address.
+- ``private_network_access_id``: A unique and stable machine-readable identifier, such as a MAC address.

--- a/falcon/middleware.py
+++ b/falcon/middleware.py
@@ -43,7 +43,7 @@ class CORSMiddleware(UniversalMiddlewareWithProcessResponse):
             (default ``None``).
 
             See also:
-                * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
+            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
         allow_credentials (Optional[Union[str, Iterable[str]]]): List of origins
             (case sensitive) for which to allow credentials via the
             ``Access-Control-Allow-Credentials`` header.
@@ -60,7 +60,7 @@ class CORSMiddleware(UniversalMiddlewareWithProcessResponse):
             (default ``False``).
 
             See also:
-                * https://wicg.github.io/private-network-access/#private-network-request-heading
+            https://wicg.github.io/private-network-access/#private-network-request-heading
     """
 
     def __init__(
@@ -157,11 +157,9 @@ class CORSMiddleware(UniversalMiddlewareWithProcessResponse):
                 resp.set_header('Access-Control-Allow-Headers', allow_headers)
                 resp.set_header('Access-Control-Max-Age', '86400')  # 24 hours
 
-            has_request_private_network = (
+            if self.allow_private_network and (
                 req.get_header('Access-Control-Request-Private-Network') == 'true'
-            )
-
-            if has_request_private_network and self.allow_private_network:
+            ):
                 resp.set_header('Access-Control-Allow-Private-Network', 'true')
 
     async def process_response_async(

--- a/tests/test_cors_middleware.py
+++ b/tests/test_cors_middleware.py
@@ -161,6 +161,36 @@ class TestCorsMiddleware:
             assert 'Access-Control-Expose-Headers' not in result.headers
             assert 'Access-Control-Allow-Origin' not in result.headers
 
+    @pytest.mark.parametrize('include_request_private_network', (True, False))
+    def test_disabled_cors_private_network(
+        self, cors_client, include_request_private_network
+    ):
+        # default scenario for cors middleware, where
+        # allow private network is disabled by default
+
+        cors_client.app.add_route('/', CORSHeaderResource())
+
+        default_headers = (
+            ('Origin', 'localhost'),
+            ('Access-Control-Request-Method', 'GET'),
+        )
+
+        if include_request_private_network:
+            headers = (
+                *default_headers,
+                ('Access-Control-Request-Private-Network', 'true'),
+            )
+        else:
+            headers = default_headers
+
+        result = cors_client.simulate_options('/', headers=headers)
+
+        h = result.headers
+
+        assert 'Access-Control-Allow-Private-Network' not in h
+        assert 'Private-Network-Access-Name' not in h
+        assert 'Private-Network-Access-ID' not in h
+
 
 @pytest.fixture(scope='function')
 def make_cors_client(asgi, util):
@@ -293,3 +323,130 @@ class TestCustomCorsMiddleware:
         assert res.headers['Access-Control-Expose-Headers'] == exp
         h = dict(res.headers.lower_items()).keys()
         assert 'Access-Control-Allow-Credentials'.lower() not in h
+
+    @pytest.mark.parametrize(
+        'network_access_name',
+        ('smart_watch', 'local_printer', 'device', None),
+    )
+    @pytest.mark.parametrize(
+        'network_access_id',
+        ('41:0e:0c:5a:c2:0d', '71:fd:71:66:67:db', '7c:c2:19:c0:db:ec', None),
+    )
+    def test_enabled_cors_private_network_headers(
+        self, make_cors_client, network_access_name, network_access_id
+    ):
+        client = make_cors_client(
+            falcon.CORSMiddleware(
+                allow_private_network=True,
+                private_network_access_name=network_access_name,
+                private_network_access_id=network_access_id,
+            )
+        )
+
+        client.app.add_route('/', CORSHeaderResource())
+
+        res = client.simulate_options(
+            '/',
+            headers=(
+                ('Origin', 'localhost'),
+                ('Access-Control-Request-Method', 'GET'),
+                ('Access-Control-Request-Private-Network', 'true'),
+            ),
+        )
+
+        h = res.headers
+
+        assert h['Access-Control-Allow-Private-Network'] == 'true'
+
+        if network_access_name is None:
+            'Private-Network-Access-Name' not in h
+        else:
+            assert h.get('Private-Network-Access-Name') == network_access_name
+
+        if network_access_id is None:
+            'Private-Network-Access-ID' not in h
+        else:
+            assert h.get('Private-Network-Access-ID') == network_access_id
+
+    @pytest.mark.parametrize(
+        'private_network_access_id, is_valid',
+        (
+            # valid
+            (None, True),
+            ('01:23:45:67:89:0A', True),
+            ('ab:cd:ef:00:11:22', True),
+            ('FF:FF:FF:FF:FF:FF', True),
+            ('00:00:00:00:00:00', True),
+            ('aB:cD:Ef:12:34:56', True),
+            # invalid
+            ('', False),
+            ('0123456789AB', False),
+            ('01:23:45:67:89:0A:BC', False),
+            ('01:23:45:67:89:ZZ', False),
+            ('01-23-45-67-89-0A', False),
+            ('01:23:45:67:89:', False),
+        ),
+    )
+    def test_cors_enabled_private_network_access_id_validation(
+        self, private_network_access_id, is_valid
+    ):
+        if is_valid:
+            try:
+                falcon.CORSMiddleware(
+                    allow_private_network=True,
+                    private_network_access_id=private_network_access_id,
+                    private_network_access_name='valid-name',
+                )
+            except ValueError:
+                pytest.fail(
+                    'Expected ID to be valid but raised ValueError: {}'.format(
+                        private_network_access_id
+                    )
+                )
+        else:
+            with pytest.raises(ValueError, match='(?i)private.*network.*id'):
+                falcon.CORSMiddleware(
+                    allow_private_network=True,
+                    private_network_access_id=private_network_access_id,
+                    private_network_access_name='valid-name',
+                )
+
+    @pytest.mark.parametrize(
+        'private_network_access_name, is_valid',
+        (
+            # valid
+            (None, True),
+            ('device-1', True),
+            ('device.name_123', True),
+            ('a' * 248, True),
+            ('a_b.c-d.e_f', True),
+            # invalid
+            ('', False),
+            ('MyDevice', False),
+            ('smart device', False),
+            ('abc\nxyz', False),
+            ('a' * 249, False),
+        ),
+    )
+    def test_cors_enabled_private_network_access_name_validation(
+        self, private_network_access_name, is_valid
+    ):
+        if is_valid:
+            try:
+                falcon.CORSMiddleware(
+                    allow_private_network=True,
+                    private_network_access_name=private_network_access_name,
+                    private_network_access_id='01:23:45:67:89:0A',
+                )
+            except ValueError:
+                pytest.fail(
+                    'Expected name to be valid but raised ValueError: '
+                    f'{private_network_access_name!r}'
+                )
+        else:
+            with pytest.raises(ValueError, match='(?i)private.*network.*name'):
+                falcon.CORSMiddleware(
+                    allow_private_network=True,
+                    private_network_access_name=private_network_access_name,
+                    private_network_access_id='01:23:45:67:89:0A',
+                )


### PR DESCRIPTION
# Summary of Changes

Added support for private networks (`Access-Control-Allow-Private-Network` header). 

I've read referenced [docs](https://wicg.github.io/private-network-access/#headers), where I also found two additional(and optional) headers that I also added support in this PR. From docs:

> * The Private-Network-Access-Name attempts to provide users a human friendly name in the private network access permission prompt.
> * The Private-Network-Access-ID header is used in the [PrivateNetworkAccessPermissionDescriptor](https://wicg.github.io/private-network-access/#dictdef-privatenetworkaccesspermissiondescriptor) to identify identical devices across IP addresses.

They are being validated accordingly as stated in [docs](https://wicg.github.io/private-network-access/#permission-prompt).

Should I update relevant docs ? I built documentation, and its generating from docstring that I modified which "might" be sufficient.

**edit:** allow edits by maintainers checkbox is not appearing, because I forked this repository in my own organization (where I store all forks).

# Related Issues

fixes: #2381

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
