### PR TITLE
chore(E2E): use bounded Queue in Hub

### DIFF
--- a/e2e-tests/server/hub.py
+++ b/e2e-tests/server/hub.py
@@ -15,7 +15,7 @@ class Emitter:
 
     def __init__(self) -> None:
         self._done: bool = False
-        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue()
+        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=100)
 
     async def events(self) -> typing.AsyncGenerator[SSEvent | None, None]:
         try:
@@ -36,7 +36,10 @@ class Emitter:
 
     async def enqueue(self, message: str) -> None:
         event = SSEvent(text=message, event_id=str(uuid.uuid4()))
-        await self._queue.put(event)
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
 
     @property
     def done(self) -> bool:

--- a/e2e-tests/server/hub.py
+++ b/e2e-tests/server/hub.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import typing
 import uuid
 
@@ -9,13 +10,19 @@ from falcon.asgi import Response
 from falcon.asgi import SSEvent
 from falcon.asgi import WebSocket
 
+logger = logging.getLogger(__name__)
+
 
 class Emitter:
     POLL_TIMEOUT = 3.0
 
     def __init__(self) -> None:
         self._done: bool = False
-        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=100)
+        # NOTE: Bounded queue prevents unbounded memory growth when SSE
+        # consumers stop reading but remain connected. In production systems,
+        # this protects against memory leaks; here it serves as a safeguard
+        # for the test harness and demonstrates safe concurrency patterns.
+        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=256)
 
     async def events(self) -> typing.AsyncGenerator[SSEvent | None, None]:
         try:
@@ -39,7 +46,14 @@ class Emitter:
         try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
-            pass
+            # NOTE(vytas): Drop message and log the incident.
+            # In production, consider implementing backpressure or
+            # terminating the stalled connection.
+            logger.warning(
+                "SSE emitter queue full (maxsize=%d), dropping message. "
+                "This indicates a slow or stalled consumer.",
+                self._queue.maxsize,
+            )
 
     @property
     def done(self) -> bool:

--- a/e2e-tests/server/hub.py
+++ b/e2e-tests/server/hub.py
@@ -45,7 +45,6 @@ class Emitter:
         event = SSEvent(text=message, event_id=str(uuid.uuid4()))
         try:
             self._queue.put_nowait(event)
-            self._queue.put_nowait(event)
         except asyncio.QueueFull:
             logger.warning(
                 'SSE emitter queue full (maxsize=%d), dropping message. '

--- a/e2e-tests/server/hub.py
+++ b/e2e-tests/server/hub.py
@@ -19,10 +19,10 @@ class Emitter:
     def __init__(self) -> None:
         self._done: bool = False
         # NOTE(tang-vu): Bounded queue prevents unbounded memory growth when
-        # SSE consumers stop reading but remain connected. While unlikely in
-        # a test harness, this guards against memory leaks in long-running
-        # scenarios and demonstrates safe concurrency patterns.
-        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=256)
+        #   SSE consumers stop reading but remain connected. While unlikely in
+        #   this short-lived E2E test, this guards against memory leaks in
+        #   long-running scenarios, and demonstrates safe concurrency patterns.
+        self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=32)
 
     async def events(self) -> typing.AsyncGenerator[SSEvent | None, None]:
         try:
@@ -45,11 +45,11 @@ class Emitter:
         event = SSEvent(text=message, event_id=str(uuid.uuid4()))
         try:
             self._queue.put_nowait(event)
+            self._queue.put_nowait(event)
         except asyncio.QueueFull:
-            # NOTE(tang-vu): Log the incident for diagnostics.
             logger.warning(
-                "SSE emitter queue full (maxsize=%d), dropping message. "
-                "This indicates a slow or stalled consumer.",
+                'SSE emitter queue full (maxsize=%d), dropping message. '
+                'This indicates a slow or stalled consumer.',
                 self._queue.maxsize,
             )
 

--- a/e2e-tests/server/hub.py
+++ b/e2e-tests/server/hub.py
@@ -18,10 +18,10 @@ class Emitter:
 
     def __init__(self) -> None:
         self._done: bool = False
-        # NOTE: Bounded queue prevents unbounded memory growth when SSE
-        # consumers stop reading but remain connected. In production systems,
-        # this protects against memory leaks; here it serves as a safeguard
-        # for the test harness and demonstrates safe concurrency patterns.
+        # NOTE(tang-vu): Bounded queue prevents unbounded memory growth when
+        # SSE consumers stop reading but remain connected. While unlikely in
+        # a test harness, this guards against memory leaks in long-running
+        # scenarios and demonstrates safe concurrency patterns.
         self._queue: asyncio.Queue[SSEvent] = asyncio.Queue(maxsize=256)
 
     async def events(self) -> typing.AsyncGenerator[SSEvent | None, None]:
@@ -46,9 +46,7 @@ class Emitter:
         try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
-            # NOTE(vytas): Drop message and log the incident.
-            # In production, consider implementing backpressure or
-            # terminating the stalled connection.
+            # NOTE(tang-vu): Log the incident for diagnostics.
             logger.warning(
                 "SSE emitter queue full (maxsize=%d), dropping message. "
                 "This indicates a slow or stalled consumer.",


### PR DESCRIPTION
## Problem

The `Emitter` class in the E2E test server initializes an `asyncio.Queue` without a `maxsize`. In the `Hub.broadcast` method, messages are enqueued for all active emitters. If a client (SSE consumer) stops reading but the connection remains open, the queue will grow indefinitely, potentially leading to a memory leak in the test server.

**Severity**: `medium`
**File**: `e2e-tests/server/hub.py`

## Solution

Set a reasonable `maxsize` for the queue and handle potential `asyncio.QueueFull` errors or use `put_nowait` with a drop-oldest strategy.

## Changes

- `e2e-tests/server/hub.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
