### PR TITLE
fix: clean up Raises section of some request method docstrings

### DIFF
--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1567,13 +1567,13 @@ class Request:
             an ``int``. If the param is not found, returns ``None``, unless
             `required` is ``True``.
 
-        Raises
-            HTTPBadRequest: The param was not found in the request, even though
-                it was required to be there, or it was found but could not
-                be converted to an ``int``. Also raised if the param's value
-                falls outside the given interval, i.e., the value must be in
-                the interval: min_value <= value <= max_value to avoid
-                triggering an error.
+        Raises:
+            HTTPBadRequest: The param was not found in the request, even
+                though it was required to be there, or it was found but
+                could not be converted to an ``int``. Also raised if the
+                param's value falls outside the given interval, i.e., the
+                value must be in the interval: min_value <= value <=
+                max_value to avoid triggering an error.
 
         """
 
@@ -1680,13 +1680,13 @@ class Request:
             an ``float``. If the param is not found, returns ``None``, unless
             `required` is ``True``.
 
-        Raises
-            HTTPBadRequest: The param was not found in the request, even though
-                it was required to be there, or it was found but could not
-                be converted to an ``float``. Also raised if the param's value
-                falls outside the given interval, i.e., the value must be in
-                the interval: min_value <= value <= max_value to avoid
-                triggering an error.
+        Raises:
+            HTTPBadRequest: The param was not found in the request, even
+                though it was required to be there, or it was found but
+                could not be converted to an ``float``. Also raised if the
+                param's value falls outside the given interval, i.e., the
+                value must be in the interval: min_value <= value <=
+                max_value to avoid triggering an error.
 
         """
 
@@ -1792,10 +1792,10 @@ class Request:
             a ``UUID``. If the param is not found, returns
             ``default`` (default ``None``), unless `required` is ``True``.
 
-        Raises
-            HTTPBadRequest: The param was not found in the request, even though
-                it was required to be there, or it was found but could not
-                be converted to a ``UUID``.
+        Raises:
+            HTTPBadRequest: The param was not found in the request, even
+                though it was required to be there, or it was found but
+                could not be converted to a ``UUID``.
         """
 
         params = self._params


### PR DESCRIPTION
# Summary of Changes

Some request method docstrings have inconsistent formatting and are missing colons. This PR fixes this issue.

# Related Issues

Fixes #2547 

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e towncrier`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
