### PR TITLE
Security: Server Binding to All Network Interfaces (0.0.0.0)

### DIFF
--- a/falcon/bench/nuts/config.py
+++ b/falcon/bench/nuts/config.py
@@ -1,5 +1,5 @@
 # Server Specific Configurations
-server = {'port': '8080', 'host': '0.0.0.0'}
+server = {'port': '8080', 'host': '127.0.0.1'}
 
 # Pecan Application Configurations
 app = {


### PR DESCRIPTION
## Problem

The benchmark server configurations bind to `0.0.0.0`, which makes the server accessible on all network interfaces. This is especially dangerous in shared or cloud environments where the benchmark might be inadvertently exposed to untrusted networks.

**Severity**: `low`
**File**: `falcon/bench/nuts/config.py`

## Solution

Use `127.0.0.1` (localhost) instead of `0.0.0.0` for benchmark/test configurations to prevent unintended network exposure.

## Changes

- `falcon/bench/nuts/config.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
