### PR TITLE
chore(tests): ignore typing errors on conditional function variants

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,6 +231,8 @@ listed below by date of first contribution:
 * Tang Vu (tang-vu)
 * Arthur Prioli (arthurprioli)
 * Matt Van Horn (mvanhorn)
+* Apoorva Verma (apoorva-01)
+* max (maxtaran2010)
 
 (et al.)
 

--- a/docs/_newsfragments/2670.bugfix.rst
+++ b/docs/_newsfragments/2670.bugfix.rst
@@ -1,8 +1,5 @@
-When decoding with ``unquote_plus=False``, the Cython-accelerated
-:meth:`falcon.uri.decode` mistook a literal plus sign followed by two
-hexadecimal digits for a percent-encoded byte. For instance,
-``uri.decode('+00', unquote_plus=False)`` returned ``'\x00'`` instead of the
-expected ``'+00'``, which could inject a NUL byte into decoded values (an ISO
-8601 timestamp such as ``...964935+00:00`` being a common trigger). The
-accelerated implementation now preserves a literal plus in this case, matching
-the pure-Python variant.
+When decoding with ``unquote_plus=False``, the cythonized variant of
+:func:`falcon.uri.decode` mistook a literal plus sign followed by two
+hexadecimal digits for a percent-encoded byte.
+This has been fixed, and a literal plus is now preserved
+just like in the pure-Python case.

--- a/docs/changes/4.4.0.rst
+++ b/docs/changes/4.4.0.rst
@@ -22,4 +22,6 @@ Contributors to this Release
 
 Many thanks to all of our talented and stylish contributors for this release!
 
+- `apoorva-01 <https://github.com/apoorva-01>`__
+- `maxtaran2010 <https://github.com/maxtaran2010>`__
 - `vytas7 <https://github.com/vytas7>`__

--- a/tests/test_custom_router.py
+++ b/tests/test_custom_router.py
@@ -29,7 +29,7 @@ def test_custom_router_find_should_be_used(asgi, util):
 
     else:
 
-        def resource(req, resp, **kwargs):
+        def resource(req, resp, **kwargs):  # type: ignore[misc]
             resp.text = f'{{"uri_template": "{req.uri_template}"}}'
 
     class CustomRouter:
@@ -106,7 +106,7 @@ def test_custom_router_takes_req_positional_argument(asgi, util):
 
     else:
 
-        def responder(req, resp):
+        def responder(req, resp):  # type: ignore[misc]
             resp.text = 'OK'
 
     class CustomRouter:
@@ -129,7 +129,7 @@ def test_custom_router_takes_req_keyword_argument(asgi, util):
 
     else:
 
-        def responder(req, resp):
+        def responder(req, resp):  # type: ignore[misc]
             resp.text = 'OK'
 
     class CustomRouter:

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -326,7 +326,7 @@ class TestCustomError:
 
         else:
 
-            def handle_zero_division(req, resp, ex, params):
+            def handle_zero_division(req, resp, ex, params):  # type: ignore[misc]
                 assert resp.render_body() is None
                 resp.status = falcon.HTTP_719
 

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -93,7 +93,7 @@ class TestDefaultRouting:
 
         else:
 
-            def sink_too(req, resp):
+            def sink_too(req, resp):  # type: ignore[misc]
                 resp.status = falcon.HTTP_781
 
         client.app.add_sink(sink, r'/foo')


### PR DESCRIPTION
Seems to be a new error surfaced by the recently released Mypy 2.3.0.