### PR TITLE
chore: prepare 4.1.0a1

### DIFF
--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,10 +7,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove, just testing.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:
@@ -33,13 +29,6 @@ jobs:
             os: macos-14
           - build: "cp313-win_amd64"
             os: windows-latest
-          # TODO(vytas): Just testing before 4.1.0a1.
-          - build: "cp314-macosx_arm64"
-            os: macos-14
-          - build: "cp314-win_amd64"
-            os: windows-latest
-          - build: "cp314-macosx_x86_64"
-            os: macos-13
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove, just testing.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:
@@ -29,6 +33,13 @@ jobs:
             os: macos-14
           - build: "cp313-win_amd64"
             os: windows-latest
+          # TODO(vytas): Just testing before 4.1.0a1.
+          - build: "cp314-macosx_arm64"
+            os: macos-14
+          - build: "cp314-win_amd64"
+            os: windows-latest
+          - build: "cp314-macosx_x86_64"
+            os: macos-13
 
     steps:
       - name: Checkout repo

--- a/AUTHORS
+++ b/AUTHORS
@@ -210,6 +210,8 @@ listed below by date of first contribution:
 * Shreshth3
 * jkmnt
 * Abduaziz (AbduazizZiyodov)
+* Emanuele Bombardelli (Bombaclath97)
+* Soubhik Kumar Mitra (x612skm)
 
 (et al.)
 

--- a/docs/changes/4.1.0.rst
+++ b/docs/changes/4.1.0.rst
@@ -30,6 +30,7 @@ Many thanks to all of our talented and stylish contributors for this release!
 
 - `aarcex3 <https://github.com/aarcex3>`__
 - `AbduazizZiyodov <https://github.com/AbduazizZiyodov>`__
+- `Bombaclath97 <https://github.com/Bombaclath97>`__
 - `bssyousefi <https://github.com/bssyousefi>`__
 - `CaselIT <https://github.com/CaselIT>`__
 - `Cycloctane <https://github.com/Cycloctane>`__
@@ -42,3 +43,4 @@ Many thanks to all of our talented and stylish contributors for this release!
 - `perodriguezl <https://github.com/perodriguezl>`__
 - `Shreshth3 <https://github.com/Shreshth3>`__
 - `vytas7 <https://github.com/vytas7>`__
+- `x612skm <https://github.com/x612skm>`__

--- a/falcon/version.py
+++ b/falcon/version.py
@@ -14,5 +14,5 @@
 
 """Falcon version."""
 
-__version__ = '4.1.0.dev2'
+__version__ = '4.1.0a1'
 """Current version of Falcon."""


### PR DESCRIPTION
I have successfully built out more CPython 3.14 wheels, so hopefully we can avoid unpleasant surprises later on: https://github.com/falconry/falcon/actions/runs/16409687738.