### PR TITLE
docs: update references to obsolete RFCs

### DIFF
--- a/docs/_newsfragments/2525.misc.rst
+++ b/docs/_newsfragments/2525.misc.rst
@@ -1,0 +1,7 @@
+References to obsolete RFCs in docstrings, comments and documentation have been
+updated to their current replacements, most notably the RFC 723x series, which
+is now superseded by RFC 9110 (HTTP Semantics), RFC 9111 (HTTP Caching) and
+RFC 9112 (HTTP/1.1). Section numbers were remapped individually, which also
+corrected the section references of :class:`~falcon.HTTPForbidden` and
+:class:`~falcon.HTTPNotFound`, as these two had been citing each other's
+sections.

--- a/docs/ext/rfc.py
+++ b/docs/ext/rfc.py
@@ -17,7 +17,7 @@
 This extensions adds hyperlinking for any RFC references that are
 formatted like this::
 
-    RFC 7231; Section 6.5.3
+    RFC 9110, Section 15.5.4
 """
 
 import re

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -1092,8 +1092,8 @@ Note that this question only applies to the WSGI flavor of Falcon. The
 requires HTTP header names to be lowercased.
 
 Furthermore, the HTTP2 standard also mandates that header field names MUST be
-converted to lowercase (see `RFC 7540, Section 8.1.2
-<https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2>`_).
+converted to lowercase (see `RFC 9113, Section 8.2.1
+<https://httpwg.org/specs/rfc9113.html#rfc.section.8.2.1>`_).
 
 .. _faq_static_files:
 

--- a/docs/user/recipes/pretty-json.rst
+++ b/docs/user/recipes/pretty-json.rst
@@ -36,7 +36,7 @@ express resource representation preferences. Although not a part of the
 REST Framework) and services support requesting a specific JSON indentation
 level using the ``indent`` content-type parameter. This recipe leaves the
 interpretation to the reader as to whether such a parameter adds "new
-functionality" as per `RFC 6836, Section 4.3
+functionality" as per `RFC 6838, Section 4.3
 <https://tools.ietf.org/html/rfc6838#section-4.3>`_.
 
 Assuming we want to add JSON ``indent`` support to a Falcon app, this can be

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -265,7 +265,7 @@ HTTP methods, lowercased (e.g., ``on_get()``, ``on_put()``,
 
 .. note::
     Supported HTTP methods are those specified in
-    `RFC 7231 <https://tools.ietf.org/html/rfc7231>`_ and
+    `RFC 9110 <https://tools.ietf.org/html/rfc9110>`_ and
     `RFC 5789 <https://tools.ietf.org/html/rfc5789>`_. This includes
     GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, and PATCH.
 

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -36,7 +36,7 @@ def _header_property(header_name: str) -> Any:
     def fget(self: Request) -> str | None:
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
+            #   RFC 9110, Section 5.5; and to strive for maximum
             #   compatibility with WSGI.
             return self._asgi_headers[header_bytes].decode('latin1') or None
         except KeyError:

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -356,7 +356,7 @@ class Response(response.Response):
 
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
+            #   RFC 9110, Section 5.5; and to strive for maximum
             #   compatibility with WSGI.
 
             # PERF(vytas): On CPython, _encode_items_to_latin1 is implemented

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -55,7 +55,7 @@ TRUE_STRINGS = frozenset(['true', 'True', 't', 'yes', 'y', '1', 'on'])
 FALSE_STRINGS = frozenset(['false', 'False', 'f', 'no', 'n', '0', 'off'])
 """Similar to :attr:`TRUE_STRINGS`, the values corresponding to boolean ``False``."""
 
-# RFC 7231, 5789 methods
+# RFC 9110, 5789 methods
 HTTP_METHODS = [
     'CONNECT',
     'DELETE',
@@ -73,7 +73,7 @@ HTTP_WG_DRAFT_METHODS = [
     'QUERY',
 ]
 
-# RFC 2518 and 4918 methods
+# RFC 4918 and 3253 methods
 WEBDAV_METHODS = [
     'CHECKIN',
     'CHECKOUT',
@@ -110,7 +110,7 @@ COMBINED_METHODS = (
     + _META_METHODS
 )
 
-# NOTE(kgriffs): According to RFC 7159, most JSON parsers assume
+# NOTE(kgriffs): According to RFC 8259, most JSON parsers assume
 # UTF-8 and so it is the recommended default charset going forward,
 # and indeed, other charsets should not be specified to ensure
 # maximum interoperability.

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -233,7 +233,7 @@ class HTTPBadRequest(HTTPError):
     syntax, invalid request message framing, or deceptive request
     routing).
 
-    (See also: RFC 7231, Section 6.5.1)
+    (See also: RFC 9110, Section 15.5.1)
 
     All the arguments are defined as keyword-only.
 
@@ -303,7 +303,7 @@ class HTTPUnauthorized(HTTPError):
     SHOULD present the enclosed representation to the user, since it
     usually contains relevant diagnostic information.
 
-    (See also: RFC 7235, Section 3.1)
+    (See also: RFC 9110, Section 15.5.2)
 
     All the arguments are defined as keyword-only.
 
@@ -335,7 +335,7 @@ class HTTPUnauthorized(HTTPError):
                 The existing value of the WWW-Authenticate in headers will be
                 overridden by this value
 
-            (See also: RFC 7235, Section 2.1)
+            (See also: RFC 9110, Section 11.3)
         href (str): A URL someone can visit to find out more information
             (default ``None``). Unicode characters are percent-encoded.
         href_text (str): If href is given, use this as the friendly
@@ -388,7 +388,7 @@ class HTTPForbidden(HTTPError):
     forbidden target resource MAY instead respond with a status code of
     404 Not Found.
 
-    (See also: RFC 7231, Section 6.5.4)
+    (See also: RFC 9110, Section 15.5.4)
 
     All the arguments are defined as keyword-only.
 
@@ -454,7 +454,7 @@ class HTTPNotFound(HTTPError):
     A 404 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.3)
+    (See also: RFC 9110, Section 15.5.5)
 
     All the arguments are defined as keyword-only.
 
@@ -565,7 +565,7 @@ class HTTPMethodNotAllowed(HTTPError):
     A 405 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.5)
+    (See also: RFC 9110, Section 15.5.6)
 
     `allowed_methods` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -644,9 +644,9 @@ class HTTPNotAcceptable(HTTPError):
     most appropriate. A user agent MAY automatically select the most
     appropriate choice from that list. However, this specification does
     not define any standard for such automatic selection, as described
-    in RFC 7231, Section 6.4.1
+    in RFC 9110, Section 15.4.1
 
-    (See also: RFC 7231, Section 6.5.6)
+    (See also: RFC 9110, Section 15.5.7)
 
     All the arguments are defined as keyword-only.
 
@@ -715,7 +715,7 @@ class HTTPConflict(HTTPError):
     case, the response representation would likely contain information
     useful for merging the differences based on the revision history.
 
-    (See also: RFC 7231, Section 6.5.8)
+    (See also: RFC 9110, Section 15.5.10)
 
     All the arguments are defined as keyword-only.
 
@@ -789,7 +789,7 @@ class HTTPGone(HTTPError):
     A 410 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.9)
+    (See also: RFC 9110, Section 15.5.11)
 
     All the arguments are defined as keyword-only.
 
@@ -852,7 +852,7 @@ class HTTPLengthRequired(HTTPError):
     header field containing the length of the message body in the
     request message.
 
-    (See also: RFC 7231, Section 6.5.10)
+    (See also: RFC 9110, Section 15.5.12)
 
     All the arguments are defined as keyword-only.
 
@@ -914,7 +914,7 @@ class HTTPPreconditionFailed(HTTPError):
     and, thus, prevent the request method from being applied if the
     target resource is in an unexpected state.
 
-    (See also: RFC 7232, Section 4.2)
+    (See also: RFC 9110, Section 15.5.13)
 
     All the arguments are defined as keyword-only.
 
@@ -978,7 +978,7 @@ class HTTPContentTooLarge(HTTPError):
     After header field to indicate that it is temporary and after what
     time the client MAY try again.
 
-    (See also: RFC 7231, Section 6.5.11)
+    (See also: RFC 9110, Section 15.5.14)
 
     All the arguments are defined as keyword-only.
 
@@ -1067,7 +1067,7 @@ class HTTPUriTooLong(HTTPError):
     A 414 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.12)
+    (See also: RFC 9110, Section 15.5.15)
 
     All the arguments are defined as keyword-only.
 
@@ -1129,7 +1129,7 @@ class HTTPUnsupportedMediaType(HTTPError):
     Type or Content-Encoding, or as a result of inspecting the data
     directly.
 
-    (See also: RFC 7231, Section 6.5.13)
+    (See also: RFC 9110, Section 15.5.16)
 
     All the arguments are defined as keyword-only.
 
@@ -1195,7 +1195,7 @@ class HTTPRangeNotSatisfiable(HTTPError):
     sender SHOULD generate a Content-Range header field specifying the
     current length of the selected representation.
 
-    (See also: RFC 7233, Section 4.4)
+    (See also: RFC 9110, Section 15.5.17)
 
     `resource_length` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -1721,7 +1721,7 @@ class HTTPInternalServerError(HTTPError):
     The server encountered an unexpected condition that prevented it
     from fulfilling the request.
 
-    (See also: RFC 7231, Section 6.6.1)
+    (See also: RFC 9110, Section 15.6.1)
 
     All the arguments are defined as keyword-only.
 
@@ -1783,9 +1783,9 @@ class HTTPNotImplemented(HTTPError):
 
     A 501 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls
-    as described in RFC 7234, Section 4.2.2.
+    as described in RFC 9111, Section 4.2.2.
 
-    (See also: RFC 7231, Section 6.6.2)
+    (See also: RFC 9110, Section 15.6.2)
 
     All the arguments are defined as keyword-only.
 
@@ -1845,7 +1845,7 @@ class HTTPBadGateway(HTTPError):
     response from an inbound server it accessed while attempting to
     fulfill the request.
 
-    (See also: RFC 7231, Section 6.6.3)
+    (See also: RFC 9110, Section 15.6.3)
 
     All the arguments are defined as keyword-only.
 
@@ -1911,7 +1911,7 @@ class HTTPServiceUnavailable(HTTPError):
     server has to use it when becoming overloaded. Some servers might
     simply refuse the connection.
 
-    (See also: RFC 7231, Section 6.6.4)
+    (See also: RFC 9110, Section 15.6.4)
 
     All the arguments are defined as keyword-only.
 
@@ -1979,7 +1979,7 @@ class HTTPGatewayTimeout(HTTPError):
     from an upstream server it needed to access in order to complete the
     request.
 
-    (See also: RFC 7231, Section 6.6.5)
+    (See also: RFC 9110, Section 15.6.5)
 
     All the arguments are defined as keyword-only.
 
@@ -2037,13 +2037,13 @@ class HTTPVersionNotSupported(HTTPError):
     server does not support, or refuses to support, the major version of
     HTTP that was used in the request message.  The server is indicating
     that it is unable or unwilling to complete the request using the same
-    major version as the client (as described in RFC 7230, Section 2.6),
+    major version as the client (as described in RFC 9110, Section 2.5),
     other than with this error message.  The server SHOULD
     generate a representation for the 505 response that describes why
     that version is not supported and what other protocols are supported
     by that server.
 
-    (See also: RFC 7231, Section 6.6.6)
+    (See also: RFC 9110, Section 15.6.6)
 
     All the arguments are defined as keyword-only.
 

--- a/falcon/forwarded.py
+++ b/falcon/forwarded.py
@@ -152,7 +152,7 @@ def _parse_forwarded_header(forwarded: str) -> list[Forwarded]:
                 elif name == 'proto':
                     # NOTE(kgriffs): RFC 7239 only requires that
                     # the "proto" value conform to the Host ABNF
-                    # described in RFC 7230. The Host ABNF, in turn,
+                    # described in RFC 9110. The Host ABNF, in turn,
                     # does not require that the scheme be in any
                     # particular case, so we normalize it here to be
                     # consistent with the WSGI spec that *does*

--- a/falcon/media/multipart.py
+++ b/falcon/media/multipart.py
@@ -59,7 +59,7 @@ _ALLOWED_CONTENT_HEADERS = frozenset(
     ]
 )
 
-_FILENAME_STAR_RFC5987 = re.compile(r"([\w-]+)'[\w]*'(.+)")
+_FILENAME_STAR_RFC8187 = re.compile(r"([\w-]+)'[\w]*'(.+)")
 
 _CRLF = b'\r\n'
 _CRLF_CRLF = _CRLF + _CRLF
@@ -202,9 +202,9 @@ class BodyPart:
 
             _, params = self._content_disposition
 
-            # NOTE(vytas): Supporting filename* as per RFC 5987, as that has
+            # NOTE(vytas): Supporting filename* as per RFC 8187, as that has
             #   been spotted in the wild, even though RFC 7578 forbids it.
-            match = _FILENAME_STAR_RFC5987.match(params.get('filename*', ''))
+            match = _FILENAME_STAR_RFC8187.match(params.get('filename*', ''))
             if match:
                 charset, filename_raw = match.groups()
                 try:

--- a/falcon/redirects.py
+++ b/falcon/redirects.py
@@ -36,7 +36,7 @@ class HTTPMovedPermanently(HTTPStatus):
         behavior is undesired, the 308 (Permanent Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.2)
+    (See also: RFC 9110, Section 15.4.2)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -67,7 +67,7 @@ class HTTPFound(HTTPStatus):
         behavior is undesired, the 307 (Temporary Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.3)
+    (See also: RFC 9110, Section 15.4.3)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -103,7 +103,7 @@ class HTTPSeeOther(HTTPStatus):
         The new URI in the Location header field is not considered
         equivalent to the effective request URI.
 
-    (See also: RFC 7231, Section 6.4.4)
+    (See also: RFC 9110, Section 15.4.4)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -134,7 +134,7 @@ class HTTPTemporaryRedirect(HTTPStatus):
         This status code is similar to 302 (Found), except that it
         does not allow changing the request method from POST to GET.
 
-    (See also: RFC 7231, Section 6.4.7)
+    (See also: RFC 9110, Section 15.4.8)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -162,7 +162,7 @@ class HTTPPermanentRedirect(HTTPStatus):
         that it does not allow changing the request method from POST to
         GET.
 
-    (See also: RFC 7238, Section 3)
+    (See also: RFC 9110, Section 15.4.9)
 
     Args:
         location (str): URI to provide as the Location header in the

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -333,7 +333,7 @@ class Request:
             # NOTE(kgriffs): Within HTTP, a payload for a GET or HEAD
             # request has no defined semantics, so we don't expect a
             # body in those cases. We would normally not expect a body
-            # for OPTIONS either, but RFC 7231 does allow for it.
+            # for OPTIONS either, but RFC 9110 does allow for it.
             self.method not in ('GET', 'HEAD')
         ):
             self._parse_form_urlencoded()
@@ -495,7 +495,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.1)
+        (See also: RFC 9110, Section 13.1.1)
         """  # noqa: D205
         # TODO(kgriffs): It may make sense at some point to create a
         #   header property generator that DRY's up the memoization
@@ -519,7 +519,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.2)
+        (See also: RFC 9110, Section 13.1.2)
         """  # noqa: D205
         if self._cached_if_none_match is _UNSET:
             header_value = self.env.get('HTTP_IF_NONE_MATCH')
@@ -608,7 +608,7 @@ class Request:
         except ValueError:
             href = 'https://tools.ietf.org/html/rfc7233'
             href_text = 'HTTP/1.1 Range Requests'
-            msg = 'It must be a range formatted according to RFC 7233.'
+            msg = 'It must be a range formatted according to RFC 9110.'
             raise errors.HTTPInvalidHeader(msg, 'Range', href=href, href_text=href_text)
 
     @property
@@ -1427,7 +1427,7 @@ class Request:
                 ``HTTPBadRequest`` instead of returning gracefully when the
                 header is not found (default ``False``).
             obs_date (bool): Support obs-date formats according to
-                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT"
+                RFC 9110, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT"
                 (default ``False``).
 
         Returns:
@@ -1451,7 +1451,7 @@ class Request:
             else:
                 return None
         except ValueError:
-            msg = 'It must be formatted according to RFC 7231, Section 7.1.1.1'
+            msg = 'It must be formatted according to RFC 9110, Section 5.6.7'
             raise errors.HTTPInvalidHeader(msg, header)
 
     def get_cookie_values(self, name: str) -> list[str] | None:
@@ -1858,7 +1858,7 @@ class Request:
         """Return the value of a query string parameter as an UUID.
 
         The value to convert must conform to the standard UUID string
-        representation per RFC 4122. For example, the following
+        representation per RFC 9562. For example, the following
         strings are all valid::
 
             # Lowercase

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -135,7 +135,7 @@ def _parse_etags(etag_str: str) -> list[ETag | Literal['*']] | None:
     ETags. The string may also contain a '*' character, in order to indicate
     that any ETag should match the precondition.
 
-    (See also: RFC 7232, Section 3)
+    (See also: RFC 9110, Section 13.1)
 
     Args:
         etag_str (str): An ASCII header value to parse ETags from. ETag values

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -886,7 +886,7 @@ class Response:
     ) -> None:
         """Append a link header to the response.
 
-        (See also: RFC 5988, Section 1)
+        (See also: RFC 8288, Section 1)
 
         Note:
             Calling this method repeatedly will cause each link to be
@@ -935,7 +935,7 @@ class Response:
                 languages.
             type_hint (str): Provides a hint as to the media type of the
                 result of dereferencing the link (default ``None``). As noted
-                in RFC 5988, this is only a hint and does not override the
+                in RFC 8288, this is only a hint and does not override the
                 Content-Type header returned when the link is followed.
             crossorigin (str):  Determines how cross origin requests are handled.
                 Can take values 'anonymous' or 'use-credentials' or None.
@@ -1105,7 +1105,7 @@ class Response:
             case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
             thing.
 
-        (See also: RFC 7233, Section 4.2)
+        (See also: RFC 9110, Section 14.4)
         """,
         _format_range,
     )
@@ -1123,7 +1123,7 @@ class Response:
         case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
         thing.
 
-    (See also: RFC 7233, Section 4.2)
+    (See also: RFC 9110, Section 14.4)
     """
 
     content_type: str | None = _header_property(
@@ -1299,7 +1299,7 @@ class Response:
         value consists of either a single asterisk ("*") or a list of
         header field names (case-insensitive).
 
-        (See also: RFC 7231, Section 7.1.4)
+        (See also: RFC 9110, Section 12.5.5)
         """,
         _format_header_value_list,
     )
@@ -1316,7 +1316,7 @@ class Response:
     value consists of either a single asterisk ("*") or a list of
     header field names (case-insensitive).
 
-    (See also: RFC 7231, Section 7.1.4)
+    (See also: RFC 9110, Section 12.5.5)
     """
 
     accept_ranges: str | None = _header_property(

--- a/falcon/routing/converters.py
+++ b/falcon/routing/converters.py
@@ -211,7 +211,7 @@ class UUIDConverter(BaseConverter):
     Identifier: `uuid`
 
     In order to be converted, the field value must consist of a
-    string of 32 hexadecimal digits, as defined in RFC 4122, Section 3.
+    string of 32 hexadecimal digits, as defined in RFC 9562, Section 4.
     Note, however, that hyphens and the URN prefix are optional.
     """
 

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -552,7 +552,7 @@ def simulate_request(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -827,7 +827,7 @@ async def _simulate_request_asgi(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1382,7 +1382,7 @@ def simulate_get(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1485,7 +1485,7 @@ def simulate_head(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1583,7 +1583,7 @@ def simulate_post(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1701,7 +1701,7 @@ def simulate_put(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1814,7 +1814,7 @@ def simulate_options(app: Callable[..., Any], path: str, **kwargs: Any) -> Resul
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -1908,7 +1908,7 @@ def simulate_patch(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:
@@ -2021,7 +2021,7 @@ def simulate_delete(app: Callable[..., Any], path: str, **kwargs: Any) -> Result
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -926,7 +926,7 @@ def create_scope(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110, Section 5.3). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1069,7 +1069,7 @@ def create_scope_ws(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110, Section 5.3). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1166,7 +1166,7 @@ def create_environ(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110, Section 5.3). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -181,7 +181,7 @@ def http_date_to_dt(http_date: str, obs_date: bool = False) -> datetime.datetime
 
     Keyword Arguments:
         obs_date (bool): Support obs-date formats according to
-            RFC 7231, e.g.:
+            RFC 9110, e.g.:
             "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
     Returns:

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -237,7 +237,7 @@ class ETag(str):
 
     This class is simply a subclass of ``str`` with a few helper methods and
     an extra attribute to indicate whether the entity-tag is weak or strong. The
-    value of the string is equivalent to what RFC 7232 calls an "opaque-tag",
+    value of the string is equivalent to what RFC 9110 calls an "opaque-tag",
     i.e. an entity-tag sans quotes and the weakness indicator.
 
     Note:
@@ -261,7 +261,7 @@ class ETag(str):
             resp.etag = content_etag
             resp.status = falcon.HTTP_200
 
-    (See also: RFC 7232)
+    (See also: RFC 9110, Section 8.8.3)
     """
 
     is_weak: bool = False
@@ -273,7 +273,7 @@ class ETag(str):
         Two entity-tags are equivalent if both are not weak and their
         opaque-tags match character-by-character.
 
-        (See also: RFC 7232, Section 2.3.2)
+        (See also: RFC 9110, Section 8.8.3.2)
 
         Arguments:
             other (ETag): The other :class:`~.ETag` to which you are comparing
@@ -289,7 +289,7 @@ class ETag(str):
     def dumps(self) -> str:
         """Serialize the ETag to a string suitable for use in a precondition header.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Returns:
             str: An opaque quoted string, possibly prefixed by a weakness
@@ -313,11 +313,11 @@ class ETag(str):
             entity-tag. It can not be used to parse a comma-separated list of
             values.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Arguments:
             etag_str (str): An ASCII string representing a single entity-tag,
-                as defined by RFC 7232.
+                as defined by RFC 9110.
 
         Returns:
             ETag: An instance of `~.ETag` representing the parsed entity-tag.

--- a/falcon/util/uri.py
+++ b/falcon/util/uri.py
@@ -531,7 +531,7 @@ def parse_host(host: str, default_port: int | None = None) -> tuple[str, int | N
 
 
 def unquote_string(quoted: str) -> str:
-    """Unquote an RFC 7320 "quoted-string".
+    """Unquote an RFC 9110 "quoted-string".
 
     Args:
         quoted (str): Original quoted string
@@ -552,7 +552,7 @@ def unquote_string(quoted: str) -> str:
     tmp_quoted = quoted[1:-1]
 
     # PERF(philiptzou): Most header strings don't contain "quoted-pair" which
-    # defined by RFC 7320. We use this little trick (quick string search) to
+    # defined by RFC 9110. We use this little trick (quick string search) to
     # speed up string parsing by preventing unnecessary processes if possible.
     if '\\' not in tmp_quoted:
         return tmp_quoted

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -8,7 +8,7 @@ import falcon
 import falcon.constants
 import falcon.testing as testing
 
-# RFC 7231, 5789 methods
+# RFC 9110, 5789 methods
 HTTP_METHODS = [
     'CONNECT',
     'DELETE',
@@ -22,7 +22,7 @@ HTTP_METHODS = [
     'QUERY',
 ]
 
-# RFC 2518 and 4918 methods
+# RFC 4918 and 3253 methods
 WEBDAV_METHODS = [
     'CHECKIN',
     'CHECKOUT',

--- a/tests/test_mediatypes.py
+++ b/tests/test_mediatypes.py
@@ -158,7 +158,7 @@ def test_quality_rfc_examples(accept, media_type, quality_value):
             0.33,
         ),
         (
-            # NOTE(vytas): Same as one of the RFC 7231 examples, just with some
+            # NOTE(vytas): Same as one of the RFC 9110 examples, just with some
             #   media ranges reordered. python-mimeparse fails to yield the
             #   correct result in this specific case.
             'text/*;q=0.3, text/html;level=1, text/html;q=0.7, '

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -615,7 +615,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "Range" header is '
             'invalid. It must be a range formatted '
-            'according to RFC 7233.'
+            'according to RFC 9110.'
         )
         self._test_error_details(
             headers,
@@ -734,7 +734,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "{}" '
             'header is invalid. It must be formatted '
-            'according to RFC 7231, Section 7.1.1.1'
+            'according to RFC 9110, Section 5.6.7'
         )
 
         self._test_error_details(
@@ -974,7 +974,7 @@ class TestRequestAttributes:
                     ETag('F9,22'),
                     _make_etag('41, 7F'),
                     _make_etag('22, 41, 7F', is_weak=True),
-                    # NOTE(kgriffs): According to the grammar in RFC 7232, zero
+                    # NOTE(kgriffs): According to the grammar in RFC 9110, zero
                     #  etagc's is acceptable.
                     _make_etag(''),
                     _make_etag('', is_weak=True),


### PR DESCRIPTION
The RFC 723x series has been obsoleted by RFC 9110 for HTTP semantics, RFC 9111 for caching and RFC 9112 for HTTP 1.1. This updates the references in docstrings, comments and the user guide, remapping each section number individually rather than mechanically.

While mapping the status code sections, HTTPForbidden and HTTPNotFound turned out to have their sections swapped, since RFC 7231, Section 6.5.3 is 403 and Section 6.5.4 is 404. Both now point at the correct RFC 9110 sections.

Other obsolete references are updated as well, RFC 5987 to RFC 8187, RFC 5988 to RFC 8288, RFC 7159 to RFC 8259, RFC 7540 to RFC 9113, RFC 4122 to RFC 9562, and RFC 2518 to RFC 4918 and RFC 3253, which is where the listed WebDAV methods are actually defined.

Two typos are corrected. The quoted string helper in falcon.uri cited RFC 7320, which covers URI design and ownership, rather than the HTTP message syntax. The pretty JSON recipe spelled RFC 6838 as RFC 6836 even though it already linked to the former.

References that describe history are left alone, such as the notes on RFC 1867, RFC 2109 and RFC 2616, as are the entries in the changelog archive.

The full test suite passes and the docs build without warnings. Fixes #2525.