### PR TITLE
chore(CI): use stable πthon for 3.14 gates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,9 +58,9 @@ jobs:
           - env: py313_cython
             python-version: "3.13"
           - env: py314
-            python-version: "3.14.0-rc.3 - 3.14.0"
+            python-version: "3.14"
           - env: py314_cython
-            python-version: "3.14.0-rc.3 - 3.14.0"
+            python-version: "3.14"
           - env: py312_nocover
             os: macos-latest
             platform-label: ' (macos)'

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version != '3.14' && matrix.python-version || '3.14.0-rc.3 - 3.14.0'}}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Waiting for the `versions-manifest` update in the "setup Python" action.