### PR TITLE
docs: enable nitpicky mode to warn on broken references

### DIFF
--- a/docs/_newsfragments/1888.misc.rst
+++ b/docs/_newsfragments/1888.misc.rst
@@ -1,0 +1,1 @@
+Enabled Sphinx ``nitpicky`` mode to surface broken references during documentation builds.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,16 @@ myst_enable_checkboxes = True
 # Intersphinx configuration
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
+# NOTE(vytas): Nitpicky mode is enabled to warn on broken references and
+#   missing links during the documentation build. Unresolved type aliases
+#   are suppressed via nitpick_ignore below.
+nitpicky = True
+nitpick_ignore = [
+    ('py:class', 'SyncMiddleware'),
+    ('py:class', 'AsyncMiddleware'),
+    ('py:class', 'PreparedMiddlewareResult'),
+]
+
 # NOTE(vytas): The autodoc_type_aliases mapping below doesn't really work as
 #   advertised...
 #   Sphinx is looking for the mapped types defined as classes, however, typing
@@ -129,8 +139,6 @@ intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 #
 #   See also https://github.com/sphinx-doc/sphinx/issues/10785 & related issues
 #   for discussion and potentially better workarounds.
-# TODO(vytas): If we enable the "nitpicky" mode, we will have to add exceptions
-#   for all unresolved aliases.
 autodoc_type_aliases = {
     'SyncMiddleware': 'SyncMiddleware',
     'AsyncMiddleware': 'AsyncMiddleware',


### PR DESCRIPTION
# Summary of Changes
Enabled nitpicky = True in docs/conf.py so Sphinx emits 
warnings on broken references during documentation builds.

Also added nitpick_ignore entries for the three unresolved 
type aliases (SyncMiddleware, AsyncMiddleware, 
PreparedMiddlewareResult) that were already noted in a 
TODO comment in the same file.

# Related Issues
Closes #1888

# Pull Request Checklist
- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added tests for changed code.
- [ ] Performed automated tests and code quality checks by running tox.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated documentation for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under docs/.
    - [ ] Updated all relevant supporting documentation files under docs/.
    - [ ] A copyright notice is included at the top of any new modules.
    - [ ] Changed/added classes/methods/functions have appropriate directives.
- [ ] Changes have towncrier news fragments under docs/_newsfragments/.
- [x] LLM output has been carefully reviewed and tested by a human developer.