### PR TITLE
Deprecate re-export of stdlib sys as falcon.sys (#2630)

### DIFF
--- a/docs/_newsfragments/2630.misc.rst
+++ b/docs/_newsfragments/2630.misc.rst
@@ -1,0 +1,6 @@
+The stdlib :mod:`sys` module is no longer re-exported as ``falcon.sys``.
+This re-export was never a documented part of Falcon's public API, and
+appears to have been added by oversight. Accessing ``falcon.sys`` now
+emits a :class:`~falcon.util.deprecation.DeprecatedWarning`; the alias
+will be removed entirely in Falcon 5.0. Import the stdlib :mod:`sys`
+module directly instead.

--- a/falcon/__init__.py
+++ b/falcon/__init__.py
@@ -636,8 +636,6 @@ from falcon.util import structures
 from falcon.util import sync
 from falcon.util import sync_to_async
 
-# TODO(vytas): Remove this re-export of sys in Falcon 5.0.
-from falcon.util import sys  # NOQA: F401
 from falcon.util import time
 from falcon.util import TimezoneGMT
 from falcon.util import to_query_str
@@ -660,3 +658,24 @@ _logger = _logging.getLogger('falcon')
 #   However, this has mostly resulted in confusion for people trying the ASGI
 #   flavor of the framework as HTTP 500 tracebacks may disappear completely,
 #   so the revised choice is NOT to prevent last resort logging to sys.stderr.
+
+
+# NOTE(SAY-5): The stdlib `sys` module was historically re-exported as
+# `falcon.sys`. It was never a documented part of Falcon's public API and
+# is scheduled for removal in Falcon 5.0 (see #2630). Until then, accessing
+# `falcon.sys` returns the stdlib module but emits a `DeprecatedWarning`.
+def __getattr__(name: str) -> object:
+    if name == 'sys':
+        import sys as _sys
+        import warnings as _warnings
+
+        from falcon.util.deprecation import DeprecatedWarning
+
+        _warnings.warn(
+            'falcon.sys is deprecated; import the stdlib sys module directly. '
+            'It will be removed in Falcon 5.0. See falconry/falcon#2630.',
+            DeprecatedWarning,
+            stacklevel=2,
+        )
+        return _sys
+    raise AttributeError(f'module {__name__!r} has no attribute {name!r}')

--- a/tests/test_alias.py
+++ b/tests/test_alias.py
@@ -45,3 +45,23 @@ def test_alias_equals_to_app(alias_client):
     with pytest.warns(DeprecatedWarning, match='API class will be removed'):
         api = falcon.API()
     assert isinstance(api, falcon.API)
+
+
+# Tests for the falcon.sys re-export deprecation (#2630). The alias is
+# scheduled for removal in Falcon 5.0; until then it must keep working
+# but warn on access.
+
+def test_falcon_sys_emits_deprecation_warning():
+    import sys as stdlib_sys
+
+    with pytest.warns(DeprecatedWarning, match='falcon.sys is deprecated'):
+        accessed = falcon.sys
+    assert accessed is stdlib_sys
+
+
+def test_falcon_unknown_attribute_still_raises_attribute_error():
+    # The new module __getattr__ must not swallow lookups for other
+    # missing attributes — those still need to raise AttributeError so
+    # `hasattr(falcon, 'something_that_does_not_exist')` returns False.
+    with pytest.raises(AttributeError, match='no attribute'):
+        falcon.this_attribute_does_not_exist  # noqa: B018


### PR DESCRIPTION
Closes #2630.

## What

Replaces the unconditional `from falcon.util import sys` re-export in
`falcon/__init__.py` with a module-level `__getattr__` that still
resolves `falcon.sys` to the stdlib module but emits a
`DeprecatedWarning` on access. The alias is scheduled for removal in
Falcon 5.0 (per the existing `TODO(vytas)` and the issue).

## Changes

- `falcon/__init__.py`: drop the `from falcon.util import sys` line;
  add module `__getattr__(name)` returning stdlib `sys` with a
  warning, and re-raising `AttributeError` for any other missing
  name so `hasattr()` / `dir()` probes still work as before.
- `docs/_newsfragments/2630.misc.rst`: deprecation newsfragment as
  requested in the issue.
- `tests/test_alias.py`: two tests covering
  - `test_falcon_sys_emits_deprecation_warning` — `falcon.sys` warns
    *and* still returns the same object as `sys` from stdlib.
  - `test_falcon_unknown_attribute_still_raises_attribute_error` — the
    new `__getattr__` doesn't accidentally swallow lookups for
    genuinely missing attributes.

## Why a `__getattr__` and not a hard removal

PEP 562 module-level `__getattr__` lets us preserve compatibility for
the next minor release while still surfacing the deprecation. Hard
removal is what the Falcon 5.0 cleanup will do; this PR gives users
a release of warning before that.

## Verification

- `python -m pytest tests/test_alias.py` → 4 passed
- `python -m pytest tests/ --ignore=tests/asgi` → 3368 passed, 336
  skipped (the skipped count matches `master` baseline). No
  regressions.
- Manual smoke: `falcon.sys is sys.modules['sys']` confirmed; the
  `DeprecatedWarning` fires once per access via the standard
  `warnings.warn(..., stacklevel=2)` path.

## Notes

- `falcon.util.sys` (the source of the re-export) is left untouched;
  this PR only addresses the top-level `falcon.sys` alias which is
  what the issue specifically calls out.
- `from falcon import sys` *also* now triggers the warning, since
  Python invokes `__getattr__` on import lookup for module
  attributes — this matches the intent of "deprecate the re-export".