### PR TITLE
Enhance ASGI scope typing and add HTTP event types

### DIFF
--- a/docs/_newsfragments/2628.newandimproved.rst
+++ b/docs/_newsfragments/2628.newandimproved.rst
@@ -1,0 +1,1 @@
+Improve ASGI typing by introducing TypedDict definitions for HTTP event messages.

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -28,6 +28,7 @@ from typing import (
     ClassVar,
     overload,
     TYPE_CHECKING,
+    cast
 )
 import warnings
 
@@ -55,6 +56,7 @@ from falcon.app_helpers import prepare_middleware_ws
 from falcon.asgi_spec import AsgiSendMsg
 from falcon.asgi_spec import EventType
 from falcon.asgi_spec import WSCloseCode
+from falcon.asgi_spec import ASGIScope
 from falcon.constants import MEDIA_JSON
 from falcon.errors import CompatibilityError
 from falcon.errors import HTTPBadRequest
@@ -68,7 +70,6 @@ from falcon.util.misc import is_python_func
 from falcon.util.sync import _should_wrap_non_coroutines
 from falcon.util.sync import _wrap_non_coroutine_unsafe
 from falcon.util.sync import wrap_sync_to_async
-
 from ._asgi_helpers import _validate_asgi_scope
 from ._asgi_helpers import _wrap_asgi_coroutine_func
 from .multipart import MultipartForm
@@ -456,7 +457,7 @@ class App(falcon.app.App[_ReqT, _RespT]):
     @_wrap_asgi_coroutine_func
     async def __call__(  # type: ignore[override] # noqa: C901
         self,
-        scope: dict[str, Any],
+        scope: ASGIScope | dict[str, Any],
         receive: AsgiReceive,
         send: AsgiSend,
     ) -> None:
@@ -488,12 +489,12 @@ class App(falcon.app.App[_ReqT, _RespT]):
             # PERF(vytas): Evaluate the potentially recurring WebSocket path
             #   first (in contrast to one-shot lifespan events).
             if scope_type == 'websocket':
-                await self._handle_websocket(spec_version, scope, receive, send)
+                await self._handle_websocket(spec_version, cast(dict[str, Any], scope), receive, send)
                 return
 
             # NOTE(vytas): Else 'lifespan' -- other scope_type values have been
             #   eliminated by _validate_asgi_scope at this point.
-            await self._call_lifespan_handlers(spec_version, scope, receive, send)
+            await self._call_lifespan_handlers(spec_version, cast(dict[str, Any], scope), receive, send)
             return
 
         # NOTE(kgriffs): Per the ASGI spec, we should not proceed with request
@@ -514,7 +515,7 @@ class App(falcon.app.App[_ReqT, _RespT]):
         assert first_event_type == 'http.request'
 
         req = self._request_type(
-            scope, receive, first_event=first_event, options=self.req_options
+            cast(dict[str, Any], scope), receive, first_event=first_event, options=self.req_options
         )
         resp = self._response_type(options=self.resp_options)
 

--- a/falcon/asgi_spec.py
+++ b/falcon/asgi_spec.py
@@ -15,9 +15,10 @@
 """Constants, etc. defined by the ASGI specification."""
 
 from __future__ import annotations
-
 from collections.abc import Mapping
-from typing import Any
+
+from typing import TypedDict, Literal,  Any, Required
+
 
 
 class EventType:
@@ -42,6 +43,45 @@ class EventType:
     WS_DISCONNECT = 'websocket.disconnect'
     WS_CLOSE = 'websocket.close'
 
+class HTTPRequestEvent(TypedDict, total=False):
+    type: Literal["http.request"]
+    body: bytes
+    more_body: bool
+
+class HTTPDisconnectEvent(TypedDict):
+    type: Literal["http.disconnect"]
+
+class HTTPResponseStartEvent(TypedDict):
+    type: Literal["http.response.start"]
+    status: int
+    headers: list[tuple[bytes, bytes]]
+
+
+class HTTPResponseBodyEvent(TypedDict, total=False):
+    type: Literal["http.response.body"]
+    body: bytes
+    more_body: bool
+
+class HTTPScope(TypedDict, total=False):
+    type: Required[Literal["http"]]
+    http_version: str
+    method: str
+    path: str
+    headers: list[tuple[bytes, bytes]]
+    asgi: dict[str, Any]
+
+class WebSocketScope(TypedDict, total=False):
+    type: Required[Literal["websocket"]]
+    path: str
+    headers: list[tuple[bytes, bytes]]
+    http_version: str
+    asgi: dict[str, Any]
+
+class LifespanScope(TypedDict, total=False):
+    type: Required[Literal["lifespan"]]
+    asgi: dict[str, Any]
+    http_version: str
+    
 
 class ScopeType:
     """Standard ASGI event type strings."""
@@ -64,7 +104,6 @@ class WSCloseCode:
     HANDLER_NOT_FOUND = 3405
 
 
-# TODO: use a typed dict for event dicts
 AsgiEvent = Mapping[str, Any]
-# TODO: use a typed dict for send msg dicts
 AsgiSendMsg = dict[str, Any]
+ASGIScope = HTTPScope | WebSocketScope | LifespanScope


### PR DESCRIPTION
# Summary of Changes

Introduce TypedDict definitions for ASGI HTTP event messages.

- Add TypedDicts for HTTP request, response start, response body, and disconnect events
- Provide structured typing for ASGI event payloads while keeping existing aliases unchanged

This improves type clarity and lays the groundwork for stricter typing in the future without affecting runtime behavior.

# Related Issues

Relates to #2628

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e towncrier`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
