### PR TITLE
Security: Unsafe tarfile extraction allows path traversal (CVE-2007-4559)

### DIFF
--- a/tools/tox_sdist.py
+++ b/tools/tox_sdist.py
@@ -28,6 +28,11 @@ def build_sdist():
 
 def extract_sdist(archive, target):
     with tarfile.open(archive) as targz:
+        resolved_target = target.resolve()
+        for member in targz.getmembers():
+            member_path = (resolved_target / member.name).resolve()
+            if not member_path.is_relative_to(resolved_target):
+                raise RuntimeError(f'Path traversal detected in tar: {member.name}')
         targz.extractall(target)
 
     content = target / archive.with_suffix('').stem


### PR DESCRIPTION
## Problem

The `tarfile.extractall()` method is called without any path validation or filtering. A maliciously crafted tar archive could contain entries with absolute paths or `../` sequences, allowing files to be written outside the intended target directory. This is a well-known vulnerability (CVE-2007-4559).

**Severity**: `high`
**File**: `tools/tox_sdist.py`

## Solution

Use the `filter='data'` parameter (Python 3.12+) or manually validate each member's path before extraction: `targz.extractall(target, filter='data')`. For older Python versions, iterate members and check that resolved paths stay within the target directory.

## Changes

- `tools/tox_sdist.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
