### PR TITLE
docs: update obsolete RFC references to current RFCs

### DIFF
--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -265,7 +265,7 @@ HTTP methods, lowercased (e.g., ``on_get()``, ``on_put()``,
 
 .. note::
     Supported HTTP methods are those specified in
-    `RFC 7231 <https://tools.ietf.org/html/rfc7231>`_ and
+    `RFC 9110 <https://datatracker.ietf.org/doc/html/rfc9110>`_ and
     `RFC 5789 <https://tools.ietf.org/html/rfc5789>`_. This includes
     GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, and PATCH.
 

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -36,8 +36,7 @@ def _header_property(header_name: str) -> Any:
     def fget(self: Request) -> str | None:
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1);
-            #   and to strive for maximum
+            #   RFC 9110, Section 5.5; and to strive for maximum
             #   compatibility with WSGI.
             return self._asgi_headers[header_bytes].decode('latin1') or None
         except KeyError:

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -36,7 +36,8 @@ def _header_property(header_name: str) -> Any:
     def fget(self: Request) -> str | None:
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1); and to strive for maximum
+            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1);
+            #   and to strive for maximum
             #   compatibility with WSGI.
             return self._asgi_headers[header_bytes].decode('latin1') or None
         except KeyError:

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -36,7 +36,7 @@ def _header_property(header_name: str) -> Any:
     def fget(self: Request) -> str | None:
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
+            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1); and to strive for maximum
             #   compatibility with WSGI.
             return self._asgi_headers[header_bytes].decode('latin1') or None
         except KeyError:

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -356,7 +356,7 @@ class Response(response.Response):
 
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
+            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1); and to strive for maximum
             #   compatibility with WSGI.
 
             # PERF(vytas): On CPython, _encode_items_to_latin1 is implemented

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -356,8 +356,7 @@ class Response(response.Response):
 
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1);
-            #   and to strive for maximum
+            #   RFC 9110, Section 5.5; and to strive for maximum
             #   compatibility with WSGI.
 
             # PERF(vytas): On CPython, _encode_items_to_latin1 is implemented

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -356,7 +356,8 @@ class Response(response.Response):
 
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1); and to strive for maximum
+            #   RFC 9110, Section 5.3 (see also RFC 9112, Section 2.1);
+            #   and to strive for maximum
             #   compatibility with WSGI.
 
             # PERF(vytas): On CPython, _encode_items_to_latin1 is implemented

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -55,7 +55,7 @@ TRUE_STRINGS = frozenset(['true', 'True', 't', 'yes', 'y', '1', 'on'])
 FALSE_STRINGS = frozenset(['false', 'False', 'f', 'no', 'n', '0', 'off'])
 """Similar to :attr:`TRUE_STRINGS`, the values corresponding to boolean ``False``."""
 
-# RFC 7231, 5789 methods
+# RFC 9110, 5789 methods
 HTTP_METHODS = [
     'CONNECT',
     'DELETE',

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -232,7 +232,7 @@ class HTTPBadRequest(HTTPError):
     syntax, invalid request message framing, or deceptive request
     routing).
 
-    (See also: RFC 7231, Section 6.5.1)
+    (See also: RFC 9110, Section 15.5.1)
 
     All the arguments are defined as keyword-only.
 
@@ -302,7 +302,7 @@ class HTTPUnauthorized(HTTPError):
     SHOULD present the enclosed representation to the user, since it
     usually contains relevant diagnostic information.
 
-    (See also: RFC 7235, Section 3.1)
+    (See also: RFC 9110, Section 15.5.2)
 
     All the arguments are defined as keyword-only.
 
@@ -334,7 +334,7 @@ class HTTPUnauthorized(HTTPError):
                 The existing value of the WWW-Authenticate in headers will be
                 overridden by this value
 
-            (See also: RFC 7235, Section 2.1)
+            (See also: RFC 9110, Section 11.6.1)
         href (str): A URL someone can visit to find out more information
             (default ``None``). Unicode characters are percent-encoded.
         href_text (str): If href is given, use this as the friendly
@@ -387,7 +387,7 @@ class HTTPForbidden(HTTPError):
     forbidden target resource MAY instead respond with a status code of
     404 Not Found.
 
-    (See also: RFC 7231, Section 6.5.4)
+    (See also: RFC 9110, Section 15.5.5)
 
     All the arguments are defined as keyword-only.
 
@@ -453,7 +453,7 @@ class HTTPNotFound(HTTPError):
     A 404 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.3)
+    (See also: RFC 9110, Section 15.5.4)
 
     All the arguments are defined as keyword-only.
 
@@ -564,7 +564,7 @@ class HTTPMethodNotAllowed(HTTPError):
     A 405 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.5)
+    (See also: RFC 9110, Section 15.5.6)
 
     `allowed_methods` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -643,9 +643,9 @@ class HTTPNotAcceptable(HTTPError):
     most appropriate. A user agent MAY automatically select the most
     appropriate choice from that list. However, this specification does
     not define any standard for such automatic selection, as described
-    in RFC 7231, Section 6.4.1
+    in RFC 9110, Section 15.4.1
 
-    (See also: RFC 7231, Section 6.5.6)
+    (See also: RFC 9110, Section 15.5.7)
 
     All the arguments are defined as keyword-only.
 
@@ -714,7 +714,7 @@ class HTTPConflict(HTTPError):
     case, the response representation would likely contain information
     useful for merging the differences based on the revision history.
 
-    (See also: RFC 7231, Section 6.5.8)
+    (See also: RFC 9110, Section 15.5.10)
 
     All the arguments are defined as keyword-only.
 
@@ -788,7 +788,7 @@ class HTTPGone(HTTPError):
     A 410 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.9)
+    (See also: RFC 9110, Section 15.5.11)
 
     All the arguments are defined as keyword-only.
 
@@ -851,7 +851,7 @@ class HTTPLengthRequired(HTTPError):
     header field containing the length of the message body in the
     request message.
 
-    (See also: RFC 7231, Section 6.5.10)
+    (See also: RFC 9110, Section 15.5.10)
 
     All the arguments are defined as keyword-only.
 
@@ -913,7 +913,7 @@ class HTTPPreconditionFailed(HTTPError):
     and, thus, prevent the request method from being applied if the
     target resource is in an unexpected state.
 
-    (See also: RFC 7232, Section 4.2)
+    (See also: RFC 9110, Section 13.1.1)
 
     All the arguments are defined as keyword-only.
 
@@ -977,7 +977,7 @@ class HTTPContentTooLarge(HTTPError):
     After header field to indicate that it is temporary and after what
     time the client MAY try again.
 
-    (See also: RFC 7231, Section 6.5.11)
+    (See also: RFC 9110, Section 15.5.11)
 
     All the arguments are defined as keyword-only.
 
@@ -1066,7 +1066,7 @@ class HTTPUriTooLong(HTTPError):
     A 414 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.12)
+    (See also: RFC 9110, Section 15.5.12)
 
     All the arguments are defined as keyword-only.
 
@@ -1128,7 +1128,7 @@ class HTTPUnsupportedMediaType(HTTPError):
     Type or Content-Encoding, or as a result of inspecting the data
     directly.
 
-    (See also: RFC 7231, Section 6.5.13)
+    (See also: RFC 9110, Section 15.5.13)
 
     All the arguments are defined as keyword-only.
 
@@ -1194,7 +1194,7 @@ class HTTPRangeNotSatisfiable(HTTPError):
     sender SHOULD generate a Content-Range header field specifying the
     current length of the selected representation.
 
-    (See also: RFC 7233, Section 4.4)
+    (See also: RFC 9110, Section 15.5.17)
 
     `resource_length` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -1720,7 +1720,7 @@ class HTTPInternalServerError(HTTPError):
     The server encountered an unexpected condition that prevented it
     from fulfilling the request.
 
-    (See also: RFC 7231, Section 6.6.1)
+    (See also: RFC 9110, Section 15.6.1)
 
     All the arguments are defined as keyword-only.
 
@@ -1782,9 +1782,9 @@ class HTTPNotImplemented(HTTPError):
 
     A 501 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls
-    as described in RFC 7234, Section 4.2.2.
+    as described in RFC 9111, Section 4.2.2.
 
-    (See also: RFC 7231, Section 6.6.2)
+    (See also: RFC 9110, Section 15.6.2)
 
     All the arguments are defined as keyword-only.
 
@@ -1844,7 +1844,7 @@ class HTTPBadGateway(HTTPError):
     response from an inbound server it accessed while attempting to
     fulfill the request.
 
-    (See also: RFC 7231, Section 6.6.3)
+    (See also: RFC 9110, Section 15.6.3)
 
     All the arguments are defined as keyword-only.
 
@@ -1910,7 +1910,7 @@ class HTTPServiceUnavailable(HTTPError):
     server has to use it when becoming overloaded. Some servers might
     simply refuse the connection.
 
-    (See also: RFC 7231, Section 6.6.4)
+    (See also: RFC 9110, Section 15.6.4)
 
     All the arguments are defined as keyword-only.
 
@@ -1978,7 +1978,7 @@ class HTTPGatewayTimeout(HTTPError):
     from an upstream server it needed to access in order to complete the
     request.
 
-    (See also: RFC 7231, Section 6.6.5)
+    (See also: RFC 9110, Section 15.6.5)
 
     All the arguments are defined as keyword-only.
 
@@ -2036,13 +2036,13 @@ class HTTPVersionNotSupported(HTTPError):
     server does not support, or refuses to support, the major version of
     HTTP that was used in the request message.  The server is indicating
     that it is unable or unwilling to complete the request using the same
-    major version as the client (as described in RFC 7230, Section 2.6),
+    major version as the client (as described in RFC 9112, Section 2.5),
     other than with this error message.  The server SHOULD
     generate a representation for the 505 response that describes why
     that version is not supported and what other protocols are supported
     by that server.
 
-    (See also: RFC 7231, Section 6.6.6)
+    (See also: RFC 9110, Section 15.6.6)
 
     All the arguments are defined as keyword-only.
 

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -387,7 +387,7 @@ class HTTPForbidden(HTTPError):
     forbidden target resource MAY instead respond with a status code of
     404 Not Found.
 
-    (See also: RFC 9110, Section 15.5.5)
+    (See also: RFC 9110, Section 15.5.4)
 
     All the arguments are defined as keyword-only.
 
@@ -453,7 +453,7 @@ class HTTPNotFound(HTTPError):
     A 404 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 9110, Section 15.5.4)
+    (See also: RFC 9110, Section 15.5.5)
 
     All the arguments are defined as keyword-only.
 
@@ -851,7 +851,7 @@ class HTTPLengthRequired(HTTPError):
     header field containing the length of the message body in the
     request message.
 
-    (See also: RFC 9110, Section 15.5.10)
+    (See also: RFC 9110, Section 15.5.12)
 
     All the arguments are defined as keyword-only.
 
@@ -913,7 +913,7 @@ class HTTPPreconditionFailed(HTTPError):
     and, thus, prevent the request method from being applied if the
     target resource is in an unexpected state.
 
-    (See also: RFC 9110, Section 13.1.1)
+    (See also: RFC 9110, Section 15.5.13)
 
     All the arguments are defined as keyword-only.
 
@@ -977,7 +977,7 @@ class HTTPContentTooLarge(HTTPError):
     After header field to indicate that it is temporary and after what
     time the client MAY try again.
 
-    (See also: RFC 9110, Section 15.5.11)
+    (See also: RFC 9110, Section 15.5.14)
 
     All the arguments are defined as keyword-only.
 
@@ -1066,7 +1066,7 @@ class HTTPUriTooLong(HTTPError):
     A 414 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 9110, Section 15.5.12)
+    (See also: RFC 9110, Section 15.5.15)
 
     All the arguments are defined as keyword-only.
 
@@ -1128,7 +1128,7 @@ class HTTPUnsupportedMediaType(HTTPError):
     Type or Content-Encoding, or as a result of inspecting the data
     directly.
 
-    (See also: RFC 9110, Section 15.5.13)
+    (See also: RFC 9110, Section 15.5.16)
 
     All the arguments are defined as keyword-only.
 
@@ -2036,7 +2036,7 @@ class HTTPVersionNotSupported(HTTPError):
     server does not support, or refuses to support, the major version of
     HTTP that was used in the request message.  The server is indicating
     that it is unable or unwilling to complete the request using the same
-    major version as the client (as described in RFC 9112, Section 2.5),
+    major version as the client (as described in RFC 9110, Section 2.5),
     other than with this error message.  The server SHOULD
     generate a representation for the 505 response that describes why
     that version is not supported and what other protocols are supported

--- a/falcon/redirects.py
+++ b/falcon/redirects.py
@@ -36,7 +36,7 @@ class HTTPMovedPermanently(HTTPStatus):
         behavior is undesired, the 308 (Permanent Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.2)
+    (See also: RFC 9110, Section 15.4.2)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -65,7 +65,7 @@ class HTTPFound(HTTPStatus):
         behavior is undesired, the 307 (Temporary Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.3)
+    (See also: RFC 9110, Section 15.4.3)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -99,7 +99,7 @@ class HTTPSeeOther(HTTPStatus):
         The new URI in the Location header field is not considered
         equivalent to the effective request URI.
 
-    (See also: RFC 7231, Section 6.4.4)
+    (See also: RFC 9110, Section 15.4.4)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -128,7 +128,7 @@ class HTTPTemporaryRedirect(HTTPStatus):
         This status code is similar to 302 (Found), except that it
         does not allow changing the request method from POST to GET.
 
-    (See also: RFC 7231, Section 6.4.7)
+    (See also: RFC 9110, Section 15.4.8)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -154,7 +154,7 @@ class HTTPPermanentRedirect(HTTPStatus):
         that it does not allow changing the request method from POST to
         GET.
 
-    (See also: RFC 7238, Section 3)
+    (See also: RFC 9110, Section 15.4.9)
 
     Args:
         location (str): URI to provide as the Location header in the

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -493,7 +493,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.1)
+        (See also: RFC 9110, Section 13.1.1)
         """  # noqa: D205
         # TODO(kgriffs): It may make sense at some point to create a
         #   header property generator that DRY's up the memoization
@@ -517,7 +517,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.2)
+        (See also: RFC 9110, Section 13.1.2)
         """  # noqa: D205
         if self._cached_if_none_match is _UNSET:
             header_value = self.env.get('HTTP_IF_NONE_MATCH')
@@ -606,7 +606,7 @@ class Request:
         except ValueError:
             href = 'https://tools.ietf.org/html/rfc7233'
             href_text = 'HTTP/1.1 Range Requests'
-            msg = 'It must be a range formatted according to RFC 7233.'
+            msg = 'It must be a range formatted according to RFC 9110.'
             raise errors.HTTPInvalidHeader(msg, 'Range', href=href, href_text=href_text)
 
     @property
@@ -1363,7 +1363,7 @@ class Request:
             else:
                 return None
         except ValueError:
-            msg = 'It must be formatted according to RFC 7231, Section 7.1.1.1'
+            msg = 'It must be formatted according to RFC 9110, Section 5.6.7'
             raise errors.HTTPInvalidHeader(msg, header)
 
     def get_cookie_values(self, name: str) -> list[str] | None:

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -35,7 +35,7 @@ _COOKIE_NAME_RESERVED_CHARS = re.compile(
 )
 
 # NOTE(kgriffs): strictly speaking, the weakness indicator is
-#   case-sensitive, but this wasn't explicit until RFC 7232
+#   case-sensitive, but this wasn't explicit until RFC 7232 (now RFC 9110)
 #   so we allow for both. We also require quotes because that's
 #   been standardized since 1999, and it makes the regex simpler
 #   and more performant.
@@ -135,7 +135,7 @@ def _parse_etags(etag_str: str) -> list[ETag | Literal['*']] | None:
     ETags. The string may also contain a '*' character, in order to indicate
     that any ETag should match the precondition.
 
-    (See also: RFC 7232, Section 3)
+    (See also: RFC 9110, Section 13.1)
 
     Args:
         etag_str (str): An ASCII header value to parse ETags from. ETag values

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -1096,7 +1096,7 @@ class Response:
             case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
             thing.
 
-        (See also: RFC 7233, Section 4.2)
+        (See also: RFC 9110, Section 14.4)
         """,
         _format_range,
     )
@@ -1114,7 +1114,7 @@ class Response:
         case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
         thing.
 
-    (See also: RFC 7233, Section 4.2)
+    (See also: RFC 9110, Section 14.4)
     """
 
     content_type: str | None = _header_property(
@@ -1290,7 +1290,7 @@ class Response:
         value consists of either a single asterisk ("*") or a list of
         header field names (case-insensitive).
 
-        (See also: RFC 7231, Section 7.1.4)
+        (See also: RFC 9110, Section 10.2.1)
         """,
         _format_header_value_list,
     )
@@ -1307,7 +1307,7 @@ class Response:
     value consists of either a single asterisk ("*") or a list of
     header field names (case-insensitive).
 
-    (See also: RFC 7231, Section 7.1.4)
+    (See also: RFC 9110, Section 10.2.1)
     """
 
     accept_ranges: str | None = _header_property(

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -1290,7 +1290,7 @@ class Response:
         value consists of either a single asterisk ("*") or a list of
         header field names (case-insensitive).
 
-        (See also: RFC 9110, Section 10.2.1)
+        (See also: RFC 9110, Section 12.5.5)
         """,
         _format_header_value_list,
     )
@@ -1307,7 +1307,7 @@ class Response:
     value consists of either a single asterisk ("*") or a list of
     header field names (case-insensitive).
 
-    (See also: RFC 9110, Section 10.2.1)
+    (See also: RFC 9110, Section 12.5.5)
     """
 
     accept_ranges: str | None = _header_property(

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -550,7 +550,7 @@ def simulate_request(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -813,7 +813,7 @@ async def _simulate_request_asgi(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1355,7 +1355,7 @@ def simulate_get(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1458,7 +1458,7 @@ def simulate_head(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1556,7 +1556,7 @@ def simulate_post(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1667,7 +1667,7 @@ def simulate_put(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1773,7 +1773,7 @@ def simulate_options(app: Callable[..., Any], path: str, **kwargs: Any) -> Resul
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1867,7 +1867,7 @@ def simulate_patch(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1973,7 +1973,7 @@ def simulate_delete(app: Callable[..., Any], path: str, **kwargs: Any) -> Result
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -928,7 +928,7 @@ def create_scope(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110 and RFC 9112). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1071,7 +1071,7 @@ def create_scope_ws(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110 and RFC 9112). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1168,7 +1168,7 @@ def create_environ(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -166,7 +166,7 @@ def http_date_to_dt(http_date: str, obs_date: bool = False) -> datetime.datetime
 
     Keyword Arguments:
         obs_date (bool): Support obs-date formats according to
-            RFC 7231, e.g.:
+            RFC 9110, e.g.:
             "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
     Returns:

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -237,7 +237,7 @@ class ETag(str):
 
     This class is simply a subclass of ``str`` with a few helper methods and
     an extra attribute to indicate whether the entity-tag is weak or strong. The
-    value of the string is equivalent to what RFC 7232 calls an "opaque-tag",
+    value of the string is equivalent to what RFC 9110 calls an "opaque-tag",
     i.e. an entity-tag sans quotes and the weakness indicator.
 
     Note:
@@ -261,7 +261,7 @@ class ETag(str):
             resp.etag = content_etag
             resp.status = falcon.HTTP_200
 
-    (See also: RFC 7232)
+    (See also: RFC 9110)
     """
 
     is_weak: bool = False
@@ -273,7 +273,7 @@ class ETag(str):
         Two entity-tags are equivalent if both are not weak and their
         opaque-tags match character-by-character.
 
-        (See also: RFC 7232, Section 2.3.2)
+        (See also: RFC 9110, Section 8.8.3.2)
 
         Arguments:
             other (ETag): The other :class:`~.ETag` to which you are comparing
@@ -289,7 +289,7 @@ class ETag(str):
     def dumps(self) -> str:
         """Serialize the ETag to a string suitable for use in a precondition header.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Returns:
             str: An opaque quoted string, possibly prefixed by a weakness
@@ -313,11 +313,11 @@ class ETag(str):
             entity-tag. It can not be used to parse a comma-separated list of
             values.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Arguments:
             etag_str (str): An ASCII string representing a single entity-tag,
-                as defined by RFC 7232.
+                as defined by RFC 9110.
 
         Returns:
             ETag: An instance of `~.ETag` representing the parsed entity-tag.

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -604,7 +604,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "Range" header is '
             'invalid. It must be a range formatted '
-            'according to RFC 7233.'
+            'according to RFC 9110.'
         )
         self._test_error_details(
             headers,
@@ -723,7 +723,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "{}" '
             'header is invalid. It must be formatted '
-            'according to RFC 7231, Section 7.1.1.1'
+            'according to RFC 9110, Section 5.6.7'
         )
 
         self._test_error_details(


### PR DESCRIPTION
## Summary

Update references to obsolete HTTP RFCs throughout the codebase with their current equivalents, as tracked in #2525.

## RFC Mapping

| Old RFC | New RFC | Subject |
|---------|---------|---------|
| RFC 7230 | RFC 9112 | HTTP/1.1 Message Syntax |
| RFC 7231 | RFC 9110 | HTTP Semantics and Content |
| RFC 7232 | RFC 9110 | Conditional Requests |
| RFC 7233 | RFC 9110 | Range Requests |
| RFC 7234 | RFC 9111 | HTTP Caching |
| RFC 7235 | RFC 9110 | Authentication |
| RFC 7238 | RFC 9110 | 308 Permanent Redirect |

## What Changed

- **falcon/errors.py**: Updated all status code RFC references with correct new section numbers
- **falcon/redirects.py**: Updated redirect status code references  
- **falcon/response.py**: Updated Content-Range and Allow header references
- **falcon/request.py**: Updated conditional request and date format references
- **falcon/request_helpers.py**: Updated ETag references
- **falcon/testing/client.py** & **helpers.py**: Updated header format references
- **falcon/util/structures.py**: Updated ETag-related references
- **falcon/util/misc.py**: Updated date format reference
- **falcon/constants.py**: Updated comment referencing method definitions
- **falcon/asgi/**: Updated header folding references
- **docs/user/tutorial.rst**: Updated link to RFC

## What Was NOT Changed

- **docs/changes/**: Historical changelog entries left unchanged
- **falcon/forwarded.py**: RFC 7239 (Forwarded header) has not been obsoleted
- **docs/ext/rfc.py**: Sphinx extension URL pattern; could be updated separately

Partial fix for #2525.