### PR TITLE
feat(routing): add regex converter support in routing

### DIFF
--- a/docs/_newsfragments/857.newandimproved.rst
+++ b/docs/_newsfragments/857.newandimproved.rst
@@ -1,0 +1,1 @@
+New `RegexConverter` has been added to support regex based path variable matching when registering new routes. The newly added converter has been added as a builtin converter.

--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -295,6 +295,7 @@ Built-in Converters
  ``dt``        :class:`~.DateTimeConverter`       ``/logs/{day:dt("%Y-%m-%d")}``
  ``float``     :class:`~.FloatConverter`          ``/python/versions/{version:float(min=3.7)}``
  ``path``      :class:`~.PathConverter`           ``/prefix/{other:path}``
+ ``regex``     :class:`~.RegexConverter`          ``/prefix/{name:regex([a-zA-z])}``
 ============  =================================  ==================================================================
 
 |
@@ -312,6 +313,9 @@ Built-in Converters
     :members:
 
 .. autoclass:: falcon.routing.PathConverter
+    :members:
+
+.. autoclass:: falcon.routing.RegexConverter
     :members:
 
 .. _routing_custom_converters:

--- a/falcon/routing/__init__.py
+++ b/falcon/routing/__init__.py
@@ -26,6 +26,7 @@ from falcon.routing.converters import DateTimeConverter
 from falcon.routing.converters import FloatConverter
 from falcon.routing.converters import IntConverter
 from falcon.routing.converters import PathConverter
+from falcon.routing.converters import RegexConverter
 from falcon.routing.converters import UUIDConverter
 from falcon.routing.static import StaticRoute
 from falcon.routing.static import StaticRouteAsync
@@ -43,6 +44,7 @@ __all__ = (
     'IntConverter',
     'map_http_methods',
     'PathConverter',
+    'RegexConverter',
     'set_default_responders',
     'StaticRoute',
     'StaticRouteAsync',

--- a/falcon/routing/converters.py
+++ b/falcon/routing/converters.py
@@ -26,6 +26,7 @@ __all__ = (
     'FloatConverter',
     'IntConverter',
     'PathConverter',
+    'RegexConverter',
     'UUIDConverter',
 )
 
@@ -249,10 +250,40 @@ class PathConverter(BaseConverter):
         return '/'.join(value)
 
 
+class RegexConverter(BaseConverter):
+    """Field converter used to match a field value against a regular expression.
+
+    Identifier: `regex`
+
+    Keyword Args:
+        pattern (str): A regex pattern that the value must match.
+            The entire value must match (anchored).
+    """
+
+    __slots__ = ('_pattern', '_compiled')
+
+    def __init__(self, pattern: str) -> None:
+        import re
+
+        self._pattern = pattern
+        try:
+            self._compiled = re.compile(pattern)
+        except re.error as ex:
+            raise ValueError(
+                f'invalid regex pattern for RegexConverter: {pattern!r} ({ex})'
+            ) from ex
+
+    def convert(self, value: str) -> str | None:
+        if self._compiled.fullmatch(value):
+            return value
+        return None
+
+
 BUILTIN = (
     ('int', IntConverter),
     ('dt', DateTimeConverter),
     ('uuid', UUIDConverter),
     ('float', FloatConverter),
     ('path', PathConverter),
+    ('regex', RegexConverter),
 )

--- a/falcon/routing/converters.py
+++ b/falcon/routing/converters.py
@@ -17,6 +17,7 @@ import abc
 from collections.abc import Iterable
 from datetime import datetime
 from math import isfinite
+import re
 from typing import Any, ClassVar, overload
 import uuid
 
@@ -263,8 +264,6 @@ class RegexConverter(BaseConverter):
     __slots__ = ('_pattern', '_compiled')
 
     def __init__(self, pattern: str) -> None:
-        import re
-
         self._pattern = pattern
         try:
             self._compiled = re.compile(pattern)

--- a/tests/test_uri_converters.py
+++ b/tests/test_uri_converters.py
@@ -180,3 +180,36 @@ def test_datetime_converter_default_format():
 def test_uuid_converter(value, expected):
     c = converters.UUIDConverter()
     assert c.convert(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value, pattern, expected',
+    [
+        ('abc', r'abc', 'abc'),
+        ('abc', r'[a-z]+', 'abc'),
+        ('123', r'\d+', '123'),
+        ('abc123', r'[a-z]+\d+', 'abc123'),
+        ('', r'', ''),
+        ('a', r'.', 'a'),
+        ('2023-01-15', r'\d{4}-\d{2}-\d{2}', '2023-01-15'),
+        ('foo_bar', r'\w+', 'foo_bar'),
+    ],
+)
+def test_regex_converter(value, pattern, expected):
+    c = converters.RegexConverter(pattern)
+    assert c.convert(value) == expected
+
+
+@pytest.mark.parametrize(
+    'value, pattern',
+    [
+        ('abc', r'\d+'),
+        ('123', r'[a-z]+'),
+        (' abc', r'abc'),
+        ('ABC', r'[a-z]+'),
+        ('', r'\d+'),
+    ],
+)
+def test_regex_converter_no_match(value, pattern):
+    c = converters.RegexConverter(pattern)
+    assert c.convert(value) is None

--- a/tests/test_uri_converters.py
+++ b/tests/test_uri_converters.py
@@ -213,3 +213,30 @@ def test_regex_converter(value, pattern, expected):
 def test_regex_converter_no_match(value, pattern):
     c = converters.RegexConverter(pattern)
     assert c.convert(value) is None
+
+
+@pytest.mark.parametrize(
+        "pattern",
+        [
+            "[",              # unterminated character set
+            "(",              # unterminated group
+            "*",              # nothing to repeat
+            "(?P<name>",      # unterminated named group
+            "a{2,1}",         # min repeat greater than max
+            "(?P<1invalid>x)",# invalid group name
+            "\\",             # trailing backslash
+        ],
+    )
+def test_regex_converter_invalid_pattern_raises_value_error(pattern):
+    with pytest.raises(ValueError, match=r'invalid regex pattern for RegexConverter'):
+        converters.RegexConverter(pattern)
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    ['[', '(', '*'],
+)
+def test_regex_converter_invalid_pattern_error_message_includes_pattern(pattern):
+    with pytest.raises(ValueError) as exc_info:
+        converters.RegexConverter(pattern)
+    assert repr(pattern) in str(exc_info.value)

--- a/tests/test_uri_converters.py
+++ b/tests/test_uri_converters.py
@@ -216,23 +216,6 @@ def test_regex_converter_no_match(value, pattern):
 
 
 @pytest.mark.parametrize(
-        "pattern",
-        [
-            "[",              # unterminated character set
-            "(",              # unterminated group
-            "*",              # nothing to repeat
-            "(?P<name>",      # unterminated named group
-            "a{2,1}",         # min repeat greater than max
-            "(?P<1invalid>x)",# invalid group name
-            "\\",             # trailing backslash
-        ],
-    )
-def test_regex_converter_invalid_pattern_raises_value_error(pattern):
-    with pytest.raises(ValueError, match=r'invalid regex pattern for RegexConverter'):
-        converters.RegexConverter(pattern)
-
-
-@pytest.mark.parametrize(
     'pattern',
     ['[', '(', '*'],
 )
@@ -240,3 +223,20 @@ def test_regex_converter_invalid_pattern_error_message_includes_pattern(pattern)
     with pytest.raises(ValueError) as exc_info:
         converters.RegexConverter(pattern)
     assert repr(pattern) in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    [
+        '[',
+        '(',
+        '*',
+        '(?P<name>',
+        'a{2,1}',
+        '(?P<1invalid>x)',
+        '\\',
+    ],
+)
+def test_regex_converter_invalid_pattern_raises_value_error(pattern):
+    with pytest.raises(ValueError, match=r'invalid regex pattern for RegexConverter'):
+        converters.RegexConverter(pattern)


### PR DESCRIPTION
Add new builtin-converter RegexConverter to allow regex pattern matching when adding routes.

Closes #857

# Summary of Changes

Add Regular Expression route conversion support

# Related Issues

Closes #857 

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [x] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e docs`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

This is my first PR in this repo and I might not be entirely sure how to change the documentations. 

*PR template inspired by the attrs project.*
