### PR TITLE
docs(response): document set_cookie() name/value ASCII restriction (#1445)

### DIFF
--- a/docs/_newsfragments/1445.misc.rst
+++ b/docs/_newsfragments/1445.misc.rst
@@ -1,0 +1,5 @@
+Documented the US-ASCII restriction on the ``name`` and ``value`` arguments
+of :meth:`falcon.Response.set_cookie`. The implementation has always rejected
+non-ASCII inputs (raising ``KeyError`` for ``name`` and ``ValueError`` for
+``value``), but the parameter and ``Raises`` entries did not call this out;
+the docstring now matches the runtime behaviour.

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -372,8 +372,14 @@ class Response:
             listed below correspond to those defined in `RFC 6265`_.
 
         Args:
-            name (str): Cookie name
-            value (str): Cookie value
+            name (str): Cookie name. Per :rfc:`6265#section-4.1.1`, cookie
+                names are restricted to US-ASCII characters; non-ASCII
+                values (e.g. multi-byte UTF-8 strings) raise ``KeyError``.
+            value (str): Cookie value. As with ``name``, the value must be
+                US-ASCII encodable; non-ASCII values raise ``ValueError``.
+                Encode non-ASCII payloads (for example with
+                :func:`urllib.parse.quote` or :mod:`base64`) before
+                passing them to this method.
 
         Keyword Args:
             expires (datetime): Specifies when the cookie should expire.
@@ -471,8 +477,10 @@ class Response:
                 .. versionadded:: 4.0
 
         Raises:
-            KeyError: `name` is not a valid cookie name.
-            ValueError: `value` is not a valid cookie value.
+            KeyError: `name` is not a valid cookie name (for example,
+                it contains non-ASCII characters).
+            ValueError: `value` is not a valid cookie value (for example,
+                it contains non-ASCII characters).
 
         .. _RFC 6265:
             http://tools.ietf.org/html/rfc6265


### PR DESCRIPTION
## Summary

Documents that `Response.set_cookie()`'s `name` and `value` arguments must be US-ASCII. The runtime check has always raised `KeyError` (for `name`) and `ValueError` (for `value`) on non-ASCII inputs, but the docstring's `Args:` and `Raises:` sections didn't say so — so users like the original reporter hit the error without warning.

Closes #1445.

## Change Type

- [x] Documentation

## Details

- `falcon/response.py:374-385` — `name` and `value` entries now explain the US-ASCII requirement, link to RFC 6265 §4.1.1, and point at common encodings (`urllib.parse.quote`, `base64`) for non-ASCII payloads.
- `falcon/response.py:479-482` — `Raises:` entries call out non-ASCII characters as a concrete trigger for the existing exceptions.
- `docs/_newsfragments/1445.misc.rst` — towncrier fragment under "Misc".

No behaviour change; the runtime behaviour was already in place via `_is_ascii_encodable(name)` / `_is_ascii_encodable(value)` (see `falcon/response.py:497-500`).