### PR TITLE
test(wsgi-servers): add CherryPy's Cheroot to WSGI server tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -195,6 +195,7 @@ commands = {[with-cython]commands}
 [testenv:wsgi_servers]
 setenv = {[with-cython]setenv}
 deps = {[with-cython]deps}
+       cheroot
        gunicorn
        uwsgi
        waitress


### PR DESCRIPTION
CherryPy is maintained by @webknjaz who has been helpful on numerous issues, so it should be a low maintenance cost addition. :sweat_smile: (Everything passed out of the box as soon as I configured the correct options.)