### PR TITLE
chore: deprecate `falcon.sys` re-export (#2630)

### DIFF
--- a/docs/_newsfragments/2630.misc.rst
+++ b/docs/_newsfragments/2630.misc.rst
@@ -1,0 +1,4 @@
+``falcon.sys`` (an internal re-export of the standard library's
+:mod:`sys` module that was added by oversight long ago) is
+scheduled for removal in Falcon 5.0. Import the standard library's
+:mod:`sys` module directly instead.


### PR DESCRIPTION
# Summary of Changes

Adds a `2630.misc.rst` newsfragment announcing the planned removal of `falcon.sys` in Falcon 5.0, per #2630.

The eager `from falcon.util import sys` re-export at the bottom of `falcon/__init__.py` is left unchanged; the actual removal will happen in 5.0.

# Related Issues

Closes #2630.

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable). - N/A, docs-only.
- [x] Added **tests** for changed code. - N/A, docs-only.
- [x] Performed automated tests and code quality checks. - `python -W error -c 'import falcon'` is clean (unchanged from base).
- [x] Prefixed code comments with appropriate prefix where new comments were added. - N/A, no code changes.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added a `2630.misc.rst` newsfragment per the issue's instructions.
- [x] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`.
- [x] LLM output has been carefully reviewed and tested.

# Note on LLM use

The newsfragment was drafted with AI assistance (Claude Code) and reviewed manually. Per @vytas7's review, the original `__getattr__`-based deprecation warning approach was dropped in 6b41c4d in favor of just announcing planned removal in the changelog.
