### PR TITLE
chore(wheels): no longer build wheels for macOS x86_64 (Intel)

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -143,10 +143,8 @@ jobs:
           - name: manylinux_s390x
             os: ubuntu-latest
             emulation: true
-          - name: macosx_x86_64
-            os: macos-13
           - name: macosx_arm64
-            os: macos-14
+            os: macos-15
           - name: win_amd64
             os: windows-latest
         python:

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove once the PoC passes on a PR.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:
@@ -26,7 +30,7 @@ jobs:
           - build: "cp314-musllinux_x86_64"
             os: ubuntu-latest
           - build: "cp313-macosx_arm64"
-            os: macos-14
+            os: macos-15
           - build: "cp313-win_amd64"
             os: windows-latest
 

--- a/docs/changes/4.2.0.rst
+++ b/docs/changes/4.2.0.rst
@@ -14,6 +14,7 @@ Changes to Supported Platforms
 
 - The end-of-life Python 3.8 is no longer supported.
   (`#2527 <https://github.com/falconry/falcon/issues/2527>`__)
+
 - Although the Falcon 4.x series is only guaranteed to support Python 3.10+,
   this release still supports the end-of-life Python 3.9 at runtime using the
   pure Python wheel.
@@ -21,6 +22,11 @@ Changes to Supported Platforms
   (Note that 3.9 is completely unsupported for new development of Falcon apps,
   as type checking, building documentation, etc, are likely to fail outright.)
 
+- Pre-compiled wheels are longer provided for the macOS x86_64 (Intel) platform.
+  Falcon will continue to :ref:`install <install>` (from the pure Python wheel)
+  and run on macOS Intel just fine.
+  You can also build the binary from *sdist* yourself.
+  (`#2536 <https://github.com/falconry/falcon/issues/2536>`__)
 
 .. towncrier release notes start
 
@@ -33,3 +39,4 @@ Many thanks to all of our talented and stylish contributors for this release!
 - `kemingy <https://github.com/kemingy>`__
 - `sonephyo <https://github.com/sonephyo>`__
 - `vytas7 <https://github.com/vytas7>`__
+- `x612skm <https://github.com/x612skm>`__

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -96,9 +96,8 @@ Compiling on Mac OS
 ^^^^^^^^^^^^^^^^^^^
 
 .. tip::
-    Pre-compiled Falcon wheels are available for macOS on both Intel and Apple
-    Silicon chips, so normally you should be fine with just
-    ``pip install falcon``.
+    Pre-compiled Falcon wheels are available for macOS on Apple Silicon chips,
+    so normally you should be fine with just ``pip install falcon``.
 
 Xcode Command Line Tools are required to compile Cython. Install them
 with this command:


### PR DESCRIPTION
Fixes #2536.