### PR TITLE
docs(typos): fix typos in comment, docstring, and recipe

### DIFF
--- a/docs/user/recipes/msgspec-integration.rst
+++ b/docs/user/recipes/msgspec-integration.rst
@@ -85,7 +85,7 @@ Schema validation can fail, and the resulting exception would unexpectedly
 bubble up as a generic HTTP 500 error. We can do better!
 Skimming through ``msgspec``\'s docs, we find out that this
 case is represented by ``msgspec.ValidationError``. We could either create an
-:meth:`error hander <falcon.App.add_error_handler>` that reraises this
+:meth:`error handler <falcon.App.add_error_handler>` that reraises this
 exception as :class:`~falcon.MediaValidationError`, or just use a
 ``try.. except`` clause, and reraise directly inside middleware.
 

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -1162,7 +1162,7 @@ class App(Generic[_ReqT, _RespT]):
                 #   binding self to the default responder method. We could
                 #   decorate the function itself with @staticmethod, but it
                 #   would perhaps be less obvious to the reader why this is
-                #   needed when just looking at the code in the reponder
+                #   needed when just looking at the code in the responder
                 #   module, so we just grab it directly here.
                 responder = self.__class__._default_responder_bad_request
         else:

--- a/falcon/routing/compiled.py
+++ b/falcon/routing/compiled.py
@@ -987,7 +987,7 @@ class CompiledRouterOptions:
     `on_post`.
 
     This option does not override `on_options()` or `on_websocket()`.
-    In case `on_options()` needs to be overriden, this can be done explicitly
+    In case `on_options()` needs to be overridden, this can be done explicitly
     by aliasing::
 
         on_options = on_request


### PR DESCRIPTION
# Summary of Changes

This PR fixes three spelling typos in a code comment, a docstring, and a documentation recipe. No functional changes.

| File | Before | After |
| --- | --- | --- |
| `falcon/app.py` | `reponder` | `responder` |
| `falcon/routing/compiled.py` | `overriden` | `overridden` |
| `docs/user/recipes/msgspec-integration.rst` | `error hander` | `error handler` |

In `msgspec-integration.rst` only the human-readable link text was changed; the `:meth:` reference target (`falcon.App.add_error_handler`) is untouched.

# Related Issues

N/A

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable). — N/A, documentation/comment only
- [x] Added **tests** for changed code. — N/A, no functional change
- [x] Performed automated tests and code quality checks. — verified with `codespell`
- [x] Prefixed code comments with GitHub nick and an appropriate prefix. — N/A, no new comments added
- [x] Coding style is consistent with the rest of the framework.
- [x] Updated **documentation** for changed code.
- [x] Changes have towncrier news fragments. — N/A, these changes do not modify functionality, so no newsfragment is required
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer.