### PR TITLE
chore(PyPI): test PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -91,14 +91,11 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'workflow_dispatch'
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish sdist and pure-Python wheel to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release'
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
 
   build-wheels:
     name: ${{ matrix.python }}-${{ matrix.platform.name }}
@@ -202,11 +199,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'workflow_dispatch'
         with:
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish binary wheels to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release'
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Not closing the issue automatically by merging the PR yet...

The plan is to merge this, and then manually dispatch a test release to TestPyPI where I also set up Trusted Publishing.

We'll start without environments for now, normally we trust the whole limited pool of maintainers for now. We can take a look at that later.