### PR TITLE
feat(static): add proper `HEAD` support and method filtering

### DIFF
--- a/docs/_newsfragments/2337.newandimproved.rst
+++ b/docs/_newsfragments/2337.newandimproved.rst
@@ -1,0 +1,9 @@
+Static routes now support ``HEAD`` requests properly. A ``HEAD`` request
+returns all the same headers as a ``GET`` request (``Content-Type``,
+``Content-Length``, ``ETag``, etc.) but does not open or stream file
+contents.
+
+Additionally, static routes now block unsupported HTTP methods (such as
+``POST``, ``PUT``, ``PATCH``, and ``DELETE``) with ``405 Method Not
+Allowed``, and the ``Allow`` header in ``OPTIONS`` responses now correctly
+lists all supported methods (``GET``, ``HEAD``, ``OPTIONS``).

--- a/falcon/routing/static.py
+++ b/falcon/routing/static.py
@@ -223,12 +223,19 @@ class StaticRoute:
             return path.startswith(self._prefix)
         return path.startswith(self._prefix) or path == self._prefix[:-1]
 
+    _ALLOWED_METHODS: ClassVar[frozenset[str]] = frozenset(
+        {'GET', 'HEAD', 'OPTIONS'}
+    )
+
     def __call__(self, req: Request, resp: Response, **kw: Any) -> None:
         """Resource responder for this route."""
         assert not kw
+
+        if req.method not in self._ALLOWED_METHODS:
+            raise falcon.HTTPMethodNotAllowed(sorted(self._ALLOWED_METHODS))
+
         if req.method == 'OPTIONS':
-            # it's likely a CORS request. Set the allow header to the appropriate value.
-            resp.set_header('Allow', 'GET')
+            resp.set_header('Allow', ', '.join(sorted(self._ALLOWED_METHODS)))
             resp.set_header('Content-Length', '0')
             return
 
@@ -279,9 +286,25 @@ class StaticRoute:
         last_modified = last_modified.replace(microsecond=0)
         resp.last_modified = last_modified
 
+        suffix = os.path.splitext(file_path)[1]
+        resp.content_type = resp.options.static_media_types.get(
+            suffix, 'application/octet-stream'
+        )
+        resp.accept_ranges = 'bytes'
+
+        if self._downloadable:
+            resp.downloadable_as = os.path.basename(file_path)
+
         if _is_not_modified(req, etag, last_modified):
             fh.close()
             resp.status = falcon.HTTP_304
+            return
+
+        if req.method == 'HEAD':
+            # NOTE(alexchenai): For HEAD requests, we set headers but do not
+            #   open a file stream, as the response must not include a body.
+            resp.content_length = st.st_size
+            fh.close()
             return
 
         req_range = req.range if req.range_unit == 'bytes' else None
@@ -292,14 +315,7 @@ class StaticRoute:
             raise falcon.HTTPNotFound()
 
         resp.set_stream(stream, length)
-        suffix = os.path.splitext(file_path)[1]
-        resp.content_type = resp.options.static_media_types.get(
-            suffix, 'application/octet-stream'
-        )
-        resp.accept_ranges = 'bytes'
 
-        if self._downloadable:
-            resp.downloadable_as = os.path.basename(file_path)
         if content_range:
             resp.status = falcon.HTTP_206
             resp.content_range = content_range

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -757,3 +757,68 @@ def test_if_none_match_precedence(client, patch_open):
     )
     assert resp2.status == falcon.HTTP_304
     assert resp2.text == ''
+
+
+def test_head_request(client, patch_open):
+    content = b'Hello, World!'
+    patch_open(content=content)
+
+    client.app.add_static_route('/static', '/var/www/statics')
+
+    resp = client.simulate_head(path='/static/foo/bar.txt')
+    assert resp.status == falcon.HTTP_200
+    assert resp.headers.get('Content-Type') is not None
+    assert int(resp.headers['Content-Length']) == len(content)
+    assert resp.headers.get('ETag') is not None
+    assert resp.headers.get('Accept-Ranges') == 'bytes'
+    # HEAD response must not include a body
+    assert resp.content == b''
+
+
+def test_head_request_not_modified(client, patch_open):
+    mtime = (1736617934, 'Sat, 11 Jan 2025 17:52:14 GMT')
+    patch_open(mtime=mtime[0])
+
+    client.app.add_static_route('/assets/', '/opt/somesite/assets')
+
+    # First, get the ETag
+    resp1 = client.simulate_request(path='/assets/css/main.css')
+    etag = resp1.headers['ETag']
+
+    # HEAD with matching ETag should return 304
+    resp2 = client.simulate_head(
+        path='/assets/css/main.css',
+        headers={'If-None-Match': etag},
+    )
+    assert resp2.status == falcon.HTTP_304
+    assert resp2.content == b''
+
+
+@pytest.mark.parametrize('method', ['POST', 'PUT', 'PATCH', 'DELETE'])
+def test_method_not_allowed(client, patch_open, method):
+    patch_open()
+
+    client.app.add_static_route('/static', '/var/www/statics')
+
+    resp = client.simulate_request(
+        method=method,
+        path='/static/foo/bar.txt',
+    )
+    assert resp.status == falcon.HTTP_405
+    allow = resp.headers.get('Allow')
+    assert allow is not None
+    allowed_methods = {m.strip() for m in allow.split(',')}
+    assert allowed_methods == {'GET', 'HEAD', 'OPTIONS'}
+
+
+def test_options_returns_all_allowed_methods(client, patch_open):
+    patch_open()
+
+    client.app.add_static_route('/static', '/var/www/statics')
+
+    resp = client.simulate_options(path='/static/foo/bar.txt')
+    assert resp.status_code == 200
+    allow = resp.headers.get('Allow')
+    assert allow is not None
+    allowed_methods = {m.strip() for m in allow.split(',')}
+    assert allowed_methods == {'GET', 'HEAD', 'OPTIONS'}


### PR DESCRIPTION
## Summary

Fixes #2337.

- **HEAD support**: Static routes now handle `HEAD` requests by returning all relevant headers (`Content-Type`, `Content-Length`, `ETag`, `Last-Modified`, `Accept-Ranges`) without opening a file stream for the response body. This avoids unnecessary file I/O for HEAD requests.
- **Method filtering**: Unsupported HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`) now receive a `405 Method Not Allowed` response with a proper `Allow` header.
- **OPTIONS fix**: The `Allow` header in `OPTIONS` responses now correctly lists all supported methods (`GET`, `HEAD`, `OPTIONS`) instead of just `GET`.

## Changes

- `falcon/routing/static.py`: Added `_ALLOWED_METHODS` class variable, method validation at the top of `__call__`, HEAD-specific handling that sets headers and closes the file without streaming, and updated OPTIONS to advertise all allowed methods.
- `tests/test_static.py`: Added tests for HEAD requests (normal + 304 Not Modified), 405 Method Not Allowed for unsupported methods, and OPTIONS returning all allowed methods.
- `docs/_newsfragments/2337.newandimproved.rst`: Towncrier changelog fragment.

## Test plan

- [x] HEAD request returns correct headers with empty body
- [x] HEAD request respects conditional headers (If-None-Match returns 304)
- [x] POST/PUT/PATCH/DELETE return 405 with correct Allow header
- [x] OPTIONS returns Allow header listing GET, HEAD, OPTIONS
- [ ] Verify existing static route tests still pass (CI)

## Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e towncrier`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [ ] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*