### PR TITLE
chore(tests): pin `cbor2` until we decide wrt exception handling

### DIFF
--- a/requirements/tests
+++ b/requirements/tests
@@ -10,7 +10,8 @@ uvicorn >= 0.17.0
 websockets >= 13.1
 
 # Handler Specific
-cbor2
+# TODO(vytas): Unpin cbor2 once we clean up exception handling, or the upstream revises 6.x behaviour.
+cbor2 < 6.0
 msgpack
 mujson
 ujson
@@ -23,5 +24,5 @@ python-rapidjson; platform_python_implementation != 'PyPy' and platform_machine 
 # (not available for CPython 3.15 either yet)
 orjson; python_version < '3.15' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
 
-# NOTE(vytas): msgspec is not fully compatible with 3.14 at the time of writing yet.
+# NOTE(vytas): msgspec is not fully compatible with 3.15 at the time of writing yet.
 msgspec; python_version < '3.15' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'


### PR DESCRIPTION
It seems in the newly released 6.0.x, `cbor2.CBORDecodeError` is not a subclass of `ValueError`.

I have reported this upstream: https://github.com/agronholm/cbor2/issues/299. Let's see what happens there; maybe we don't need to do anything, just wait for a new release. Otherwise we may need to adapt the tests, or stop testing `cbor2` altogether.