### PR TITLE
fix(bench): gate vmprof to python<3.11 in bench requirements

### DIFF
--- a/requirements/bench
+++ b/requirements/bench
@@ -6,4 +6,4 @@ bottle
 pprofile
 # NOTE(vytas): vmprof supports only up to Python 3.11 at the time of writing.
 #   (https://github.com/vmprof/vmprof-python/issues/261)
-vmprof
+vmprof; python_version  < '3.11'


### PR DESCRIPTION
requirements/bench unconditionally listed vmprof, but vmprof's C extension fails to build on Python 3.11+ since PyThreadState no longer exposes a frame member (removed as part of CPython's interpreter changes). This caused tox -e py3xx_bench to fail during environment setup, before falcon-bench even ran — even though falcon/bench/bench.py already treats vmprof as optional via try/except ImportError.
This PR adds a python_version < '3.11' marker so pip skips vmprof on newer interpreters instead of failing the install.
This addresses the install-breakage part of #2691. The larger ask in that issue (migrating the benchmark harness to use pyperf) is being tracked separately.
Testing: confirmed pip install -r requirements/bench and tox -e py310_bench both complete cleanly on Python 3.12 with this change.
Closes #2691