### PR TITLE
chore(cibuildwheel): enable CPython 3.14 wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -127,20 +127,11 @@ jobs:
           - name: win_amd64
             os: windows-latest
         python:
-          - cp39
           - cp310
           - cp311
           - cp312
           - cp313
-        include:
-          - platform:
-              name: manylinux_x86_64
-              os: ubuntu-latest
-            python: cp38
-          - platform:
-              name: musllinux_x86_64
-              os: ubuntu-latest
-            python: cp38
+          - cp314
 
     defaults:
       run:
@@ -159,8 +150,11 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.0.1
         env:
+          # TODO(vytas): Remove cpython-prerelease when 3.14.0rc1 is out.
+          CIBW_ENABLE: cpython-prerelease
+
           CIBW_ARCHS_LINUX: all
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform.name }}
 

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove when it's green on PR.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:
@@ -16,14 +20,14 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - build: "cp313-manylinux_aarch64"
+          - build: "cp314-manylinux_aarch64"
             os: ubuntu-24.04-arm
-          - build: "cp313-manylinux_s390x"
+          - build: "cp314-manylinux_s390x"
             os: ubuntu-latest
             emulation: true
           - build: "cp38-manylinux_x86_64"
             os: ubuntu-latest
-          - build: "cp313-musllinux_x86_64"
+          - build: "cp314-musllinux_x86_64"
             os: ubuntu-latest
           - build: "cp313-macosx_arm64"
             os: macos-14
@@ -43,7 +47,10 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.0.1
         env:
+          # TODO(vytas): Remove cpython-prerelease when 3.14.0rc1 is out.
+          CIBW_ENABLE: cpython-prerelease
+
           CIBW_ARCHS_LINUX: all
           CIBW_BUILD: ${{ matrix.platform.build }}

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,10 +7,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove when it's green on PR.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,9 @@ jobs:
           - env: py313_cython
             python-version: "3.13"
           - env: py314
-            python-version: "3.14.0-alpha.5 - 3.14.0"
+            python-version: "3.14.0-beta.4 - 3.14.0"
+          - env: py314_cython
+            python-version: "3.14.0-beta.4 - 3.14.0"
           - env: py312_nocover
             os: macos-latest
             platform-label: ' (macos)'

--- a/docs/ext/cibuildwheel.py
+++ b/docs/ext/cibuildwheel.py
@@ -47,6 +47,8 @@ _CPYTHON_PLATFORMS = {
     'win_arm64': '**Windows ARM** 64-bit',
 }
 
+_EXTEND_CPYTHONS = frozenset({'cp38', 'cp39'})
+
 
 class WheelsDirective(sphinx.util.docutils.SphinxDirective):
     """Directive to tabulate build info from a YAML workflow."""
@@ -92,7 +94,7 @@ class WheelsDirective(sphinx.util.docutils.SphinxDirective):
 
         matrix = workflow['jobs']['build-wheels']['strategy']['matrix']
         platforms = matrix['platform']
-        include = matrix['include']
+        include = matrix.get('include', [])
         assert not matrix.get('exclude'), 'TODO: exclude is not supported yet'
         supported = set(
             itertools.product(
@@ -100,7 +102,10 @@ class WheelsDirective(sphinx.util.docutils.SphinxDirective):
             )
         )
         supported.update((item['platform']['name'], item['python']) for item in include)
-        cpythons = sorted({cp for _, cp in supported}, key=lambda val: (len(val), val))
+        cpythons = sorted(
+            {cp for _, cp in supported} | _EXTEND_CPYTHONS,
+            key=lambda val: (len(val), val),
+        )
 
         header = ['Platform / CPython version']
         table = [header + [cp.replace('cp3', '3.') for cp in cpythons]]

--- a/falcon/cyutil/uri.pyx
+++ b/falcon/cyutil/uri.pyx
@@ -17,21 +17,23 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.string cimport memcpy
 
 
-cdef list build_hex_table():
-    cdef list result = [-1] * 0x10000
+cdef void _init_hex_table(int* data):
+    cdef Py_ssize_t index
+
+    for index in range(0x10000):
+        data[index] = -1
+
     for ch1 in '0123456789abcdefABCDEF':
         for ch2 in '0123456789abcdefABCDEF':
             try:
-                result[(ord(ch1) << 8) | ord(ch2)] = int(ch1 + ch2, 16)
+                data[(ord(ch1) << 8) | ord(ch2)] = int(ch1 + ch2, 16)
             except ValueError:
                 pass
-
-    return result
 
 
 # PERF(vytas): Cache hex characters lookup table
 cdef int[0x10000] HEX_CHARS
-HEX_CHARS[:] = build_hex_table()
+_init_hex_table(HEX_CHARS)
 
 # PERF(vytas): Cache an empty string object.
 cdef EMPTY_STRING = u''

--- a/tox.ini
+++ b/tox.ini
@@ -189,6 +189,14 @@ deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
+[testenv:py314_cython]
+basepython = python3.14
+# NOTE(vytas): pyximport relies on distutils.extension
+deps = {[with-cython]deps}
+       setuptools
+setenv = {[with-cython]setenv}
+commands = {[with-cython]commands}
+
 # --------------------------------------------------------------------
 # WSGI servers (Cythonized Falcon)
 # --------------------------------------------------------------------


### PR DESCRIPTION
**Note**: it is important not to publish any stable release wheels compiled against a pre-release CPython.
However, the `rc1` is anticipated in ~1 week, so the risk of us ushering a stable release out the door is highly unlikely anyway.