### PR TITLE
chore(docs): unmodernize PyData Sphinx Theme fonts

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,6 +1,18 @@
-/* Customize the PyData theme's font colors. */
+/* Customize the PyData theme's fonts and colors. */
 
 /* Some ideas partially inspired by Bokeh docs. */
+
+/* NOTE(vytas): Revert to older PyData Sphinx Theme fonts from 0.16.x. */
+/*   Despite being not as "modern", they fluctuate less across the browsers. */
+html {
+  --pst-font-family-base-system:
+    -apple-system, "BlinkMacSystemFont", "Segoe UI", "Helvetica Neue", "Arial",
+    sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --pst-font-family-monospace-system:
+    "SFMono-Regular", "Menlo", "Consolas", "Monaco", "Liberation Mono",
+    "Lucida Console", monospace;
+}
+
 html[data-theme=light] {
   --pst-color-borders: rgb(206, 212, 218);
   --pst-color-primary: var(--pst-color-text-base);


### PR DESCRIPTION
Here we essentially revert https://github.com/pydata/pydata-sphinx-theme/pull/2263.

Although using a more modern selection provides many advantages (better emoji support, better Cyrillic support, etc), we don't really benefit that much, as our docs are very lean on emojis, and primarily use a variant of American English (aka the @kgriffs -style). Also cited is better box drawing, but I'm only seeing an issue on Android, and the modernization doesn't help there.

Conversely, the new selection prioritizes the default UI fonts, which introduces wild variations in how different browser such as Chrome, Firefox follow present even on the **same machine**.

Based on that, we revert to the "last known good" configuration for now.