### PR TITLE
chore(platform): enable full CPython 3.15 support

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -165,6 +165,7 @@ jobs:
           - cp312
           - cp313
           - cp314
+          - cp315
         include:
           - platform:
               name: manylinux_x86_64
@@ -182,6 +183,22 @@ jobs:
               name: musllinux_aarch64
               os: ubuntu-24.04-arm
             python: cp314t
+          - platform:
+              name: manylinux_x86_64
+              os: ubuntu-latest
+            python: cp315t
+          - platform:
+              name: musllinux_x86_64
+              os: ubuntu-latest
+            python: cp315t
+          - platform:
+              name: manylinux_aarch64
+              os: ubuntu-24.04-arm
+            python: cp315t
+          - platform:
+              name: musllinux_aarch64
+              os: ubuntu-24.04-arm
+            python: cp315t
 
     defaults:
       run:
@@ -201,7 +218,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,10 +7,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove once proven to pass on PR.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove once proven to pass on PR.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - build: "cp314-manylinux_aarch64"
+          - build: "cp315-manylinux_aarch64"
             os: ubuntu-24.04-arm
           - build: "cp314-manylinux_s390x"
             os: ubuntu-latest
@@ -46,11 +46,11 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@f03ac7617d6cff873ccf24cc0d567ef5ba5a9e6d # v4.0.0
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).
-          # CIBW_ENABLE: cpython-prerelease
+          CIBW_ENABLE: cpython-prerelease
 
           CIBW_ARCHS_LINUX: all
           CIBW_BUILD: ${{ matrix.platform.build }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,7 +65,9 @@ jobs:
           - env: py314_cython
             python-version: "3.14"
           - env: py315
-            python-version: "3.15.0-alpha.3 - 3.15.0"
+            python-version: "3.15.0-beta.3 - 3.15.0"
+          - env: py315_cython
+            python-version: "3.15.0-beta.3 - 3.15.0"
           - env: py312_nocover
             os: macos-latest
             platform-label: ' (macos)'

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove once proven to pass on PR.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   run_tox:
@@ -22,6 +26,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
 
     steps:
       - name: Checkout repo
@@ -33,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version != '3.15' && matrix.python-version || '3.15.0-beta.3 - 3.15.0'}}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -6,10 +6,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove once proven to pass on PR.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   run_tox:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,11 +46,18 @@ $ tox -e reformat
 ```
 
 You can check all this by running ``tox`` from within the Falcon project directory.
-Your environment must be based on CPython 3.10, 3.11, 3.12, 3.13, or 3.14:
+Your environment must be based on CPython 3.10, 3.11, 3.12, 3.13, 3.14, or 3.15:
 
 ```bash
 $ pip install -U tox
 $ tox --recreate
+```
+
+If you prefer, you can also use [`uvx`](https://docs.astral.sh/uv/) to run
+``ruff`` and ``tox`` directly:
+
+```bash
+$ uvx tox -e reformat  # also applies to other examples, e.g., uvx tox --recreate
 ```
 
 ### Reviews

--- a/docs/changes/4.4.0.rst
+++ b/docs/changes/4.4.0.rst
@@ -9,10 +9,11 @@ Falcon 4.4 is in development. The progress is tracked via the
 on GitHub.
 
 
-.. Changes to Supported Platforms
-.. ------------------------------
+Changes to Supported Platforms
+------------------------------
 
-.. NOTE(vytas): No changes to the supported platforms (yet).
+- CPython 3.15 is now fully supported.
+  (`#2593 <https://github.com/falconry/falcon/issues/2593>`__)
 
 
 .. towncrier release notes start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: Free Threading",
     "Programming Language :: Python :: Free Threading :: 3 - Stable",
     "Programming Language :: Cython",

--- a/tox.ini
+++ b/tox.ini
@@ -200,6 +200,14 @@ deps = {[with-cython]deps}
 setenv = {[with-cython]setenv}
 commands = {[with-cython]commands}
 
+[testenv:py315_cython]
+basepython = python3.15
+# NOTE(vytas): pyximport relies on distutils.extension
+deps = {[with-cython]deps}
+       setuptools
+setenv = {[with-cython]setenv}
+commands = {[with-cython]commands}
+
 # --------------------------------------------------------------------
 # WSGI servers (Cythonized Falcon)
 # --------------------------------------------------------------------


### PR DESCRIPTION
Closes #2593.

I have tentatively enabled everything including Cibuildwheel outputs, however, we ought to hold release until CPython 3.15 reaches rc1 (expected August 2026).
