### PR TITLE
refactor: use `pytest.importorskip` for optional dependency imports

### DIFF
--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -27,7 +27,7 @@ _SHUTDOWN_TIMEOUT = 20
 def _cheroot_args(host, port):
     """CherryPy's Cheroot"""
 
-    cheroot = pytest.importorskip('cheroot')
+    pytest.importorskip('cheroot')
 
     args = (
         sys.executable,
@@ -45,7 +45,7 @@ def _cheroot_args(host, port):
 
 def _gunicorn_args(host, port, extra_opts=()):
     """Gunicorn"""
-    gunicorn = pytest.importorskip('gunicorn')
+    pytest.importorskip('gunicorn')
 
     args = (
         sys.executable,
@@ -70,7 +70,7 @@ def _gunicorn_args(host, port, extra_opts=()):
 def _meinheld_args(host, port):
     """Gunicorn + Meinheld"""
 
-    meinheld = pytest.importorskip('meinheld')
+    pytest.importorskip('meinheld')
 
     return _gunicorn_args(
         host,
@@ -87,7 +87,7 @@ def _meinheld_args(host, port):
 def _uvicorn_args(host, port):
     """Uvicorn (WSGI interface)"""
 
-    uvicorn = pytest.importorskip('uvicorn')
+    pytest.importorskip('uvicorn')
 
     return (
         sys.executable,
@@ -116,8 +116,8 @@ def _uwsgi_args(host, port):
 
 def _waitress_args(host, port):
     """Waitress"""
-    
-    waitress = pytest.importorskip('waitress')
+
+    pytest.importorskip('waitress')
 
     return (
         sys.executable,

--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -26,10 +26,8 @@ _SHUTDOWN_TIMEOUT = 20
 
 def _cheroot_args(host, port):
     """CherryPy's Cheroot"""
-    try:
-        import cheroot  # noqa: F401
-    except ImportError:
-        pytest.skip('cheroot not installed')
+
+    cheroot = pytest.importorskip('cheroot')
 
     args = (
         sys.executable,
@@ -47,10 +45,7 @@ def _cheroot_args(host, port):
 
 def _gunicorn_args(host, port, extra_opts=()):
     """Gunicorn"""
-    try:
-        import gunicorn  # noqa: F401
-    except ImportError:
-        pytest.skip('gunicorn not installed')
+    gunicorn = pytest.importorskip('gunicorn')
 
     args = (
         sys.executable,
@@ -74,10 +69,8 @@ def _gunicorn_args(host, port, extra_opts=()):
 
 def _meinheld_args(host, port):
     """Gunicorn + Meinheld"""
-    try:
-        import meinheld  # noqa: F401
-    except ImportError:
-        pytest.skip('meinheld not installed')
+
+    meinheld = pytest.importorskip('meinheld')
 
     return _gunicorn_args(
         host,
@@ -93,10 +86,8 @@ def _meinheld_args(host, port):
 
 def _uvicorn_args(host, port):
     """Uvicorn (WSGI interface)"""
-    try:
-        import uvicorn  # noqa: F401
-    except ImportError:
-        pytest.skip('uvicorn not installed')
+
+    uvicorn = pytest.importorskip('uvicorn')
 
     return (
         sys.executable,
@@ -125,10 +116,8 @@ def _uwsgi_args(host, port):
 
 def _waitress_args(host, port):
     """Waitress"""
-    try:
-        import waitress  # noqa: F401
-    except ImportError:
-        pytest.skip('waitress not installed')
+    
+    waitress = pytest.importorskip('waitress')
 
     return (
         sys.executable,


### PR DESCRIPTION
# Summary of Changes

This PR refactors `tests/test_wsgi_servers.py`  that relied on optional dependencies by replacing manual try-except import with `pytest.importorskip`.

What does `pytest.importorskip` do? 
`pytest.importorskip("module_name")` tries to import a module only if it's available. If it's not, it skips the test automatically with a clear message, instead of failing due to an ImportError.

Benefits:
- Follows pytest best practices for optional imports
- Reduces boilerplate code and duplication
- Makes test behavior more consistent across environments

Also I was novice around this approach so took some help from the LLMs around the globe where I found that,
Using `pytest.importorskip` can reduce the need for linter overrides — especially around:

- F401 (imported but unused)
- E402 (module-level import not at top of file)
- F821 (undefined name if import fails)

Thanks! 
Closes #2480


# Related Issues

#2480 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
