### PR TITLE
fix(uri): preserve literal plus when unquote_plus is disabled

### DIFF
--- a/docs/_newsfragments/2670.bugfix.rst
+++ b/docs/_newsfragments/2670.bugfix.rst
@@ -1,0 +1,8 @@
+When decoding with ``unquote_plus=False``, the Cython-accelerated
+:meth:`falcon.uri.decode` mistook a literal plus sign followed by two
+hexadecimal digits for a percent-encoded byte. For instance,
+``uri.decode('+00', unquote_plus=False)`` returned ``'\x00'`` instead of the
+expected ``'+00'``, which could inject a NUL byte into decoded values (an ISO
+8601 timestamp such as ``...964935+00:00`` being a common trigger). The
+accelerated implementation now preserves a literal plus in this case, matching
+the pure-Python variant.

--- a/falcon/cyutil/uri.pyx
+++ b/falcon/cyutil/uri.pyx
@@ -89,10 +89,14 @@ cdef unicode _cy_decode(unsigned char* data, Py_ssize_t start, Py_ssize_t end,
             dst_start += pos - src_start
             src_start = pos
 
-            if data[pos] == b'+' and unquote_plus:
-                result[dst_start] = b' '
-                dst_start += 1
-                src_start += 1
+            if data[pos] == b'+':
+                # NOTE(apoorva-01): A literal plus is only rewritten to a space
+                #   when unquote_plus is enabled; otherwise it is preserved
+                #   as-is and must not be mistaken for a percent sequence.
+                if unquote_plus:
+                    result[dst_start] = b' '
+                    dst_start += 1
+                    src_start += 1
                 continue
 
             # NOTE(vytas): Else %

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -371,6 +371,15 @@ class TestFalconUtils:
             '/disk/lost+found/fd0'
         )
 
+        # NOTE(apoorva-01): A plus followed by two hex digits must not be
+        #   decoded as a percent sequence when unquote_plus is False (#2670).
+        assert uri.decode('+00', unquote_plus=False) == '+00'
+        assert uri.decode('+00', unquote_plus=True) == ' 00'
+        assert (
+            uri.decode('2026-06-29T23:11:38.964935+00:00.jpg', unquote_plus=False)
+            == '2026-06-29T23:11:38.964935+00:00.jpg'
+        )
+
         assert uri.decode('http://example.com?x=ab%2Bcd%3D42%2C9') == (
             'http://example.com?x=ab+cd=42,9'
         )


### PR DESCRIPTION
# Summary of Changes

`uri.decode('+00', unquote_plus=False)` returns `'\x00'` instead of `'+00'`. In the Cython version, a literal `+` that happens to be followed by two hex digits gets picked up by the percent-decoding branch, so the `+00` is read as a
percent-escaped NUL byte. It's easy to hit in practice with an ISO 8601 timestamp, e.g. the `+00:00` offset in `...964935+00:00`.

The pure-Python `decode()` gets this right, so only the Cython path was wrong. The fix deals with `+` on its own in `_cy_decode`: turn it into a space when `unquote_plus` is set, otherwise leave it alone so it never reaches the percent branch. Only `falcon/cyutil/uri.pyx` changes. `parse_query_string` always decodes with `unquote_plus=True`, so it isn't affected.

I added the `+00` cases and the timestamp from the issue to `test_uri_decode_unquote_plus`. If you revert the `.pyx` change and rebuild the extension, it fails on the Cython build but still passes with pure Python - which lines up with the report that testing and the app behaved differently.

# Related Issues

Closes #2670

# Pull Request Checklist

- [x] Added tests for changed code.
- [x] Performed automated tests and code quality checks (`pytest` on both the Cython and pure-Python builds, `ruff`).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Added a towncrier news fragment (`docs/_newsfragments/2670.bugfix.rst`).