### PR TITLE
docs: update obsolete RFC references to current specifications

### DIFF
--- a/docs/api/cookies.rst
+++ b/docs/api/cookies.rst
@@ -156,7 +156,7 @@ Currently, :meth:`~falcon.Response.set_cookie` does not set `SameSite` by
 default, although this may change in a future release.
 
 .. _RFC 6265, Section 4.1.2.5:
-    https://tools.ietf.org/html/rfc6265#section-4.1.2.5
+    https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.2.5
 
 When unsetting a cookie, :meth:`~falcon.Response.unset_cookie`,
 the default `SameSite` setting of the unset cookie is ``'Lax'``, but can be changed

--- a/docs/api/websocket.rst
+++ b/docs/api/websocket.rst
@@ -7,7 +7,7 @@ Falcon builds upon the
 `ASGI WebSocket Specification <https://asgi.readthedocs.io/en/latest/specs/www.html#websocket>`_
 to provide a simple, no-nonsense WebSocket server implementation.
 
-With support for both `WebSocket <https://tools.ietf.org/html/rfc6455>`_ and
+With support for both `WebSocket <https://datatracker.ietf.org/doc/html/rfc6455>`_ and
 `Server-Sent Events <https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events>`_
 (SSE), Falcon facilitates real-time, event-oriented communication between an
 ASGI application and a web browser, mobile app, or other client application.

--- a/docs/changes/3.0.0.rst
+++ b/docs/changes/3.0.0.rst
@@ -252,7 +252,7 @@ Fixed
   application is not behind a proxy. (`#1678 <https://github.com/falconry/falcon/issues/1678>`__)
 - The :attr:`Response.downloadable_as <falcon.Response.downloadable_as>` property
   is now correctly encoding non-ASCII filenames as per
-  `RFC 6266 <https://tools.ietf.org/html/rfc6266#appendix-D>`_ recommendations. (`#1749 <https://github.com/falconry/falcon/issues/1749>`__)
+  `RFC 6266 <https://datatracker.ietf.org/doc/html/rfc6266#appendix-D>`_ recommendations. (`#1749 <https://github.com/falconry/falcon/issues/1749>`__)
 - The :class:`falcon.routing.CompiledRouter` no longer mistakenly sets route parameters
   while exploring non matching routes. (`#1779 <https://github.com/falconry/falcon/issues/1779>`__)
 - The :func:`~falcon.to_query_str` method now correctly encodes parameter keys

--- a/docs/ext/rfc.py
+++ b/docs/ext/rfc.py
@@ -17,7 +17,7 @@
 This extensions adds hyperlinking for any RFC references that are
 formatted like this::
 
-    RFC 7231; Section 6.5.3
+    RFC 9110; Section 15.5.3
 """
 
 import re
@@ -27,7 +27,7 @@ RFC_PATTERN = re.compile(r'RFC (\d{4}), Section ([\d\.]+)')
 
 
 def _render_section(section_number, rfc_number):
-    template = '`{0} <https://tools.ietf.org/html/rfc{1}#section-{0}>`_'
+    template = '`{0} <https://datatracker.ietf.org/doc/html/rfc{1}#section-{0}>`_'
     return template.format(section_number, rfc_number)
 
 

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -741,7 +741,7 @@ Falcon does not offer official support for parsing nested multipart forms
 ``multipart/mixed`` part) at this time. The usage is considered deprecated
 according to the `living HTML5 standard
 <https://html.spec.whatwg.org/multipage/form-control-infrastructure.html>`_ and
-`RFC 7578, Section 4.3 <https://tools.ietf.org/html/rfc7578#section-4.3>`_.
+`RFC 7578, Section 4.3 <https://datatracker.ietf.org/doc/html/rfc7578#section-4.3>`_.
 
 .. tip::
     If your app absolutely must deal with such legacy forms, the parser may
@@ -812,7 +812,7 @@ value of the query string, for example ``?c={"a":1,"b":2}``, the value will be
 added to ``request.params`` in an unexpected way: ``{'c': ['{"a":1', '"b":2}']}``.
 
 Commas are a reserved character that can be escaped according to
-`RFC 3986 - 2.2. Reserved Characters <https://tools.ietf.org/html/rfc3986#section-2.2>`_,
+`RFC 3986 - 2.2. Reserved Characters <https://datatracker.ietf.org/doc/html/rfc3986#section-2.2>`_,
 so one possible solution is to percent encode any commas that appear in your
 JSON query string.
 
@@ -1092,8 +1092,8 @@ Note that this question only applies to the WSGI flavor of Falcon. The
 requires HTTP header names to be lowercased.
 
 Furthermore, the HTTP2 standard also mandates that header field names MUST be
-converted to lowercase (see `RFC 7540, Section 8.1.2
-<https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2>`_).
+converted to lowercase (see `RFC 9113, Section 8.2
+<https://datatracker.ietf.org/doc/html/rfc9113#section-8.2>`_).
 
 .. _faq_static_files:
 

--- a/docs/user/recipes/multipart-mixed.rst
+++ b/docs/user/recipes/multipart-mixed.rst
@@ -12,7 +12,7 @@ using a nested ``multipart/mixed`` part).
     `living HTML5 standard
     <https://html.spec.whatwg.org/multipage/form-control-infrastructure.html>`_
     and
-    `RFC 7578, Section 4.3 <https://tools.ietf.org/html/rfc7578#section-4.3>`_.
+    `RFC 7578, Section 4.3 <https://datatracker.ietf.org/doc/html/rfc7578#section-4.3>`_.
 
 If your app needs to handle nested forms, this can be done in the same
 fashion as any other part embedded in the form -- by installing an appropriate
@@ -39,7 +39,7 @@ Let us now use the nesting-aware parser in an app:
 
 We should now be able to consume a form containing a nested ``multipart/mixed``
 part (the example is adapted from the now-obsolete
-`RFC 1867 <https://tools.ietf.org/html/rfc1867>`_)::
+`RFC 1867 <https://datatracker.ietf.org/doc/html/rfc1867>`_)::
 
     --AaB03x
     Content-Disposition: form-data; name="field1"

--- a/docs/user/recipes/output-csv.rst
+++ b/docs/user/recipes/output-csv.rst
@@ -24,7 +24,7 @@ and then assign its value to :attr:`resp.text <falcon.Response.text>`:
             :language: python
 
 Here we set the response ``Content-Type`` to :data:`~falcon.constants.MEDIA_CSV` as
-recommended by `RFC 4180 <https://tools.ietf.org/html/rfc4180>`_, and assign
+recommended by `RFC 4180 <https://datatracker.ietf.org/doc/html/rfc4180>`_, and assign
 the downloadable file name ``report.csv`` via the ``Content-Disposition``
 header (see also: :ref:`serve-downloadable-as`).
 

--- a/docs/user/recipes/pretty-json.rst
+++ b/docs/user/recipes/pretty-json.rst
@@ -36,8 +36,8 @@ express resource representation preferences. Although not a part of the
 REST Framework) and services support requesting a specific JSON indentation
 level using the ``indent`` content-type parameter. This recipe leaves the
 interpretation to the reader as to whether such a parameter adds "new
-functionality" as per `RFC 6836, Section 4.3
-<https://tools.ietf.org/html/rfc6838#section-4.3>`_.
+functionality" as per `RFC 6838, Section 4.3
+<https://datatracker.ietf.org/doc/html/rfc6838#section-4.3>`_.
 
 Assuming we want to add JSON ``indent`` support to a Falcon app, this can be
 implemented with a :ref:`custom media handler <custom-media-handler-type>`:

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -265,8 +265,8 @@ HTTP methods, lowercased (e.g., ``on_get()``, ``on_put()``,
 
 .. note::
     Supported HTTP methods are those specified in
-    `RFC 7231 <https://tools.ietf.org/html/rfc7231>`_ and
-    `RFC 5789 <https://tools.ietf.org/html/rfc5789>`_. This includes
+    `RFC 9110 <https://datatracker.ietf.org/doc/html/rfc9110>`_ and
+    `RFC 9111 <https://datatracker.ietf.org/doc/html/rfc9111>`_. This includes
     GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, and PATCH.
 
 We call these well-known methods "responders". Each responder takes (at


### PR DESCRIPTION
## Summary

This PR updates all obsolete RFC references in the documentation to their current, consolidated specifications, as requested in #2525.

## Changes

### RFC Updates

| Old RFC | New RFC | Description |
|---------|---------|-------------|
| RFC 7231 | RFC 9110 | HTTP Semantics (consolidated) |
| RFC 5789 | RFC 9110 | PATCH method (incorporated) |
| RFC 7540 | RFC 9113 | HTTP/2 (current spec) |
| RFC 6836 | RFC 6838 | Media type structure (typo fix) |

### URL Updates

All `tools.ietf.org` URLs have been updated to `datatracker.ietf.org/doc/html`, which is the current canonical location for IETF RFC documents.

### Files Modified

- `docs/ext/rfc.py` — Updated docstring example and template URL
- - `docs/user/tutorial.rst` — Updated RFC 7231/5789 to RFC 9110/9111
- - `docs/user/faq.rst` — Updated RFC 7540 to RFC 9113, fixed tools.ietf.org URLs
- - `docs/api/cookies.rst` — Updated tools.ietf.org to datatracker.ietf.org
- - `docs/api/websocket.rst` — Updated tools.ietf.org to datatracker.ietf.org
- - `docs/user/recipes/multipart-mixed.rst` — Updated tools.ietf.org URLs
- - `docs/user/recipes/output-csv.rst` — Updated tools.ietf.org URL
- - `docs/user/recipes/pretty-json.rst` — Fixed RFC 6836 to RFC 6838 typo, updated URL
- - `docs/changes/3.0.0.rst` — Updated tools.ietf.org URL
## Note

This is my first contribution to the Falcon project. I am a B.Tech CS student and Python backend developer looking to get involved in the community. Please let me know if any changes are needed!

Resolves #2525