### PR TITLE
feat(request): add delimiter support to get_param_as_list

### DIFF
--- a/docs/_newsfragments/2538.newandimproved.rst
+++ b/docs/_newsfragments/2538.newandimproved.rst
@@ -1,0 +1,1 @@
+req.get_param_as_list() now supports a delimiter argument for splitting values.

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1943,6 +1943,7 @@ class Request:
         *,
         required: Literal[True],
         store: StoreArg = ...,
+        delimiter: str | None = None,
         default: list[str] | None = ...,
     ) -> list[str]: ...
 
@@ -1953,6 +1954,7 @@ class Request:
         transform: Callable[[str], _T],
         required: Literal[True],
         store: StoreArg = ...,
+        delimiter: str | None = None,
         default: list[_T] | None = ...,
     ) -> list[_T]: ...
 
@@ -1963,6 +1965,7 @@ class Request:
         transform: None = ...,
         required: bool = ...,
         store: StoreArg = ...,
+        delimiter: str | None = None,
         *,
         default: list[str],
     ) -> list[str]: ...
@@ -1974,6 +1977,7 @@ class Request:
         transform: Callable[[str], _T],
         required: bool = ...,
         store: StoreArg = ...,
+        delimiter: str | None = None,
         *,
         default: list[_T],
     ) -> list[_T]: ...
@@ -1985,6 +1989,7 @@ class Request:
         transform: None = ...,
         required: bool = ...,
         store: StoreArg = ...,
+        delimiter: str | None = None,
         default: list[str] | None = ...,
     ) -> list[str] | None: ...
 
@@ -1995,6 +2000,7 @@ class Request:
         transform: Callable[[str], _T],
         required: bool = ...,
         store: StoreArg = ...,
+        delimiter: str | None = None,
         default: list[_T] | None = ...,
     ) -> list[_T] | None: ...
 
@@ -2004,6 +2010,7 @@ class Request:
         transform: Callable[[str], _T] | None = None,
         required: bool = False,
         store: StoreArg = None,
+        delimiter: str | None = None,
         default: list[_T] | None = None,
     ) -> list[_T] | list[str] | None:
         """Return the value of a query string parameter as a list.
@@ -2021,6 +2028,10 @@ class Request:
             name (str): Parameter name, case-sensitive (e.g., 'ids').
 
         Keyword Args:
+            delimiter(str): An optional character for splitting a parameter
+                value into a list. Useful for styles like ``spaceDelimited``
+                or ``pipeDelimited``. If not provided, default list parsing
+                applies.
             transform (callable): An optional transform function
                 that takes as input each element in the list as a ``str`` and
                 outputs a transformed element for inclusion in the list that
@@ -2065,6 +2076,16 @@ class Request:
         #       know how likely params are to be specified by clients.
         if name in params:
             items = params[name]
+
+            # If a delimiter is specified AND the param is a single string, split it.
+            if delimiter and isinstance(items, str):
+                if delimiter == ' ':
+                    items = items.split(' ')
+                elif delimiter == '|':
+                    items = items.split('|')
+                else:
+                    # For commas and others, also strip whitespace for convenience.
+                    items = [v.strip() for v in items.split(delimiter)]
 
             # NOTE(warsaw): When a key appears multiple times in the request
             # query, it will already be represented internally as a list.

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -1012,6 +1012,35 @@ class TestRequestAttributes:
 
         assert _parse_etags(header_value) is None
 
+    @pytest.mark.parametrize('asgi', [False, True])
+    def test_get_param_as_list_space_delimited(self, asgi):
+        req = create_req(asgi, query_string='names=Luke%20Leia%20Han')
+        result = req.get_param_as_list('names', delimiter=' ')
+        assert result == ['Luke', 'Leia', 'Han']
+
+    @pytest.mark.parametrize('asgi', [False, True])
+    def test_get_param_as_list_pipe_delimited(self, asgi):
+        req = create_req(asgi, query_string='names=Luke|Leia|Han')
+        result = req.get_param_as_list('names', delimiter='|')
+        assert result == ['Luke', 'Leia', 'Han']
+
+    @pytest.mark.parametrize('asgi', [False, True])
+    def test_get_param_as_list_custom_delimiter(self, asgi):
+        req = create_req(asgi, query_string='names=Luke;Leia;Han')
+        result = req.get_param_as_list('names', delimiter=';')
+        assert result == ['Luke', 'Leia', 'Han']
+
+    @pytest.mark.parametrize('asgi', [False, True])
+    def test_get_param_as_list_no_delimiter_still_defaults_to_comma(self, asgi):
+        options = falcon.RequestOptions()
+        options.auto_parse_qs_csv = True
+
+        req = create_req(asgi, query_string='names=Luke,Leia,Han', options=options)
+
+        result = req.get_param_as_list('names', delimiter=None)
+
+        assert result == ['Luke', 'Leia', 'Han']
+
     # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Add a new delimiter keyword argument to 
req.get_param_as_list to support splitting query parameter values on characters other than a comma.

Closes #2538 

# Summary of Changes

This PR introduces a new delimiter keyword argument to the req.get_param_as_list() method.

This enhancement allows for parsing list-style query parameters that use delimiters other than the default comma (e.g., spaces, pipes). The primary motivation is to better support spaceDelimited and pipeDelimited styles as described in the OpenAPI specification.

The splitting logic is only applied when the parameter value is a single string, which preserves the framework's existing behavior for handling multiple instances of the same parameter in a query string.

# Related Issues

Closes #2538 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) news fragments under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `towncrier --draft` to ensure it renders correctly.)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
