### PR TITLE
chore("AI"): add `CLAUDE.md` wrapper importing `AGENTS.md`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -233,6 +233,8 @@ listed below by date of first contribution:
 * Matt Van Horn (mvanhorn)
 * Apoorva Verma (apoorva-01)
 * max (maxtaran2010)
+* Johannes Rueschel (chbndrhnns)
+* Gaurav Yadav (MeGaurav4)
 
 (et al.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/changes/4.4.0.rst
+++ b/docs/changes/4.4.0.rst
@@ -23,5 +23,8 @@ Contributors to this Release
 Many thanks to all of our talented and stylish contributors for this release!
 
 - `apoorva-01 <https://github.com/apoorva-01>`__
+- `chbndrhnns <https://github.com/chbndrhnns>`__
 - `maxtaran2010 <https://github.com/maxtaran2010>`__
+- `MeGaurav4 <https://github.com/MeGaurav4>`__
+- `mvanhorn <https://github.com/mvanhorn>`__
 - `vytas7 <https://github.com/vytas7>`__


### PR DESCRIPTION
At EuroPython '26, I was privileged to participate in several discussions & presentations on the subject.

The consensus is that the cleanest way (for now) is to add `CLAUDE.md` importing `@AGENTS.md` as proposed in this changeset.
