### PR TITLE
docs: clarify ASGI request header casing

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -1086,10 +1086,16 @@ expecting a specific header name capitalization, see this recipe how to
 override header names using generic WSGI middleware:
 :ref:`capitalizing_response_headers`.
 
-Note that this question only applies to the WSGI flavor of Falcon. The
-`ASGI HTTP scope specification
+The preceding workaround only applies to the WSGI flavor of Falcon. For ASGI
+responses, the `Response Start event
 <https://asgi.readthedocs.io/en/latest/specs/www.html#response-start-send-event>`_
-requires HTTP header names to be lowercased.
+requires applications to supply lowercase header names.
+
+Incoming ASGI request headers are different. The `HTTP Connection Scope
+<https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope>`_
+recommends, but does not require, that servers supply lowercase header names.
+Falcon expects servers to follow this recommendation and does not normalize
+non-lowercase request header names.
 
 Furthermore, the HTTP2 standard also mandates that header field names MUST be
 converted to lowercase (see `RFC 7540, Section 8.1.2

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -55,6 +55,11 @@ class Request(request.Request):
     Note:
         `Request` is not meant to be instantiated directly by responders.
 
+        Falcon expects ASGI servers to supply lowercase request header names,
+        as recommended by the `ASGI HTTP Connection Scope
+        <https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope>`__.
+        Header names that are not lowercase are not normalized by Falcon.
+
     Args:
         scope (dict): ASGI HTTP connection scope passed in from the server (see
             also: `Connection Scope`_).
@@ -69,7 +74,6 @@ class Request(request.Request):
 
     .. _Connection Scope:
         https://asgi.readthedocs.io/en/latest/specs/www.html#connection-scope
-
     """
 
     __slots__ = [
@@ -692,10 +696,14 @@ class Request(request.Request):
 
     @property
     def headers(self) -> Mapping[str, str]:
-        """Raw HTTP headers from the request with dash-separated
-        names normalized to lowercase.
+        """HTTP headers from the request with dash-separated lowercase names.
 
         Note:
+            Falcon expects the ASGI server to supply lowercase header names,
+            as recommended by the `ASGI HTTP Connection Scope
+            <https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope>`__.
+            Header names that are not lowercase are not normalized by Falcon.
+
             This property differs from the WSGI version of ``Request.headers``
             in that the latter returns *uppercase* names for historical
             reasons. Middleware, such as tracing and logging components, that


### PR DESCRIPTION
# Summary of Changes

Update the `falcon.asgi.Request` class and `headers` property documentation in `falcon/asgi/request.py` so the generated API reference clearly states that Falcon expects ASGI servers to supply lowercase request header names and does not normalize nonconforming input. Revise the ASGI portion of `docs/user/faq.rst` to distinguish incoming request headers from outgoing response headers, link each claim to the applicable ASGI scope/event language, and avoid implying a stronger requirement than the current specification. This supersedes the closed, unmerged PR #2706 by following the latest maintainer direction and covering both the public API contract and the stale FAQ explanation, without changing the performance-sensitive request path or introducing a configuration option.

Falcon's ASGI request path stores incoming header names as supplied and relies on the server to follow the ASGI recommendation to lowercase them. The current API documentation says the resulting names are normalized, while the FAQ cites an outdated mandatory-casing requirement for a response event rather than the incoming HTTP connection scope. Maintainers prefer documenting this assumption instead of adding unconditional normalization or a request option without a real-world server incompatibility.

Fixes #2456

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
  Not run in this workspace, so this is left for CI to confirm.
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
      Not run in this workspace, so this is left for CI to confirm.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
      Not run in this workspace, so this is left for CI to confirm.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
      Not run in this workspace, so this is left for CI to confirm.
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e docs`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
  Not run in this workspace, so this is left for CI to confirm.
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*

AI was used for assistance.
