### PR TITLE
Security: Potential XSS in Mako error template due to unescaped variables

### DIFF
--- a/falcon/bench/nuts/nuts/templates/error.html
+++ b/falcon/bench/nuts/nuts/templates/error.html
@@ -2,11 +2,11 @@
 
 ## provide definitions for blocks we want to redefine
 <%def name="title()">
-    Server Error ${status}
+    Server Error ${status | h}
 </%def>
 
 ## now define the body of the template
     <header>
-      <h1>Server Error ${status}</h1>
+      <h1>Server Error ${status | h}</h1>
     </header>
-    <p>${message}</p>
+    <p>${message | h}</p>


### PR DESCRIPTION
## Problem

The Mako template renders `${status}` and `${message}` variables without explicit HTML escaping. Mako does NOT enable HTML escaping by default. If `status` or `message` contain user-controlled input (e.g., from a URL or request that triggered the error), an attacker could inject arbitrary HTML/JavaScript.

**Severity**: `medium`
**File**: `falcon/bench/nuts/nuts/templates/error.html`

## Solution

Use Mako's HTML escaping filter: `${status | h}` and `${message | h}`, or configure `default_filters=['h']` in the Mako template lookup to enable auto-escaping by default.

## Changes

- `falcon/bench/nuts/nuts/templates/error.html` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
