### PR TITLE
fix(WebSocket): properly pass `WebSocket` object to sinks

### DIFF
--- a/docs/_newsfragments/2414.bugfix.rst
+++ b/docs/_newsfragments/2414.bugfix.rst
@@ -1,0 +1,9 @@
+Previously, Falcon's :ref:`WebSocket implementation <ws>` was not documented to
+route the request to any :meth:`sink <falcon.asgi.App.add_sink>`. However, in
+the case of a missing route, a matching sink was actually invoked, passing
+:class:`ws <falcon.asgi.WebSocket>` in place of the incompatible
+:class:`resp <falcon.asgi.Response>`.
+
+This mismatch has been addressed by introducing a `ws` keyword argument
+(similar to ASGI :meth:`error handlers <falcon.asgi.App.add_error_handler>`)
+for sink functions meant to accept WebSocket connections.

--- a/docs/_newsfragments/2414.bugfix.rst
+++ b/docs/_newsfragments/2414.bugfix.rst
@@ -7,3 +7,9 @@ the case of a missing route, a matching sink was actually invoked, passing
 This mismatch has been addressed by introducing a `ws` keyword argument
 (similar to ASGI :meth:`error handlers <falcon.asgi.App.add_error_handler>`)
 for sink functions meant to accept WebSocket connections.
+
+For backwards-compatibility, when `ws` is absent from the sink's signature, the
+:class:`~falcon.asgi.WebSocket` object is still passed in place of the
+incompatible `resp`.
+This behavior will change in Falcon 5.0: when draining a WebSocket connection,
+`resp` will always be set to ``None``.

--- a/docs/api/websocket.rst
+++ b/docs/api/websocket.rst
@@ -90,7 +90,7 @@ framework would expect an ``on_websocket()`` responder similar to this:
 
 .. code:: python
 
-    async def on_websocket(self, req: Request, ws: WebSocket, account_id: str):
+    async def on_websocket(self, req: Request, ws: WebSocket, account_id: str) -> None:
         pass
 
 If no route matches the path requested in the WebSocket handshake, control then

--- a/docs/api/websocket.rst
+++ b/docs/api/websocket.rst
@@ -93,8 +93,28 @@ framework would expect an ``on_websocket()`` responder similar to this:
     async def on_websocket(self, req: Request, ws: WebSocket, account_id: str) -> None:
         pass
 
-If no route matches the path requested in the WebSocket handshake, control then
-passes to a default responder that simply raises an instance of
+Just like other HTTP requests, WebSocket connections can also be handled
+dynamically by :meth:`sinks <falcon.asgi.App.add_sink>`. In order to receive
+a :class:`~falcon.asgi.WebSocket` connection object, the sink method ought to
+define a `ws` keyword argument:
+
+.. code:: python
+
+    async def sink(
+        req: Request,
+        resp: Response | None,
+        ws: WebSocket | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if ws is not None:
+            # WebSocket connection (resp is None)
+            ...
+        else:
+            # Ordinary HTTP request (ws is None)
+            ...
+
+If no route or sink matches the path requested in the WebSocket handshake,
+control then passes to a default responder that simply raises an instance of
 :class:`~.HTTPRouteNotFound`. By default, this error will be rendered as a 403
 response with a 3404 close code. This behavior can be modified by adding a
 custom error handler (see also: :meth:`~falcon.asgi.App.add_error_handler`).

--- a/falcon/_typing.py
+++ b/falcon/_typing.py
@@ -99,7 +99,7 @@ class SinkCallable(Protocol):
 
 class AsgiSinkCallable(Protocol):
     async def __call__(
-        self, req: AsgiRequest, resp: AsgiResponse, **kwargs: Optional[str]
+        self, req: AsgiRequest, resp: Optional[AsgiResponse], **kwargs: Optional[str]
     ) -> None: ...
 
 

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -764,7 +764,30 @@ class App:
 
                 Note:
                     When using an async version of the ``App``, this must be a
-                    coroutine.
+                    coroutine function taking the form
+                    ``func(req, resp, ws=None, **kwargs)``.
+
+                    Similar to
+                    :meth:`error handlers <falcon.asgi.App.add_error_handler>`,
+                    in the case of a WebSocket connection, the
+                    :class:`resp <falcon.asgi.Response>` argument will be
+                    ``None``, whereas the `ws` keyword argument will receive
+                    the :class:`~falcon.asgi.WebSocket` connection object.
+
+                    For backwards-compatibility, when `ws` is absent from the
+                    sink's signature, or a regex match (see **prefix** below)
+                    contains a group named 'ws', the
+                    :class:`~falcon.asgi.WebSocket` object is passed in place
+                    of the incompatible `resp`.
+
+                    This behavior will change in Falcon 5.0: when draining a
+                    WebSocket connection, `resp` will always be set to ``None``
+                    regardless of the sink's signature.
+
+                .. versionadded:: 4.1
+                    If an asynchronous sink callable explicitly defines a `ws`
+                    argument, it is used to pass the
+                    :class:`~falcon.asgi.WebSocket` connection object.
 
             prefix (str): A regex string, typically starting with '/', which
                 will trigger the sink if it matches the path portion of the

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -64,7 +64,7 @@ from falcon.errors import WebSocketDisconnected
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
 from falcon.media.multipart import MultipartFormHandler
-from falcon.util import get_argnames
+from falcon.util.misc import _has_arg_name
 from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines
 from falcon.util.sync import _wrap_non_coroutine_unsafe
@@ -1298,7 +1298,10 @@ class App(falcon.app.App):
             try:
                 kwargs = {}
 
-                if ws and 'ws' in get_argnames(err_handler):
+                # PERF(vytas): Using the LRU-cache backed misc._has_arg_name
+                #   here as inspect.signature (and by proxy misc.get_argnames)
+                #   can be very slow (on the order of magnitude of 10 µs).
+                if ws and _has_arg_name(err_handler, 'ws'):
                     kwargs['ws'] = ws
 
                 await err_handler(req, resp, ex, params, **kwargs)

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -337,6 +337,20 @@ def get_argnames(func: Callable[..., Any]) -> List[str]:
     return args
 
 
+@functools.lru_cache
+def _has_arg_name_cached(func: Callable[..., Any], name: str) -> bool:
+    return name in get_argnames(func)
+
+
+def _has_arg_name(func: Callable[..., Any], name: str) -> bool:
+    try:
+        return _has_arg_name_cached(func, name)
+    except TypeError:
+        # NOTE(vytas): Most probably the exception was thrown by the LRU cache
+        #   indicating that the func object was unhashable.
+        return name in get_argnames(func)
+
+
 def secure_filename(filename: str, max_length: Optional[int] = None) -> str:
     """Sanitize the provided `filename` to contain only ASCII characters.
 

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -1457,3 +1457,46 @@ async def test_max_receive_queue_sizes(conductor, max_receive_queue):
                 received.append(await ws.receive_text())
 
     assert len(received) == 6
+
+
+@pytest.mark.parametrize('sink', ['no-ws-arg', 'with-ws-arg', 'unhashable-obj'])
+async def test_sinks(conductor, sink):
+    async def say_hello(req, resp_or_ws, name):
+        greeting = f'Hello, {name}!'
+        if req.is_websocket:
+            await resp_or_ws.accept()
+            await resp_or_ws.send_text(greeting)
+        else:
+            resp_or_ws.content_type = falcon.MEDIA_TEXT
+            resp_or_ws.text = greeting
+
+    async def sink_no_ws_arg(req, resp_or_ws, name):
+        assert resp_or_ws is not None
+        await say_hello(req, resp_or_ws, name)
+
+    async def sink_with_ws_arg(req, resp, name, ws=None):
+        if ws:
+            assert resp is None
+            await say_hello(req, ws, name)
+        else:
+            assert resp is not None
+            await say_hello(req, resp, name)
+
+    class Unhashable(list):
+        async def __call__(self, req, resp, name, ws=None):
+            await sink_with_ws_arg(req, resp, name, ws=ws)
+
+    sinks = {
+        'no-ws-arg': sink_no_ws_arg,
+        'with-ws-arg': sink_with_ws_arg,
+        'unhashable-obj': Unhashable(),
+    }
+    conductor.app.add_sink(sinks[sink], r'/ws/(?P<name>\w+)')
+
+    async with conductor as c:
+        resp = await c.simulate_get('/ws/World')
+        assert resp.status_code == 200
+        assert resp.text == 'Hello, World!'
+
+        async with c.simulate_ws('/ws/World') as ws:
+            assert await ws.receive_text() == 'Hello, World!'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1342,6 +1342,33 @@ def test_get_argnames():
     assert misc.get_argnames(functools.partial(foo, 42)) == ['b', 'c']
 
 
+def test_has_arg_name():
+    def foo(a, b, c):
+        pass
+
+    class Bar:
+        def __call__(self, a, b):
+            pass
+
+    class Baz(list):
+        def __call__(self, a, b):
+            pass
+
+    assert misc._has_arg_name(foo, 'a')
+    assert misc._has_arg_name(foo, 'b')
+    assert misc._has_arg_name(foo, 'c')
+
+    bar = Bar()
+    assert misc._has_arg_name(bar, 'a')
+    assert misc._has_arg_name(bar, 'b')
+    assert not misc._has_arg_name(bar, 'c')
+
+    baz = Baz()
+    assert misc._has_arg_name(baz, 'a')
+    assert misc._has_arg_name(baz, 'b')
+    assert not misc._has_arg_name(baz, 'c')
+
+
 class TestContextType:
     class CustomContextType(structures.Context):
         def __init__(self):


### PR DESCRIPTION
As discussed with @CaselIT, we address the issue by passing a `WebSocket` connection object to the matching sink via the `ws` keyword argument.

Fixes #2414.
