### PR TITLE
docs(examples): add type hints to things examples

### DIFF
--- a/examples/things.py
+++ b/examples/things.py
@@ -1,5 +1,6 @@
-# examples/things.py
+from __future__ import annotations
 
+# examples/things.py
 # Let's get this party started!
 from wsgiref.simple_server import make_server
 
@@ -10,7 +11,7 @@ import falcon
 # other things) that you think in terms of resources and state
 # transitions, which map to HTTP verbs.
 class ThingsResource:
-    def on_get(self, req, resp):
+    def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
         """Handles GET requests"""
         resp.status = falcon.HTTP_200  # This is the default status
         resp.content_type = falcon.MEDIA_TEXT  # Default is JSON, so override
@@ -24,7 +25,7 @@ class ThingsResource:
 
 # falcon.App instances are callable WSGI apps
 # in larger applications the app is created in a separate file
-app = falcon.App()
+app: falcon.App = falcon.App()
 
 # Resources are represented by long-lived class instances
 things = ThingsResource()

--- a/examples/things_asgi.py
+++ b/examples/things_asgi.py
@@ -1,5 +1,6 @@
-# examples/things_asgi.py
+from __future__ import annotations
 
+# examples/things_asgi.py
 import falcon
 import falcon.asgi
 
@@ -8,7 +9,7 @@ import falcon.asgi
 # other things) that you think in terms of resources and state
 # transitions, which map to HTTP verbs.
 class ThingsResource:
-    async def on_get(self, req, resp):
+    async def on_get(self, req: falcon.Request, resp: falcon.Response) -> None:
         """Handles GET requests"""
         resp.status = falcon.HTTP_200  # This is the default status
         resp.content_type = falcon.MEDIA_TEXT  # Default is JSON, so override
@@ -22,7 +23,7 @@ class ThingsResource:
 
 # falcon.asgi.App instances are callable ASGI apps...
 # in larger applications the app is created in a separate file
-app = falcon.asgi.App()
+app: falcon.asgi.App = falcon.asgi.App()
 
 # Resources are represented by long-lived class instances
 things = ThingsResource()


### PR DESCRIPTION
## Summary
Focused first slice of type hints for tutorials/examples:

- annotate `examples/things.py` (WSGI)
- annotate `examples/things_asgi.py` (ASGI)

This intentionally does **not** rewrite the whole docs tree — just a small, reviewable starting point.

## Test plan
- [x] `python -m py_compile` on both example files
- [ ] CI / docs examples still import cleanly

Refs #1820
