### PR TITLE
chore(release): decouple jobs with `id-token` access from other actions

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -52,17 +52,16 @@ jobs:
           name: cibw-sdist
           path: dist/falcon-*
 
-  publish-sdist:
-    name: publish-sdist
+  upload-sdist:
+    name: upload-sdist
     needs:
       - build-sdist
     runs-on: ubuntu-latest
 
     permissions:
       # NOTE(vytas): The 'contents' permission is needed for writing release assets.
+      #   The default permissions seem to suffice, but we specify for clarity.
       contents: write
-      # NOTE(vytas): This permission is mandatory for trusted publishing.
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -92,6 +91,25 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           files: 'dist/*.tar.gz'
+
+  publish-sdist:
+    name: publish-sdist
+    needs:
+      - build-sdist
+      - upload-sdist
+    runs-on: ubuntu-latest
+
+    permissions:
+      # NOTE(vytas): This permission is mandatory for Trusted Publishing.
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-sdist
+          path: dist
+          merge-multiple: true
 
       - name: Publish sdist and pure-Python wheel to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -166,16 +184,11 @@ jobs:
           name: cibw-wheel-${{ matrix.python }}-${{ matrix.platform.name }}
           path: wheelhouse/falcon-*.whl
 
-  publish-wheels:
-    name: publish-wheels
+  check-wheels:
+    name: check-wheels
     needs:
       - build-wheels
-      - publish-sdist
     runs-on: ubuntu-latest
-
-    permissions:
-      # NOTE(vytas): This permission is mandatory for trusted publishing.
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -198,6 +211,26 @@ jobs:
       - name: Check collected artifacts
         run: |
           tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
+
+  publish-wheels:
+    name: publish-wheels
+    needs:
+      - build-wheels
+      - check-wheels
+      - publish-sdist
+    runs-on: ubuntu-latest
+
+    permissions:
+      # NOTE(vytas): This permission is mandatory for Trusted Publishing.
+      id-token: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-wheel-*
+          path: dist
+          merge-multiple: true
 
       - name: Publish binary wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -95,7 +95,6 @@ jobs:
   publish-sdist:
     name: publish-sdist
     needs:
-      - build-sdist
       - upload-sdist
     runs-on: ubuntu-latest
 
@@ -221,7 +220,6 @@ jobs:
   publish-wheels:
     name: publish-wheels
     needs:
-      - build-wheels
       - check-wheels
       - publish-sdist
     runs-on: ubuntu-latest

--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -103,6 +103,9 @@ jobs:
       # NOTE(vytas): This permission is mandatory for Trusted Publishing.
       id-token: write
 
+    # APPSEC(vytas): By using as few third-party actions as possible,
+    #   this job reduces its attack vector, and minimizes the risk of
+    #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -111,6 +114,9 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # NOTE(vytas): Normally, invoking pypi-publish more than once in the
+      #   same job is not considered supported, however, the two steps below
+      #   are made mutually exclusive by the github.event_name condition.
       - name: Publish sdist and pure-Python wheel to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'workflow_dispatch'
@@ -224,6 +230,9 @@ jobs:
       # NOTE(vytas): This permission is mandatory for Trusted Publishing.
       id-token: write
 
+    # APPSEC(vytas): By using as few third-party actions as possible,
+    #   this job reduces its attack vector, and minimizes the risk of
+    #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -232,6 +241,9 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # NOTE(vytas): Normally, invoking pypi-publish more than once in the
+      #   same job is not considered supported, however, the two steps below
+      #   are made mutually exclusive by the github.event_name condition.
       - name: Publish binary wheels to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
As pointed out by @webknjaz, the best practice recommended by `pypa/gh-action-pypi-publish` is to expose the created _Trusted Publisher_ OIDC tokens to as few third-party actions as possible.

This changeset aims to address the issue (unless I misunderstood it again :cold_sweat:).