### PR TITLE
Use ParamSpec for LRU cache decorators

### DIFF
--- a/docs/_newsfragments/2629.misc.rst
+++ b/docs/_newsfragments/2629.misc.rst
@@ -1,0 +1,1 @@
+Improved typing for Falcon's internal LRU cache decorators.

--- a/falcon/media/handlers.py
+++ b/falcon/media/handlers.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 import functools
 from typing import (
     Any,
+    Callable,
     cast,
     Literal,
     NoReturn,
@@ -56,6 +57,8 @@ _ResolverMethodReturnTuple = tuple[
 
 
 class ResolverMethod(Protocol):
+    cache_clear: Callable[[], None]
+
     @overload
     def __call__(
         self, media_type: str | None, default: str, raise_not_found: Literal[False]
@@ -98,14 +101,14 @@ class Handlers(UserDict[str, BaseHandler]):
         # NOTE(kgriffs): When the mapping changes, we do not want to use a
         #   cached handler from the previous mapping, in case it was
         #   replaced.
-        self._resolve.cache_clear()  # type: ignore[attr-defined]
+        self._resolve.cache_clear()
 
     def __delitem__(self, key: str) -> None:
         super().__delitem__(key)
 
         # NOTE(kgriffs): Similar to __setitem__(), we need to avoid resolving
         #   to a cached handler that was removed.
-        self._resolve.cache_clear()  # type: ignore[attr-defined]
+        self._resolve.cache_clear()
 
     def _create_resolver(self) -> ResolverMethod:
         # PERF(kgriffs): Under PyPy the LRU is relatively expensive as compared

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -963,6 +963,12 @@ async def _simulate_request_asgi(
 
         req_event_emitter.disconnect()
         await task_req
+
+        if resp_event_collector.status is None:
+            # NOTE(kgriffs): An immediate disconnect was simulated, and so
+            #   the app could not return a status.
+            raise ConnectionError('An immediate disconnect was simulated.')
+
         return Result(
             resp_event_collector.body_chunks,
             code_to_http_status(resp_event_collector.status),

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -33,7 +33,7 @@ import inspect
 import os
 import os.path
 import re
-from typing import Any, Callable
+from typing import Any, Callable, cast, TYPE_CHECKING, TypeVar
 import unicodedata
 
 from falcon import status_codes
@@ -87,6 +87,25 @@ _utcnow: Callable[[], datetime.datetime] = functools.partial(
     datetime.datetime.now, datetime.timezone.utc
 )
 
+_T = TypeVar('_T')
+_T_co = TypeVar('_T_co', covariant=True)
+
+if TYPE_CHECKING:
+    from typing import ParamSpec, Protocol
+
+    _P = ParamSpec('_P')
+
+    class _CachedCallable(Protocol[_P, _T_co]):
+        cache_clear: Callable[[], None]
+
+        def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _T_co: ...
+
+    class _LruCacheDecorator(Protocol):
+        def __call__(
+            self, maxsize: int
+        ) -> Callable[[Callable[_P, _T]], _CachedCallable[_P, _T]]: ...
+
+
 # The above aliases were not underscored prior to Falcon 3.1.2.
 strptime: Callable[[str, str], datetime.datetime] = deprecated(
     'This was a private alias local to this module; '
@@ -103,23 +122,25 @@ utcnow: Callable[[], datetime.datetime] = deprecated(
 #   the nocover pragma here.
 def _lru_cache_nop(
     maxsize: int,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:  # pragma: nocover
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+) -> Callable[[Callable[_P, _T]], _CachedCallable[_P, _T]]:  # pragma: nocover
+    def decorator(func: Callable[_P, _T]) -> _CachedCallable[_P, _T]:
         # NOTE(kgriffs): Partially emulate the lru_cache protocol; only add
         #   cache_info() later if/when it becomes necessary.
-        func.cache_clear = lambda: None  # type: ignore
+        cached_func = cast('_CachedCallable[_P, _T]', func)
+        cached_func.cache_clear = lambda: None
 
-        return func
+        return cached_func
 
     return decorator
 
 
 # PERF(kgriffs): Using lru_cache is slower on PyPy when the wrapped
 #   function is just doing a few non-IO operations.
+_lru_cache_for_simple_logic: '_LruCacheDecorator'
 if PYPY:
     _lru_cache_for_simple_logic = _lru_cache_nop  # pragma: nocover
 else:
-    _lru_cache_for_simple_logic = functools.lru_cache
+    _lru_cache_for_simple_logic = cast('_LruCacheDecorator', functools.lru_cache)
 
 
 def is_python_func(func: Callable[..., Any] | Any) -> bool:


### PR DESCRIPTION
# Summary of Changes

Typed Falcon's internal LRU cache decorator helpers with `ParamSpec` so decorated callables preserve their original argument and return types.

This also exposes the `cache_clear()` method through typing for cached callables, allowing existing `type: ignore[attr-defined]` comments around media handler cache clearing to be removed. While validating the stricter typing, an ASGI testing client call site was updated to explicitly handle the `None` status case before normalizing the response status.

# Related Issues

Closes #2629

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e towncrier`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

## Checks Performed

```text
python -B -m pytest tests\test_media_handlers.py
# 37 passed, 5 skipped
```

`tox` was not available locally, and raw `python -m mypy --strict falcon` was blocked by local Python 3.14/toolchain issues, including `strict_bytes` being reported as an unrecognized mypy option and unrelated existing typing errors.

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
