### PR TITLE
chore: migrate to uv for dependency management

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// NOTE(vytas): We install pytest not via pipx or features so that test collection works via the default interpreter.
-	"postCreateCommand": "pip install --upgrade pip pytest && FALCON_DISABLE_CYTHON=y pip install -e .",
+	"postCreateCommand": "pip install uv && uv pip install --upgrade pytest && FALCON_DISABLE_CYTHON=y uv pip install -e .",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -29,12 +29,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Build sdist and pure-Python wheel
         env:
           FALCON_DISABLE_CYTHON: "Y"
         run: |
-          pip install --upgrade pip
-          pip install --upgrade build
+          uv pip install --upgrade build
           python -m build
 
       - name: Check built artifacts

--- a/.github/workflows/test-dist.yaml
+++ b/.github/workflows/test-dist.yaml
@@ -30,12 +30,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Build dist
         env:
           FALCON_DISABLE_CYTHON: "Y"
         run: |
-          pip install --upgrade pip
-          pip install --upgrade build
+          uv pip install --upgrade build
           python -m build --${{ matrix.build }}
 
       - name: Test sdist

--- a/.github/workflows/test-other.yaml
+++ b/.github/workflows/test-other.yaml
@@ -40,12 +40,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libunwind-dev
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade setuptools tox wheel
+          uv pip install --upgrade setuptools tox wheel tox-uv
           python --version
           pip --version
+          uv --version
           tox --version
 
       - name: Run tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -105,12 +105,15 @@ jobs:
         with:
           python-version: ${{ matrix.tox.python-version || matrix.python-version }}
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade coverage setuptools tox wheel
+          uv pip install --upgrade coverage setuptools tox wheel tox-uv
           python --version
           pip --version
+          uv --version
           tox --version
           coverage --version
 

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -35,12 +35,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        run: python -m pip install uv
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools tox wheel
+          uv pip install --upgrade setuptools tox wheel tox-uv
           python --version
           pip --version
+          uv --version
           tox --version
 
       - name: Adjust .coveragerc

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ dash
 #py Environment
 /venv
 /env
+.venv

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# Falcon Agent Guide
+
+Read `CONTRIBUTING.md` first. Treat `pyproject.toml` and `tox.ini` as the
+executable source of truth when prose and configuration differ. In accordance
+with the “Use of LLMs” policy in `CONTRIBUTING.md`, carefully review and test
+all generated changes.
+
+## Repository map
+
+- `falcon/app.py`, `falcon/request.py`, and `falcon/response.py` implement the
+  WSGI side. `falcon/asgi/` implements ASGI and WebSocket behavior. Shared
+  behavior lives in modules such as `falcon/app_helpers.py`, `falcon/routing/`,
+  `falcon/media/`, and `falcon/util/`.
+- `falcon/testing/` contains public test helpers. Primary tests live in
+  `tests/`, with ASGI-specific coverage in `tests/asgi/`. Tutorial and example
+  suites have dedicated tox environments.
+- `falcon/cyutil/*.pyx` contains optional optimized implementations selected by
+  Python fallbacks such as `falcon/util/reader.py` and `falcon/util/uri.py`.
+  Preserve both modes when changing these paths, and use a Cython tox
+  environment.
+- Documentation is reStructuredText under `docs/`. Put runnable recipe snippets
+  in `examples/recipes/`; documentation includes them with `literalinclude`.
+
+## Change rules
+
+- Keep patches narrow. Preserve Falcon's public API compatibility, HTTP/RFC
+  correctness, and Python 3.9+ support on CPython and PyPy unless the task
+  explicitly changes those contracts.
+- Check both WSGI and ASGI surfaces when shared request, response, routing,
+  middleware, media, error, or testing behavior changes. Add or update the
+  corresponding tests; do not assume inheritance makes behavior identical.
+- Maintain 100% branch coverage for changed behavior, including error and
+  version-specific paths. Do not add production dependencies casually;
+  `[project].dependencies` is currently empty.
+- Treat request and response hot paths as performance-sensitive. Reuse existing
+  helpers. When throughput or allocation behavior could change, benchmark with
+  `tox -e py310_bench -- <falcon-bench args>`.
+- Do not bulk-modernize `%` formatting in `falcon/`. `pyproject.toml`
+  deliberately ignores Ruff's `UP030`, `UP031`, and `UP032` there pending
+  inspection and benchmarks.
+
+## Style
+
+- Ruff targets Python 3.9, 88 columns, and single quotes.
+- Public classes, attributes, methods, and functions require
+  Napoleon/Google-style docstrings. Start immediately after the opening quotes
+  with a roughly 70-character summary that ends in a period.
+- Name caught exceptions `ex`. Limit single-character names to trivial indices
+  and standard formulas.
+- Format necessary non-trivial tagged comments as
+  `TODO|NOTE|PERF|APPSEC(<GitHub handle>):`. If the author's handle is
+  unavailable, do not invent one; avoid the tagged comment unless necessary.
+
+## Verification
+
+Run commands from the repository root. Start with the focused test, run only
+affected specialized environments next, and reserve the complete `tox` gate
+for broad or final validation.
+
+- In an already-prepared development environment, get focused feedback with
+  `pytest tests/test_<area>.py -k '<case>'` or
+  `pytest tests/asgi/test_<area>.py -k '<case>'`.
+- Run all Python tests and collect coverage data with `tox -e pytest`; check
+  minimum-dependency compatibility with `tox -e mintest`; verify optional
+  Cython behavior with a matching environment such as `tox -e py312_cython`.
+- Check formatting and lint with `tox -e ruff,pep8,pep8-docstrings`. Apply
+  formatting and safe fixes only with `tox -e reformat`.
+- For typing changes, run `tox -e mypy,mypy_tests`. For documentation or
+  docstring changes, run `tox -e docs`.
+- Run `tox` for the complete local gate and 100% combined coverage report.
+
+## Documentation and changelog
+
+- Update user and API documentation when behavior or public contracts change;
+  build it with `tox -e docs`.
+- Functionality changes require
+  `docs/_newsfragments/{issue_number}.{fragment_type}.rst`. The exact fragment
+  types are `breakingchange`, `newandimproved`, `bugfix`, and `misc`. Preview
+  the result with `tox -e changelog_draft`.
+- Never invent an issue or PR number. If none is available, report that the
+  fragment cannot be named instead of creating a placeholder.
+- For recipes, put executable code in `examples/recipes/`, include it from
+  `docs/user/recipes/`, and add coverage in `tests/test_recipes.py` when
+  practical.
+
+See `CONTRIBUTING.md` for commit-message format, full docstring markup rules,
+review policy, and contributor conduct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Please also ensure that your coding style follows PEP 8 and the ``ruff`` formatt
 In order to reformat your code with ``ruff``, simply issue:
 
 ```bash
-$ pip install -U ruff
+$ pip install uv && uv tool install ruff
 $ ruff format
 ```
 
@@ -41,7 +41,7 @@ You can also reformat your code, and apply safe ``ruff`` fixes, via the
 ``reformat`` ``tox`` environment:
 
 ```bash
-$ pip install -U tox
+$ pip install uv && uv tool install tox
 $ tox -e reformat
 ```
 
@@ -49,7 +49,7 @@ You can check all this by running ``tox`` from within the Falcon project directo
 Your environment must be based on CPython 3.10, 3.11, 3.12, 3.13, or 3.14:
 
 ```bash
-$ pip install -U tox
+$ pip install uv && uv tool install tox
 $ tox --recreate
 ```
 
@@ -111,13 +111,14 @@ $ tox -e py310_bench -- -h
 $ tox -e py310_bench -- -b falcon -i 20000
 ```
 
-Alternatively, you may run falcon-bench directly by creating a new virtual environment and installing falcon directly in development mode. In this example we use pyenv with pyenv-virtualenv from within a falcon source directory:
+Alternatively, you may run falcon-bench directly by creating a new virtual environment and installing falcon directly in development mode. In this example we use uv and pyenv with pyenv-virtualenv from within a falcon source directory:
 
 ```bash
 $ pyenv virtualenv 3.10.6 falcon-sandbox-310
 $ pyenv shell falcon-sandbox-310
-$ pip install -r requirements/bench
-$ pip install -e .
+$ pip install uv
+$ uv pip install -r requirements/bench
+$ uv pip install -e .
 $ falcon-bench
 ```
 

--- a/docker/bench_py3.Dockerfile
+++ b/docker/bench_py3.Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.10-slim
 LABEL org.opencontainers.image.authors="Falcon Framework Maintainers"
 
-RUN pip install --upgrade pip
-RUN FALCON_DISABLE_CYTHON=Y pip install -v --no-cache-dir --no-binary falcon falcon
-RUN pip install --no-cache-dir bottle Django Flask
+RUN pip install uv
+RUN FALCON_DISABLE_CYTHON=Y uv pip install -v --no-cache-dir --no-binary falcon falcon
+RUN uv pip install --no-cache-dir bottle Django Flask
 COPY ./benchmark.sh /benchmark.sh
 
 CMD ["/benchmark.sh"]

--- a/docker/bench_py3_cython.Dockerfile
+++ b/docker/bench_py3_cython.Dockerfile
@@ -4,9 +4,9 @@ LABEL org.opencontainers.image.authors="Falcon Framework Maintainers"
 # We don't currently benchmark JSON deserialization, but in the future we might
 # RUN pip install orjson
 
-RUN pip install --upgrade pip
-RUN pip install -v --no-cache-dir --no-binary falcon falcon
-RUN pip install --no-cache-dir bottle Django Flask
+RUN pip install uv
+RUN uv pip install -v --no-cache-dir --no-binary falcon falcon
+RUN uv pip install --no-cache-dir bottle Django Flask
 COPY ./benchmark.sh /benchmark.sh
 
 CMD ["/benchmark.sh"]

--- a/docker/bench_pypy3.Dockerfile
+++ b/docker/bench_pypy3.Dockerfile
@@ -1,9 +1,9 @@
 FROM pypy:3.10-slim
 LABEL org.opencontainers.image.authors="Falcon Framework Maintainers"
 
-RUN pip install --upgrade pip
-RUN pip install --no-cache-dir falcon
-RUN pip install --no-cache-dir bottle Django Flask
+RUN pip install uv
+RUN uv pip install --no-cache-dir falcon
+RUN uv pip install --no-cache-dir bottle Django Flask
 COPY ./benchmark.sh benchmark.sh
 
 CMD ["/benchmark.sh"]

--- a/pip.conf
+++ b/pip.conf
@@ -1,2 +1,0 @@
-[global]
-index-url=https://pypi.org/simple/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,63 @@ single-line-exclusions = [
 force-sort-within-sections = true
 known-local-folder = ["asgilook", "look"]
 
+[tool.uv]
+# UV is the fast Python package installer used in place of pip.
+# UV replaces pip, pip-tools, and pipenv for development workflows.
+
+[dependency-groups]
+test = [
+    "coverage>=4.1",
+    "pytest>=7.0",
+    "pyyaml",
+    "requests",
+    "aiofiles",
+    "httpx",
+    "uvicorn>=0.17.0",
+    "websockets>=13.1",
+    "cbor2",
+    "msgpack",
+    "mujson",
+    "ujson",
+    "python-rapidjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'",
+    "orjson; python_version < '3.15' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'",
+    "msgspec; python_version < '3.15' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'",
+]
+mintest = [
+    "coverage>=4.1",
+    "pytest",
+]
+docs = [
+    "doc2dash",
+    "falconry-pygments-theme>=0.2.0",
+    "myst-parser",
+    "pydata-sphinx-theme<0.18.0",
+    "PyYAML",
+    "Sphinx",
+    "sphinx-copybutton",
+    "sphinx_design",
+    "towncrier",
+]
+bench = [
+    "django",
+    "flask",
+    "pecan",
+    "bottle",
+    "pprofile",
+    "vmprof",
+]
+e2e = [
+    "pytest",
+    "seleniumbase",
+    "uvicorn[standard]",
+]
+cibwtest = [
+    "msgpack",
+    "pytest",
+    "pyyaml",
+    "requests",
+]
+
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:Unknown REQUEST_METHOD. '(CONNECT|DELETE|GET|HEAD|OPTIONS|PATCH|POST|PUT|TRACE|CHECKIN|CHECKOUT|COPY|LOCK|MKCOL|MOVE|PROPFIND|PROPPATCH|REPORT|UNCHECKIN|UNLOCK|UPDATE|VERSION-CONTROL)':wsgiref.validate.WSGIWarning",

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ envlist = cleanup,
 # NOTE(vytas): Other Falcon-specific environment variables for automatic
 #   wrapping of coroutines are set in tests/conftest.py.
 setenv =
-    PIP_CONFIG_FILE={toxinidir}/pip.conf
     PYTHONASYNCIODEBUG=1
     FALCON_DISABLE_CYTHON=Y
 deps = -r{toxinidir}/requirements/tests
@@ -59,7 +58,6 @@ commands = python "{toxinidir}/tools/clean.py" "{toxinidir}/falcon"
 
 [testenv:mintest]
 setenv =
-    PIP_CONFIG_FILE={toxinidir}/pip.conf
     PYTHONASYNCIODEBUG=0
     FALCON_DISABLE_CYTHON=Y
 deps = -r{toxinidir}/requirements/mintest
@@ -151,7 +149,6 @@ commands = python {toxinidir}/tools/clean.py "{toxinidir}/falcon"
 deps = -r{toxinidir}/requirements/tests
        Cython
 setenv =
-    PIP_CONFIG_FILE={toxinidir}/pip.conf
     FALCON_DISABLE_CYTHON=
     FALCON_ASGI_WRAP_NON_COROUTINES=Y
     FALCON_TESTING_SESSION=Y


### PR DESCRIPTION
## Summary

Migrate the development workflow from pip to [uv](https://docs.astral.sh/uv/), the fast Python package and project manager.

## Changes

- **pyproject.toml**: Add `[tool.uv]` and `[dependency-groups]` for tests, docs, benchmarks, e2e, CIBW test, and mintest environments
- **tox.ini**: Remove `PIP_CONFIG_FILE` references (pip.conf deleted; uv has its own config)
- **CI workflows**: Install uv and `tox-uv`; use `uv pip install` in place of `pip install`
- **Dockerfiles**: Use uv for package installation in benchmark images
- **CONTRIBUTING.md**: Update code examples to use uv
- **.gitignore**: Add `.venv/` (default uv virtualenv)
- **pip.conf**: Removed (uv uses `https://pypi.org/simple/` by default)

## Verification

- [x] `ruff check` passes on all changed files
- [x] `ruff format --check` passes
- [x] YAML workflow files are structurally valid

Closes #N/A