### PR TITLE
docs: fix the WSGI MultiPart docstring

### DIFF
--- a/falcon/asgi/multipart.py
+++ b/falcon/asgi/multipart.py
@@ -43,7 +43,7 @@ MultipartParseError = multipart.MultipartParseError
 
 
 class BodyPart(multipart.BodyPart):
-    """Represents a body part in a multipart form in a ASGI application.
+    """Represents a body part in a multipart form in an ASGI application.
 
     Note:
         :class:`BodyPart` is meant to be instantiated directly only by the

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -71,7 +71,7 @@ _CRLF_CRLF = _CRLF + _CRLF
 # TODO(vytas): Consider supporting -charset- stuff.
 #   Does anyone use that (?)
 class BodyPart:
-    """Represents a body part in a multipart form in an ASGI application.
+    """Represents a body part in a multipart form in a WSGI application.
 
     Note:
         :class:`BodyPart` is meant to be instantiated directly only by the


### PR DESCRIPTION
# Summary of Changes

The current docs show the WSGI MultiPart "in an ASGI application".

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
