### PR TITLE
fix(asgi.Request): handle `scope['client']` being `None`

### DIFF
--- a/docs/_newsfragments/2583.bugfix.rst
+++ b/docs/_newsfragments/2583.bugfix.rst
@@ -1,0 +1,9 @@
+Due to the differences in interpretation of the ASGI specification, Uvicorn
+could set `client` in the HTTP connection scope in a way that broke
+:meth:`req.access_route <falcon.asgi.Request.access_route>` and
+:meth:`req.remote_addr <falcon.asgi.Request.remote_addr>` when the app server
+was bound to a Unix domain socket.
+
+This discrepancy was addressed, and Falcon should now fall back to the same
+default value (``'127.0.0.1'``) in this case as if `client` was missing
+altogether.

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -489,7 +489,12 @@ class Request(request.Request):
                 #   effectively what we are doing since we only ever
                 #   access this field when setting self._cached_access_route
                 client, __ = self.scope['client']
-            except KeyError:
+            # NOTE(vytas): Uvicorn may explicitly set scope['client'] to None.
+            #   According to the spec, it does default to None when missing,
+            #   but it is unclear whether it can be explicitly set to None, or
+            #   it must be a valid iterable when present. In any case, we
+            #   simply catch TypeError here too to account for this scenario.
+            except (KeyError, TypeError):
                 # NOTE(kgriffs): Default to localhost so that app logic does
                 #   note have to special-case the handling of a missing
                 #   client field in the connection scope. This should be

--- a/tests/asgi/test_request_asgi.py
+++ b/tests/asgi/test_request_asgi.py
@@ -1,12 +1,25 @@
 import pytest
 
 from falcon import testing
+from falcon.asgi import Request
 
 
 def test_missing_server_in_scope():
     req = testing.create_asgi_req(include_server=False, http_version='1.0')
     assert req.host == 'localhost'
     assert req.port == 80
+
+
+def test_client_none_in_scope():
+    # Regression test for #2583
+
+    async def recv():
+        pass
+
+    scope = testing.create_scope()
+    scope['client'] = None
+    req = Request(scope, recv)
+    assert req.remote_addr == '127.0.0.1'
 
 
 def test_log_error_not_supported():


### PR DESCRIPTION
Fixes #2583.
