### PR TITLE
docs(redirects): clarify headers argument on redirect exceptions

### DIFF
--- a/docs/_newsfragments/1920.misc.rst
+++ b/docs/_newsfragments/1920.misc.rst
@@ -1,0 +1,6 @@
+The ``headers`` argument of the redirect exceptions
+(:class:`~falcon.HTTPMovedPermanently`, :class:`~falcon.HTTPFound`,
+:class:`~falcon.HTTPSeeOther`, :class:`~falcon.HTTPTemporaryRedirect`, and
+:class:`~falcon.HTTPPermanentRedirect`) is now documented. The accompanying
+docstrings clarify that these headers are merged into the ones already set on
+the response, and are unrelated to the headers of the incoming request.

--- a/falcon/redirects.py
+++ b/falcon/redirects.py
@@ -41,6 +41,9 @@ class HTTPMovedPermanently(HTTPStatus):
     Args:
         location (str): URI to provide as the Location header in the
             response.
+        headers (dict): Extra headers to add to the response. These are
+            merged into the headers already set on the response; they
+            are not related to the headers of the incoming request.
     """
 
     def __init__(self, location: str, headers: Headers | None = None) -> None:
@@ -70,6 +73,9 @@ class HTTPFound(HTTPStatus):
     Args:
         location (str): URI to provide as the Location header in the
             response.
+        headers (dict): Extra headers to add to the response. These are
+            merged into the headers already set on the response; they
+            are not related to the headers of the incoming request.
     """
 
     def __init__(self, location: str, headers: Headers | None = None) -> None:
@@ -104,6 +110,9 @@ class HTTPSeeOther(HTTPStatus):
     Args:
         location (str): URI to provide as the Location header in the
             response.
+        headers (dict): Extra headers to add to the response. These are
+            merged into the headers already set on the response; they
+            are not related to the headers of the incoming request.
     """
 
     def __init__(self, location: str, headers: Headers | None = None) -> None:
@@ -133,6 +142,9 @@ class HTTPTemporaryRedirect(HTTPStatus):
     Args:
         location (str): URI to provide as the Location header in the
             response.
+        headers (dict): Extra headers to add to the response. These are
+            merged into the headers already set on the response; they
+            are not related to the headers of the incoming request.
     """
 
     def __init__(self, location: str, headers: Headers | None = None) -> None:
@@ -159,6 +171,9 @@ class HTTPPermanentRedirect(HTTPStatus):
     Args:
         location (str): URI to provide as the Location header in the
             response.
+        headers (dict): Extra headers to add to the response. These are
+            merged into the headers already set on the response; they
+            are not related to the headers of the incoming request.
     """
 
     def __init__(self, location: str, headers: Headers | None = None) -> None:


### PR DESCRIPTION
## Summary

The redirect exceptions (`HTTPMovedPermanently`, `HTTPFound`, `HTTPSeeOther`, `HTTPTemporaryRedirect`, `HTTPPermanentRedirect`) accept a `headers` argument, but it was undocumented. As raised in #1920, this left it ambiguous whether those headers merge with the incoming **request** headers or the **response** headers.

This PR documents the `headers` argument on all five redirect classes, clarifying that the headers are merged into those already set on the response, and are unrelated to the headers of the incoming request.

## Changes
- Added a `headers` entry to the `Args:` docstring of each redirect exception in `falcon/redirects.py`.
- Added a `misc` news fragment (`docs/_newsfragments/1920.misc.rst`).

## Verification
- `ruff format --check` and `ruff check` pass (docstring-only change; no formatting impact).
- `towncrier build --draft` renders the changelog entry correctly.

Closes #1920