### PR TITLE
chore(CI): audit GitHub actions with `zizmor`

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -50,7 +50,7 @@ jobs:
           tools/test_dist.py dist/*.whl
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cibw-sdist
           path: dist/falcon-*
@@ -79,7 +79,7 @@ jobs:
           python-version: "3.12"
 
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cibw-sdist
           path: dist
@@ -89,7 +89,7 @@ jobs:
           tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
 
       - name: Upload sdist to release
-        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
         if: github.event_name == 'release'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
     #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cibw-sdist
           path: dist
@@ -119,13 +119,13 @@ jobs:
       #   same job is not considered supported, however, the two steps below
       #   are made mutually exclusive by the github.event_name condition.
       - name: Publish sdist and pure-Python wheel to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: github.event_name == 'workflow_dispatch'
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish sdist and pure-Python wheel to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: github.event_name == 'release'
 
   build-wheels:
@@ -189,7 +189,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         if: ${{ matrix.platform.emulation }}
         with:
           platforms: all
@@ -205,7 +205,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform.name }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cibw-wheel-${{ matrix.python }}-${{ matrix.platform.name }}
           path: wheelhouse/falcon-*.whl
@@ -231,7 +231,7 @@ jobs:
           python-version: "3.12"
 
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cibw-wheel-*
           path: dist
@@ -257,7 +257,7 @@ jobs:
     #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cibw-wheel-*
           path: dist
@@ -267,11 +267,11 @@ jobs:
       #   same job is not considered supported, however, the two steps below
       #   are made mutually exclusive by the github.event_name condition.
       - name: Publish binary wheels to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: github.event_name == 'workflow_dispatch'
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish binary wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         if: github.event_name == 'release'

--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -13,16 +13,19 @@ jobs:
   build-sdist:
     # NOTE(vytas): We actually build sdist and pure-Python wheel.
     name: sdist
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -47,7 +50,7 @@ jobs:
           tools/test_dist.py dist/*.whl
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cibw-sdist
           path: dist/falcon-*
@@ -65,17 +68,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cibw-sdist
           path: dist
@@ -85,7 +89,7 @@ jobs:
           tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
 
       - name: Upload sdist to release
-        uses: AButler/upload-release-assets@v3.0
+        uses: AButler/upload-release-assets@3d6774fae0ed91407dc5ae29d576b166536d1777 # v3.0
         if: github.event_name == 'release'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -106,7 +110,7 @@ jobs:
     #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: cibw-sdist
           path: dist
@@ -115,18 +119,20 @@ jobs:
       #   same job is not considered supported, however, the two steps below
       #   are made mutually exclusive by the github.event_name condition.
       - name: Publish sdist and pure-Python wheel to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'workflow_dispatch'
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish sdist and pure-Python wheel to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release'
 
   build-wheels:
     name: ${{ matrix.python }}-${{ matrix.platform.name }}
     needs: build-sdist
+    permissions:
+      contents: read
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
@@ -177,18 +183,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         if: ${{ matrix.platform.emulation }}
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).
@@ -198,7 +205,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform.name }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cibw-wheel-${{ matrix.python }}-${{ matrix.platform.name }}
           path: wheelhouse/falcon-*.whl
@@ -207,21 +214,24 @@ jobs:
     name: check-wheels
     needs:
       - build-wheels
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: cibw-wheel-*
           path: dist
@@ -247,7 +257,7 @@ jobs:
     #   unauthorized access to the GitHub-backed trusted identity.
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: cibw-wheel-*
           path: dist
@@ -257,11 +267,11 @@ jobs:
       #   same job is not considered supported, however, the two steps below
       #   are made mutually exclusive by the github.event_name condition.
       - name: Publish binary wheels to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'workflow_dispatch'
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish binary wheels to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         if: github.event_name == 'release'

--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -38,8 +38,11 @@ jobs:
           python -m build
 
       - name: Check built artifacts
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
+          tools/check_dist.py -e $GITHUB_EVENT_NAME -r $GITHUB_REF
 
       - name: Test sdist
         run: |
@@ -85,8 +88,11 @@ jobs:
           path: dist
 
       - name: Check collected artifacts
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
+          tools/check_dist.py -e $GITHUB_EVENT_NAME -r $GITHUB_REF
 
       - name: Upload sdist to release
         uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
@@ -238,8 +244,11 @@ jobs:
           merge-multiple: true
 
       - name: Check collected artifacts
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
         run: |
-          tools/check_dist.py ${{ github.event_name == 'release' && format('-r {0}', github.ref) || '' }}
+          tools/check_dist.py -e $GITHUB_EVENT_NAME -r $GITHUB_REF
 
   publish-wheels:
     name: publish-wheels

--- a/.github/workflows/test-dist.yaml
+++ b/.github/workflows/test-dist.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-dist:
     name: test-${{ matrix.build }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,13 +19,14 @@ jobs:
           - wheel
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test-mailman.yaml
+++ b/.github/workflows/test-mailman.yaml
@@ -11,13 +11,16 @@ on:
 jobs:
   run_tox:
     name: tox -e falcon-nocov
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Run tox
         uses: docker://ghcr.io/maxking/mailman-ci-runner-falcon:master

--- a/.github/workflows/test-other.yaml
+++ b/.github/workflows/test-other.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   run-tox:
     name: tox -e ${{ matrix.tox.env }}
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,12 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.tox.python-version }}
 

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -40,13 +40,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@5566d5f9322a1df04fb97ee8b7db60ec956eabff # v4.1.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         if: ${{ matrix.platform.emulation }}
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@02d94edfc5fdf48ac283246e87aff761af8b9fa7 # v3.4.1
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   test-emulated:
     name: "cibuildwheel: ${{ matrix.platform.build }}"
+    permissions:
+      contents: read
     runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: false
@@ -32,18 +34,19 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@5566d5f9322a1df04fb97ee8b7db60ec956eabff # v4.1.0
         if: ${{ matrix.platform.emulation }}
         with:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.2.1
+        uses: pypa/cibuildwheel@02d94edfc5fdf48ac283246e87aff761af8b9fa7 # v3.4.1
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   run-tox:
     name: tox -e ${{ matrix.tox.env }}${{ matrix.tox.platform-label || '' }}
+    # APPSEC(vytas): Establish global restrictive permissions baseline.
+    permissions: {}
     runs-on: ${{ matrix.tox.os || matrix.default-os }}
     strategy:
       fail-fast: false
@@ -95,6 +97,7 @@ jobs:
         #   https://github.com/codecov/codecov-action/issues/190
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -126,3 +129,6 @@ jobs:
           env_vars: PYTHON
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+          # APPSEC(vytas): This is not optimal, but verifying seems to cause
+          #   intermittent bugs when pinning directly to a hash.
+          verify_signatures: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,6 +79,7 @@ jobs:
           - env: "ws_tutorial"
           # Tooling
           - env: "twine_check"
+          - env: "zizmor-github"
           # ASGI & WSGI servers
           - env: "daphne"
           - env: "hypercorn"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,14 +90,14 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         # NOTE(vytas): Work around
         #   https://github.com/codecov/codecov-action/issues/190
         with:
           fetch-depth: 2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.tox.python-version || matrix.python-version }}
 
@@ -120,7 +120,7 @@ jobs:
           coverage combine
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: ${{ matrix.tox.coverage }}
         with:
           env_vars: PYTHON

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -131,4 +131,4 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           # APPSEC(vytas): This is not optimal, but verifying seems to cause
           #   intermittent bugs when pinning directly to a hash.
-          verify_signatures: false
+          skip_validation: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -79,7 +79,7 @@ jobs:
           - env: "ws_tutorial"
           # Tooling
           - env: "twine_check"
-          - env: "zizmor-github"
+          - env: "zizmor_github"
           # ASGI & WSGI servers
           - env: "daphne"
           - env: "hypercorn"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,8 @@ jobs:
   run-tox:
     name: tox -e ${{ matrix.tox.env }}${{ matrix.tox.platform-label || '' }}
     # APPSEC(vytas): Establish global restrictive permissions baseline.
-    permissions: {}
+    permissions:
+      contents: read
     runs-on: ${{ matrix.tox.os || matrix.default-os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   run_tox:
     name: tox (python${{ matrix.python-version }})
+    permissions:
+      contents: read
     runs-on: "ubuntu-latest"
     strategy:
       fail-fast: false
@@ -23,10 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -14,12 +14,19 @@ on:
 jobs:
   run-zizmor:
     name: zizmor
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout repo
+      - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
 
-      - name: Run Zizmor via Tox
-        run: pipx run tox -e zizmor
+      - name: Run Zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          version: latest
+          advanced-security: false
+          annotations: true

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Run Zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,20 @@
+# Audit GitHub Actions
+name: zizmor
+
+on:
+  # NOTE(vytas): Trigger the tests workflow on push or pull request
+  #   (pull requests only for the master branch for now).
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  run-zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Zizmor via Tox
+        run: pipx run tox -e zizmor

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,12 +2,9 @@
 name: zizmor
 
 on:
-  # NOTE(vytas): Trigger the tests workflow on push or pull request
-  #   (pull requests only for the master branch for now).
+  # Trigger the workflow on master but also allow it to run manually.
+  workflow_dispatch:
   push:
-    branches:
-      - "*"
-  pull_request:
     branches:
       - master
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -16,5 +16,10 @@ jobs:
     name: zizmor
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 2
+
       - name: Run Zizmor via Tox
         run: pipx run tox -e zizmor

--- a/docs/_newsfragments/2651.misc.rst
+++ b/docs/_newsfragments/2651.misc.rst
@@ -1,0 +1,5 @@
+Our GitHub Actions workflows are now audited with
+`zizmor <https://zizmor.sh/>`__, a static analysis tool that catches common
+security pitfalls in CI/CD pipelines. The audit runs both as a dedicated
+workflow and as part of our ``tox`` checks, and the existing workflows were
+hardened to address the issues it surfaced.

--- a/tools/check_dist.py
+++ b/tools/check_dist.py
@@ -13,6 +13,8 @@ CHANGELOGS = FALCON_ROOT / 'docs' / 'changes'
 RELEASE_STABLE_VERSION_PATTERN = re.compile(r'^(\d+)\.(\d+).(\d+)$')
 RELEASE_META_PATTERN = re.compile(r'\.\.\s+falcon-release\:\s+([\d-]+)')
 
+RELEASE_EVENT_NAME = 'release'
+
 
 def check_dist(dist, git_ref):
     sdist = None
@@ -88,6 +90,12 @@ def main():
         default=str(DIST),
         help='dist directory to check (default: %(default)s)',
     )
+    # NOTE(vytas): This is semantically awkward, but it eases CI plumbing a lot.
+    parser.add_argument(
+        '-e',
+        '--event-name',
+        help='event name (e.g. $GITHUB_EVENT_NAME) for interpreting --git-ref',
+    )
     parser.add_argument(
         '-r',
         '--git-ref',
@@ -95,7 +103,10 @@ def main():
     )
 
     args = parser.parse_args()
-    check_dist(pathlib.Path(args.dist_dir).resolve(), args.git_ref)
+
+    event_name = args.event_name or RELEASE_EVENT_NAME
+    git_ref = args.git_ref if event_name == RELEASE_EVENT_NAME else None
+    check_dist(pathlib.Path(args.dist_dir).resolve(), git_ref)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -351,7 +351,7 @@ deps = zizmor
 commands =
     zizmor .github/workflows/
 
-[testenv:zizmor-github]
+[testenv:zizmor_github]
 skipsdist = True
 deps = zizmor
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -349,7 +349,13 @@ commands =
 skipsdist = True
 deps = zizmor
 commands =
-    zizmor --format github .github/workflows/tests.yaml
+    zizmor .github/workflows/
+
+[testenv:zizmor-github]
+skipsdist = True
+deps = zizmor
+commands =
+    zizmor --format github .github/workflows/
 
 # --------------------------------------------------------------------
 # Documentation

--- a/tox.ini
+++ b/tox.ini
@@ -342,6 +342,16 @@ commands =
     twine check {toxinidir}/dist/*
 
 # --------------------------------------------------------------------
+# Security auditing
+# --------------------------------------------------------------------
+
+[testenv:zizmor]
+skipsdist = True
+deps = zizmor
+commands =
+    zizmor --format github .github/workflows/tests.yaml
+
+# --------------------------------------------------------------------
 # Documentation
 # --------------------------------------------------------------------
 


### PR DESCRIPTION
Audit our GitHub Actions workflows with [`zizmor`](https://zizmor.sh/), a static analysis tool that catches common security pitfalls in CI/CD pipelines.

Fixes #2651.
