### PR TITLE
chore(CI): upgrade to `cibuildwheel` v4.0.0

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -201,7 +201,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@9c00cb4f6b517705a3794b22395aedc36257242c # v3.2.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,9 +7,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:
@@ -46,7 +49,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4.1
+        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/falcon/version.py
+++ b/falcon/version.py
@@ -14,5 +14,5 @@
 
 """Falcon version."""
 
-__version__ = '4.3.0a1'
+__version__ = '4.3.0a2'
 """Current version of Falcon."""


### PR DESCRIPTION
(Also bump the tag to `4.3.0a2`.)
