### PR TITLE
perf(uri): speed up URI encoding by hand-crafted Cython code

### DIFF
--- a/docs/_newsfragments/1169.newandimproved.rst
+++ b/docs/_newsfragments/1169.newandimproved.rst
@@ -1,0 +1,13 @@
+The URI encoding functions :func:`~falcon.uri.encode`,
+:func:`~falcon.uri.encode_check_escaped`, :func:`~falcon.uri.encode_value`, and
+:func:`~falcon.uri.encode_value_check_escaped` have been reimplemented in
+Cython, leading to a significant speed bump under CPython (provided Falcon is
+:ref:`installed <install>` from a binary wheel, or cythonized from a source
+distribution).
+
+The performance improvement can reach an order of magnitude, although the
+actual numbers vary depending on the input data. For instance, on CPython 3.12,
+calling :func:`~falcon.uri.encode_value` with
+``'no-reply@falconframework.org'`` would be sped up ~9x, and using the already
+encoded value ``'no-reply%40falconframework.org'`` with
+:func:`~falcon.uri.encode_value_check_escaped` could yield a ~12x speed boost.

--- a/falcon/cyutil/uri.pyx
+++ b/falcon/cyutil/uri.pyx
@@ -17,7 +17,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.string cimport memcpy
 
 
-cdef void _init_hex_table(int* data):
+cdef void _init_hex_chars_table(int* data):
     cdef Py_ssize_t index
 
     for index in range(0x10000):
@@ -31,19 +31,33 @@ cdef void _init_hex_table(int* data):
                 pass
 
 
+cdef void _init_hex_encoded_table(int* data):
+    cdef Py_ssize_t index
+    cdef unsigned char b1
+    cdef unsigned char b2
+
+    for index in range(0x100):
+        b1, b2 = f'{index:02X}'.encode()
+        data[index] = (b1 << 8) + b2
+
+
 # PERF(vytas): Cache hex characters lookup table
-cdef int[0x10000] HEX_CHARS
-_init_hex_table(HEX_CHARS)
+cdef int[0x10000] _HEX_CHARS
+_init_hex_chars_table(_HEX_CHARS)
+
+# PERF(vytas): Encoded hex characters.
+cdef int[0x100] _HEX_ENCODED
+_init_hex_encoded_table(_HEX_ENCODED)
 
 # PERF(vytas): Cache an empty string object.
 cdef EMPTY_STRING = u''
 
 
-cdef inline int cy_decode_hex(unsigned char nibble1, unsigned char nibble2):
-    return HEX_CHARS[(nibble1 << 8) | nibble2]
+cdef inline int _cy_decode_hex(unsigned char nibble1, unsigned char nibble2):
+    return _HEX_CHARS[(nibble1 << 8) | nibble2]
 
 
-cdef unicode cy_decode(unsigned char* data, Py_ssize_t start, Py_ssize_t end,
+cdef unicode _cy_decode(unsigned char* data, Py_ssize_t start, Py_ssize_t end,
                        Py_ssize_t encoded_start, bint unquote_plus):
     # PERF(vytas): encoded_start being -1 signifies that the caller
     #   (cy_parse_query_string) has already verified that no encoding
@@ -81,7 +95,7 @@ cdef unicode cy_decode(unsigned char* data, Py_ssize_t start, Py_ssize_t end,
 
             # NOTE(vytas): Else %
             if pos < end - 2:
-                decoded = cy_decode_hex(data[pos+1], data[pos+2])
+                decoded = _cy_decode_hex(data[pos+1], data[pos+2])
                 if decoded < 0:
                     continue
 
@@ -103,7 +117,7 @@ cdef unicode cy_decode(unsigned char* data, Py_ssize_t start, Py_ssize_t end,
         PyMem_Free(result)
 
 
-cdef cy_handle_csv(dict result, bint keep_blank, unicode key, bytes value):
+cdef _cy_handle_csv(dict result, bint keep_blank, unicode key, bytes value):
     # NOTE(kgriffs): Falcon supports a more compact form of lists, in which the
     # elements are comma-separated and assigned to a single param instance. If
     # it turns out that very few people use this, it can be deprecated at some
@@ -125,7 +139,7 @@ cdef cy_handle_csv(dict result, bint keep_blank, unicode key, bytes value):
         #   for 'foo=1,,3' as 'foo=1&foo=&foo=3'
         #   (but only if keep_blank is set to False).
         additional_values = [
-            cy_decode(element, 0, len(element), 0, True)
+            _cy_decode(element, 0, len(element), 0, True)
             for element in value.split(b',') if keep_blank or element
         ]
 
@@ -138,7 +152,7 @@ cdef cy_handle_csv(dict result, bint keep_blank, unicode key, bytes value):
             result[key] = additional_values
 
     else:
-        decoded = cy_decode(value, 0, len(value), 0, True)
+        decoded = _cy_decode(value, 0, len(value), 0, True)
 
         if old_value is None:
             result[key] = decoded
@@ -148,8 +162,8 @@ cdef cy_handle_csv(dict result, bint keep_blank, unicode key, bytes value):
             result[key] = [old_value, decoded]
 
 
-cdef cy_parse_query_string(unsigned char* data, Py_ssize_t length,
-                           bint keep_blank, bint csv):
+cdef _cy_parse_query_string(unsigned char* data, Py_ssize_t length,
+                            bint keep_blank, bint csv):
     cdef Py_ssize_t pos
     cdef unsigned char current
 
@@ -177,18 +191,18 @@ cdef cy_parse_query_string(unsigned char* data, Py_ssize_t length,
             #   Keep them in sync until they are improved to share code.
             if pos > start:
                 if partition >= 0:
-                    key = cy_decode(data, start, partition, encoded_start_key, True)
+                    key = _cy_decode(data, start, partition, encoded_start_key, True)
                     if csv and encoded_start_val >= 0:
-                        cy_handle_csv(result, keep_blank, key, data[partition+1:pos])
+                        _cy_handle_csv(result, keep_blank, key, data[partition+1:pos])
                         start = pos + 1
                         encoded_start_key = -1
                         encoded_start_val = -1
                         partition = -1
                         continue
 
-                    value = cy_decode(data, partition+1, pos, encoded_start_val, True)
+                    value = _cy_decode(data, partition+1, pos, encoded_start_val, True)
                 else:
-                    key = cy_decode(data, start, pos, encoded_start_key, True)
+                    key = _cy_decode(data, start, pos, encoded_start_key, True)
                     value = EMPTY_STRING
 
                 if value is not EMPTY_STRING or keep_blank:
@@ -229,14 +243,14 @@ cdef cy_parse_query_string(unsigned char* data, Py_ssize_t length,
     #   Keep them in sync until they are improved to share code.
     if length > start:
         if partition >= 0:
-            key = cy_decode(data, start, partition, encoded_start_key, True)
+            key = _cy_decode(data, start, partition, encoded_start_key, True)
             if csv and encoded_start_val >= 0:
-                cy_handle_csv(result, keep_blank, key, data[partition+1:length])
+                _cy_handle_csv(result, keep_blank, key, data[partition+1:length])
                 return result
 
-            value = cy_decode(data, partition+1, length, encoded_start_val, True)
+            value = _cy_decode(data, partition+1, length, encoded_start_val, True)
         else:
-            key = cy_decode(data, start, length, encoded_start_key, True)
+            key = _cy_decode(data, start, length, encoded_start_key, True)
             value = EMPTY_STRING
 
         if value is not EMPTY_STRING or keep_blank:
@@ -252,14 +266,159 @@ cdef cy_parse_query_string(unsigned char* data, Py_ssize_t length,
     return result
 
 
+cdef Py_ssize_t _cy_probe_encoded_length(unsigned char* data, Py_ssize_t length,
+                                         bint is_value, bint check_is_escaped):
+    cdef Py_ssize_t pos
+    cdef Py_ssize_t extra_length = 0
+    cdef bint already_escaped = check_is_escaped
+
+    # PERF(vytas): Here we unroll the code for different values of is_value.
+    #   This could by DRYed at a minor perf cost, but, OTOH, these
+    #   redundant blocks are not too large anyway.
+    if is_value:
+        for pos in range(length):
+            # NOTE(vytas): See _UNRESERVED in uri.py.
+            if data[pos] not in (b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+                                 b'0123456789-._~'):
+                # NOTE(vytas): 2 extra bytes will be needed following the % char.
+                extra_length += 2
+
+                if already_escaped:
+                    if data[pos] == b'%' and pos < length - 2:
+                        already_escaped = (
+                            data[pos + 1] in b'0123456789ABCDEFabcdef' and
+                            data[pos + 2] in b'0123456789ABCDEFabcdef')
+                    else:
+                        already_escaped = False
+
+    else:
+        for pos in range(length):
+            # NOTE(vytas): See _ALL_ALLOWED in uri.py.
+            if data[pos] not in (b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                                 b"0123456789-._~:/?#[]@!$&'()*+,;="):
+                # NOTE(vytas): 2 extra bytes will be needed following the % char.
+                extra_length += 2
+
+                if already_escaped:
+                    if data[pos] == b'%' and pos < length - 2:
+                        already_escaped = (
+                            data[pos + 1] in b'0123456789ABCDEFabcdef' and
+                            data[pos + 2] in b'0123456789ABCDEFabcdef')
+                    else:
+                        already_escaped = False
+
+    # NOTE(vytas): The downstream functions will return the unmodified input
+    #   in the case the returned encoded length is equal to length.
+    if already_escaped:
+        return length
+
+    return length + extra_length
+
+
+cdef _cy_encode(unsigned char* data, Py_ssize_t length, Py_ssize_t encoded_length,
+                bint is_value):
+    cdef unsigned char* result = <unsigned char*> PyMem_Malloc(encoded_length)
+    cdef unsigned char c
+    cdef Py_ssize_t pos
+    cdef Py_ssize_t out_offset = 0
+    cdef Py_ssize_t out_pos
+
+    try:
+        # PERF(vytas): Here we unroll the code for different values of is_value.
+        #   This could by DRYed at a minor perf cost, but, OTOH, these
+        #   redundant blocks are not too large anyway.
+        if is_value:
+            for pos in range(length):
+                c = data[pos]
+                out_pos = pos + out_offset
+                # NOTE(vytas): See _UNRESERVED in uri.py.
+                if c in (b'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+                         b'0123456789-._~'):
+                    result[pos + out_offset] = c
+                else:
+                    result[out_pos] = b'%'
+                    result[out_pos + 1] = _HEX_ENCODED[c] >> 8
+                    result[out_pos + 2] = _HEX_ENCODED[c] & 0xFF
+
+                    out_offset += 2
+
+        else:
+            for pos in range(length):
+                c = data[pos]
+                out_pos = pos + out_offset
+                # NOTE(vytas): See _ALL_ALLOWED in uri.py.
+                if c in (b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+                         b"0123456789-._~:/?#[]@!$&'()*+,;="):
+                    result[pos + out_offset] = c
+                else:
+                    result[out_pos] = b'%'
+                    result[out_pos + 1] = _HEX_ENCODED[c] >> 8
+                    result[out_pos + 2] = _HEX_ENCODED[c] & 0xFF
+
+                    out_offset += 2
+
+        return result[:encoded_length].decode('ascii')
+
+    finally:
+        PyMem_Free(result)
+
+
 def parse_query_string(unicode query_string not None, bint keep_blank=False,
                        bint csv=False):
     cdef bytes byte_string = query_string.encode('utf-8')
     cdef unsigned char* data = byte_string
-    return cy_parse_query_string(data, len(byte_string), keep_blank, csv)
+    return _cy_parse_query_string(data, len(byte_string), keep_blank, csv)
 
 
 def decode(unicode encoded_uri not None, bint unquote_plus=True):
     cdef bytes byte_string = encoded_uri.encode('utf-8')
     cdef unsigned char* data = byte_string
-    return cy_decode(data, 0, len(byte_string), 0, unquote_plus)
+    return _cy_decode(data, 0, len(byte_string), 0, unquote_plus)
+
+
+def encode(unicode uri not None):
+    cdef bytes data = uri.encode('utf-8')
+    cdef Py_ssize_t length = len(data)
+    cdef Py_ssize_t encoded_length = _cy_probe_encoded_length(
+        data, length, False, False)
+
+    if length == encoded_length:
+        return uri
+
+    return _cy_encode(data, length, encoded_length, False)
+
+
+def encode_check_escaped(unicode uri not None):
+    cdef bytes data = uri.encode('utf-8')
+    cdef Py_ssize_t length = len(data)
+    cdef Py_ssize_t encoded_length = _cy_probe_encoded_length(
+        data, length, False, True)
+
+    if length == encoded_length:
+        return uri
+
+    return _cy_encode(data, length, encoded_length, False)
+
+
+def encode_value(unicode uri not None):
+    cdef bytes data = uri.encode('utf-8')
+    cdef Py_ssize_t length = len(data)
+    cdef Py_ssize_t encoded_length = _cy_probe_encoded_length(
+        data, length, True, False)
+
+    if length == encoded_length:
+        return uri
+
+    return _cy_encode(data, length, encoded_length, True)
+
+
+def encode_value_check_escaped(unicode uri not None):
+    cdef bytes data = uri.encode('utf-8')
+    cdef Py_ssize_t length = len(data)
+    cdef Py_ssize_t encoded_length = _cy_probe_encoded_length(
+        data, length, True, True)
+
+    if length == encoded_length:
+        return uri
+
+    return _cy_encode(data, length, encoded_length, True)

--- a/falcon/cyutil/uri.pyx
+++ b/falcon/cyutil/uri.pyx
@@ -33,8 +33,8 @@ cdef void _init_hex_chars_table(int* data):
 
 cdef void _init_hex_encoded_table(int* data):
     cdef Py_ssize_t index
-    cdef unsigned char b1
-    cdef unsigned char b2
+    cdef unsigned short b1
+    cdef unsigned short b2
 
     for index in range(0x100):
         b1, b2 = f'{index:02X}'.encode()

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -567,5 +567,10 @@ def unquote_string(quoted: str) -> str:
 # TODO(vytas): Restructure this in favour of a cleaner way to hoist the pure
 # Cython functions into this module.
 if _cy_uri is not None:  # pragma: nocover
+    encode = _cy_uri.encode  # NOQA
+    encode_check_escaped = _cy_uri.encode_check_escaped  # NOQA
+    encode_value = _cy_uri.encode_value  # NOQA
+    encode_value_check_escaped = _cy_uri.encode_value_check_escaped  # NOQA
+
     decode = _cy_uri.decode  # NOQA
     parse_query_string = _cy_uri.parse_query_string  # NOQA


### PR DESCRIPTION
The URI encoding functions [encode()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode), [encode_check_escaped()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode_check_escaped), [encode_value()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode_value), and [encode_value_check_escaped()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode_value_check_escaped) have been reimplemented in Cython, leading to a significant speed bump under CPython (provided Falcon is [installed](file:///home/vytas/progs/falcon/docs/_build/html/user/install.html#install) from a binary wheel, or cythonized from a source distribution).

The performance improvement can reach an order of magnitude, although the actual numbers vary depending on the input data. For instance, on CPython 3.12, calling [encode_value()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode_value) with `'no-reply@falconframework.org'` would be sped up ~9x, and using the already encoded value `'no-reply%40falconframework.org'` with [encode_value_check_escaped()](https://falcon.readthedocs.io/en/stable/api/util.html#falcon.uri.encode_value_check_escaped) could yield a ~12x speed boost. (#1169)

Closes #1169.