### PR TITLE
docs: update obsolete RFC citations to RFC 9110, 9111, and 9112

### DIFF
--- a/docs/_newsfragments/2525.misc.rst
+++ b/docs/_newsfragments/2525.misc.rst
@@ -1,0 +1,2 @@
+Citations of obsolete HTTP specifications (RFC 2616 and RFC 7230–7235) have been
+updated to the current HTTP standards (RFC 9110, RFC 9111, and RFC 9112).

--- a/docs/ext/rfc.py
+++ b/docs/ext/rfc.py
@@ -17,7 +17,7 @@
 This extensions adds hyperlinking for any RFC references that are
 formatted like this::
 
-    RFC 7231; Section 6.5.3
+    RFC 9110, Section 15.5.4
 """
 
 import re

--- a/docs/user/tutorial.rst
+++ b/docs/user/tutorial.rst
@@ -265,8 +265,8 @@ HTTP methods, lowercased (e.g., ``on_get()``, ``on_put()``,
 
 .. note::
     Supported HTTP methods are those specified in
-    `RFC 7231 <https://tools.ietf.org/html/rfc7231>`_ and
-    `RFC 5789 <https://tools.ietf.org/html/rfc5789>`_. This includes
+    `RFC 9110 <https://datatracker.ietf.org/doc/html/rfc9110>`_ and
+    `RFC 5789 <https://datatracker.ietf.org/doc/html/rfc5789>`_. This includes
     GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, and PATCH.
 
 We call these well-known methods "responders". Each responder takes (at

--- a/falcon/app.py
+++ b/falcon/app.py
@@ -517,9 +517,9 @@ class App(Generic[_ReqT, _RespT]):
             # assumption _TYPELESS_STATUS_CODES <= _BODILESS_STATUS_CODES.
 
             # NOTE(kgriffs): Based on wsgiref.validate's interpretation of
-            # RFC 2616, as commented in that module's source code. The
-            # presence of the Content-Length header is not similarly
-            # enforced.
+            # RFC 2616 (superseded by RFC 9110), as commented in that module's
+            # source code. The presence of the Content-Length header is not
+            # similarly enforced.
             if resp_status in _TYPELESS_STATUS_CODES:
                 default_media_type = None
             elif (

--- a/falcon/asgi/_request_helpers.py
+++ b/falcon/asgi/_request_helpers.py
@@ -36,8 +36,8 @@ def _header_property(header_name: str) -> Any:
     def fget(self: Request) -> str | None:
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
-            #   compatibility with WSGI.
+            #   RFC 9112, Section 5.2 (and RFC 9110, Section 5.5); and to
+            #   strive for maximum compatibility with WSGI.
             return self._asgi_headers[header_bytes].decode('latin1') or None
         except KeyError:
             return None

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -662,9 +662,9 @@ class App(falcon.app.App[_ReqT, _RespT]):
             # assumption _TYPELESS_STATUS_CODES <= _BODILESS_STATUS_CODES.
             #
             # NOTE(kgriffs): Based on wsgiref.validate's interpretation of
-            # RFC 2616, as commented in that module's source code. The
-            # presence of the Content-Length header is not similarly
-            # enforced.
+            # RFC 2616 (superseded by RFC 9110), as commented in that module's
+            # source code. The presence of the Content-Length header is not
+            # similarly enforced.
             #
             # NOTE(kgriffs): Assuming the same for ASGI until proven otherwise.
             #

--- a/falcon/asgi/response.py
+++ b/falcon/asgi/response.py
@@ -356,8 +356,8 @@ class Response(response.Response):
 
         try:
             # NOTE(vytas): Supporting ISO-8859-1 for historical reasons as per
-            #   RFC 7230, Section 3.2.4; and to strive for maximum
-            #   compatibility with WSGI.
+            #   RFC 9112, Section 5.2 (and RFC 9110, Section 5.5); and to
+            #   strive for maximum compatibility with WSGI.
 
             # PERF(vytas): On CPython, _encode_items_to_latin1 is implemented
             #   in Cython (with a pure Python fallback), where the resulting

--- a/falcon/constants.py
+++ b/falcon/constants.py
@@ -55,7 +55,7 @@ TRUE_STRINGS = frozenset(['true', 'True', 't', 'yes', 'y', '1', 'on'])
 FALSE_STRINGS = frozenset(['false', 'False', 'f', 'no', 'n', '0', 'off'])
 """Similar to :attr:`TRUE_STRINGS`, the values corresponding to boolean ``False``."""
 
-# RFC 7231, 5789 methods
+# RFC 9110, 5789 methods
 HTTP_METHODS = [
     'CONNECT',
     'DELETE',

--- a/falcon/errors.py
+++ b/falcon/errors.py
@@ -233,7 +233,7 @@ class HTTPBadRequest(HTTPError):
     syntax, invalid request message framing, or deceptive request
     routing).
 
-    (See also: RFC 7231, Section 6.5.1)
+    (See also: RFC 9110, Section 15.5.1)
 
     All the arguments are defined as keyword-only.
 
@@ -303,7 +303,7 @@ class HTTPUnauthorized(HTTPError):
     SHOULD present the enclosed representation to the user, since it
     usually contains relevant diagnostic information.
 
-    (See also: RFC 7235, Section 3.1)
+    (See also: RFC 9110, Section 15.5.2)
 
     All the arguments are defined as keyword-only.
 
@@ -335,7 +335,7 @@ class HTTPUnauthorized(HTTPError):
                 The existing value of the WWW-Authenticate in headers will be
                 overridden by this value
 
-            (See also: RFC 7235, Section 2.1)
+            (See also: RFC 9110, Section 11.6.1)
         href (str): A URL someone can visit to find out more information
             (default ``None``). Unicode characters are percent-encoded.
         href_text (str): If href is given, use this as the friendly
@@ -388,7 +388,7 @@ class HTTPForbidden(HTTPError):
     forbidden target resource MAY instead respond with a status code of
     404 Not Found.
 
-    (See also: RFC 7231, Section 6.5.4)
+    (See also: RFC 9110, Section 15.5.4)
 
     All the arguments are defined as keyword-only.
 
@@ -454,7 +454,7 @@ class HTTPNotFound(HTTPError):
     A 404 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.3)
+    (See also: RFC 9110, Section 15.5.5)
 
     All the arguments are defined as keyword-only.
 
@@ -565,7 +565,7 @@ class HTTPMethodNotAllowed(HTTPError):
     A 405 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.5)
+    (See also: RFC 9110, Section 15.5.6)
 
     `allowed_methods` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -644,9 +644,9 @@ class HTTPNotAcceptable(HTTPError):
     most appropriate. A user agent MAY automatically select the most
     appropriate choice from that list. However, this specification does
     not define any standard for such automatic selection, as described
-    in RFC 7231, Section 6.4.1
+    in RFC 9110, Section 15.4.1
 
-    (See also: RFC 7231, Section 6.5.6)
+    (See also: RFC 9110, Section 15.5.7)
 
     All the arguments are defined as keyword-only.
 
@@ -715,7 +715,7 @@ class HTTPConflict(HTTPError):
     case, the response representation would likely contain information
     useful for merging the differences based on the revision history.
 
-    (See also: RFC 7231, Section 6.5.8)
+    (See also: RFC 9110, Section 15.5.10)
 
     All the arguments are defined as keyword-only.
 
@@ -789,7 +789,7 @@ class HTTPGone(HTTPError):
     A 410 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.9)
+    (See also: RFC 9110, Section 15.5.11)
 
     All the arguments are defined as keyword-only.
 
@@ -852,7 +852,7 @@ class HTTPLengthRequired(HTTPError):
     header field containing the length of the message body in the
     request message.
 
-    (See also: RFC 7231, Section 6.5.10)
+    (See also: RFC 9110, Section 15.5.12)
 
     All the arguments are defined as keyword-only.
 
@@ -914,7 +914,7 @@ class HTTPPreconditionFailed(HTTPError):
     and, thus, prevent the request method from being applied if the
     target resource is in an unexpected state.
 
-    (See also: RFC 7232, Section 4.2)
+    (See also: RFC 9110, Section 15.5.13)
 
     All the arguments are defined as keyword-only.
 
@@ -978,7 +978,7 @@ class HTTPContentTooLarge(HTTPError):
     After header field to indicate that it is temporary and after what
     time the client MAY try again.
 
-    (See also: RFC 7231, Section 6.5.11)
+    (See also: RFC 9110, Section 15.5.14)
 
     All the arguments are defined as keyword-only.
 
@@ -1067,7 +1067,7 @@ class HTTPUriTooLong(HTTPError):
     A 414 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls.
 
-    (See also: RFC 7231, Section 6.5.12)
+    (See also: RFC 9110, Section 15.5.15)
 
     All the arguments are defined as keyword-only.
 
@@ -1129,7 +1129,7 @@ class HTTPUnsupportedMediaType(HTTPError):
     Type or Content-Encoding, or as a result of inspecting the data
     directly.
 
-    (See also: RFC 7231, Section 6.5.13)
+    (See also: RFC 9110, Section 15.5.16)
 
     All the arguments are defined as keyword-only.
 
@@ -1195,7 +1195,7 @@ class HTTPRangeNotSatisfiable(HTTPError):
     sender SHOULD generate a Content-Range header field specifying the
     current length of the selected representation.
 
-    (See also: RFC 7233, Section 4.4)
+    (See also: RFC 9110, Section 15.5.17)
 
     `resource_length` is the only positional argument allowed,
     the other arguments are defined as keyword-only.
@@ -1721,7 +1721,7 @@ class HTTPInternalServerError(HTTPError):
     The server encountered an unexpected condition that prevented it
     from fulfilling the request.
 
-    (See also: RFC 7231, Section 6.6.1)
+    (See also: RFC 9110, Section 15.6.1)
 
     All the arguments are defined as keyword-only.
 
@@ -1783,9 +1783,9 @@ class HTTPNotImplemented(HTTPError):
 
     A 501 response is cacheable by default; i.e., unless otherwise
     indicated by the method definition or explicit cache controls
-    as described in RFC 7234, Section 4.2.2.
+    as described in RFC 9111, Section 5.5.
 
-    (See also: RFC 7231, Section 6.6.2)
+    (See also: RFC 9110, Section 15.6.2)
 
     All the arguments are defined as keyword-only.
 
@@ -1845,7 +1845,7 @@ class HTTPBadGateway(HTTPError):
     response from an inbound server it accessed while attempting to
     fulfill the request.
 
-    (See also: RFC 7231, Section 6.6.3)
+    (See also: RFC 9110, Section 15.6.3)
 
     All the arguments are defined as keyword-only.
 
@@ -1911,7 +1911,7 @@ class HTTPServiceUnavailable(HTTPError):
     server has to use it when becoming overloaded. Some servers might
     simply refuse the connection.
 
-    (See also: RFC 7231, Section 6.6.4)
+    (See also: RFC 9110, Section 15.6.4)
 
     All the arguments are defined as keyword-only.
 
@@ -1979,7 +1979,7 @@ class HTTPGatewayTimeout(HTTPError):
     from an upstream server it needed to access in order to complete the
     request.
 
-    (See also: RFC 7231, Section 6.6.5)
+    (See also: RFC 9110, Section 15.6.5)
 
     All the arguments are defined as keyword-only.
 
@@ -2037,13 +2037,13 @@ class HTTPVersionNotSupported(HTTPError):
     server does not support, or refuses to support, the major version of
     HTTP that was used in the request message.  The server is indicating
     that it is unable or unwilling to complete the request using the same
-    major version as the client (as described in RFC 7230, Section 2.6),
+    major version as the client (as described in RFC 9110, Section 2.5),
     other than with this error message.  The server SHOULD
     generate a representation for the 505 response that describes why
     that version is not supported and what other protocols are supported
     by that server.
 
-    (See also: RFC 7231, Section 6.6.6)
+    (See also: RFC 9110, Section 15.6.6)
 
     All the arguments are defined as keyword-only.
 

--- a/falcon/forwarded.py
+++ b/falcon/forwarded.py
@@ -152,7 +152,7 @@ def _parse_forwarded_header(forwarded: str) -> list[Forwarded]:
                 elif name == 'proto':
                     # NOTE(kgriffs): RFC 7239 only requires that
                     # the "proto" value conform to the Host ABNF
-                    # described in RFC 7230. The Host ABNF, in turn,
+                    # described in RFC 9112 (and RFC 9110). The Host ABNF, in turn,
                     # does not require that the scheme be in any
                     # particular case, so we normalize it here to be
                     # consistent with the WSGI spec that *does*

--- a/falcon/redirects.py
+++ b/falcon/redirects.py
@@ -36,7 +36,7 @@ class HTTPMovedPermanently(HTTPStatus):
         behavior is undesired, the 308 (Permanent Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.2)
+    (See also: RFC 9110, Section 15.4.2)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -67,7 +67,7 @@ class HTTPFound(HTTPStatus):
         behavior is undesired, the 307 (Temporary Redirect) status code
         can be used instead.
 
-    (See also: RFC 7231, Section 6.4.3)
+    (See also: RFC 9110, Section 15.4.3)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -103,7 +103,7 @@ class HTTPSeeOther(HTTPStatus):
         The new URI in the Location header field is not considered
         equivalent to the effective request URI.
 
-    (See also: RFC 7231, Section 6.4.4)
+    (See also: RFC 9110, Section 15.4.4)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -134,7 +134,7 @@ class HTTPTemporaryRedirect(HTTPStatus):
         This status code is similar to 302 (Found), except that it
         does not allow changing the request method from POST to GET.
 
-    (See also: RFC 7231, Section 6.4.7)
+    (See also: RFC 9110, Section 15.4.8)
 
     Args:
         location (str): URI to provide as the Location header in the
@@ -162,7 +162,7 @@ class HTTPPermanentRedirect(HTTPStatus):
         that it does not allow changing the request method from POST to
         GET.
 
-    (See also: RFC 7238, Section 3)
+    (See also: RFC 9110, Section 15.4.9)
 
     Args:
         location (str): URI to provide as the Location header in the

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -333,7 +333,7 @@ class Request:
             # NOTE(kgriffs): Within HTTP, a payload for a GET or HEAD
             # request has no defined semantics, so we don't expect a
             # body in those cases. We would normally not expect a body
-            # for OPTIONS either, but RFC 7231 does allow for it.
+            # for OPTIONS either, but RFC 9110 does allow for it.
             self.method not in ('GET', 'HEAD')
         ):
             self._parse_form_urlencoded()
@@ -495,7 +495,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.1)
+        (See also: RFC 9110, Section 13.1.1)
         """  # noqa: D205
         # TODO(kgriffs): It may make sense at some point to create a
         #   header property generator that DRY's up the memoization
@@ -519,7 +519,7 @@ class Request:
         header, both strong and weak, in the same order as listed in
         the header.
 
-        (See also: RFC 7232, Section 3.2)
+        (See also: RFC 9110, Section 13.1.2)
         """  # noqa: D205
         if self._cached_if_none_match is _UNSET:
             header_value = self.env.get('HTTP_IF_NONE_MATCH')
@@ -606,9 +606,9 @@ class Request:
             return first_num, last_num
 
         except ValueError:
-            href = 'https://tools.ietf.org/html/rfc7233'
-            href_text = 'HTTP/1.1 Range Requests'
-            msg = 'It must be a range formatted according to RFC 7233.'
+            href = 'https://tools.ietf.org/html/rfc9110#section-14'
+            href_text = 'HTTP Semantics: Range Requests'
+            msg = 'It must be a range formatted according to RFC 9110.'
             raise errors.HTTPInvalidHeader(msg, 'Range', href=href, href_text=href_text)
 
     @property
@@ -1427,7 +1427,7 @@ class Request:
                 ``HTTPBadRequest`` instead of returning gracefully when the
                 header is not found (default ``False``).
             obs_date (bool): Support obs-date formats according to
-                RFC 7231, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT"
+                RFC 9110, e.g.: "Sunday, 06-Nov-94 08:49:37 GMT"
                 (default ``False``).
 
         Returns:
@@ -1451,7 +1451,7 @@ class Request:
             else:
                 return None
         except ValueError:
-            msg = 'It must be formatted according to RFC 7231, Section 7.1.1.1'
+            msg = 'It must be formatted according to RFC 9110, Section 5.6.7'
             raise errors.HTTPInvalidHeader(msg, header)
 
     def get_cookie_values(self, name: str) -> list[str] | None:

--- a/falcon/request_helpers.py
+++ b/falcon/request_helpers.py
@@ -35,7 +35,7 @@ _COOKIE_NAME_RESERVED_CHARS = re.compile(
 )
 
 # NOTE(kgriffs): strictly speaking, the weakness indicator is
-#   case-sensitive, but this wasn't explicit until RFC 7232
+#   case-sensitive, but this wasn't explicit until RFC 9110, Section 8.8.3
 #   so we allow for both. We also require quotes because that's
 #   been standardized since 1999, and it makes the regex simpler
 #   and more performant.
@@ -135,7 +135,7 @@ def _parse_etags(etag_str: str) -> list[ETag | Literal['*']] | None:
     ETags. The string may also contain a '*' character, in order to indicate
     that any ETag should match the precondition.
 
-    (See also: RFC 7232, Section 3)
+    (See also: RFC 9110, Section 13.1)
 
     Args:
         etag_str (str): An ASCII header value to parse ETags from. ETag values

--- a/falcon/response.py
+++ b/falcon/response.py
@@ -1105,7 +1105,7 @@ class Response:
             case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
             thing.
 
-        (See also: RFC 7233, Section 4.2)
+        (See also: RFC 9110, Section 14.4)
         """,
         _format_range,
     )
@@ -1123,7 +1123,7 @@ class Response:
         case, raising ``falcon.HTTPRangeNotSatisfiable`` will do the right
         thing.
 
-    (See also: RFC 7233, Section 4.2)
+    (See also: RFC 9110, Section 14.4)
     """
 
     content_type: str | None = _header_property(
@@ -1299,7 +1299,7 @@ class Response:
         value consists of either a single asterisk ("*") or a list of
         header field names (case-insensitive).
 
-        (See also: RFC 7231, Section 7.1.4)
+        (See also: RFC 9110, Section 12.5.5)
         """,
         _format_header_value_list,
     )
@@ -1316,7 +1316,7 @@ class Response:
     value consists of either a single asterisk ("*") or a list of
     header field names (case-insensitive).
 
-    (See also: RFC 7231, Section 7.1.4)
+    (See also: RFC 9110, Section 12.5.5)
     """
 
     accept_ranges: str | None = _header_property(

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -552,7 +552,7 @@ def simulate_request(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -827,7 +827,7 @@ async def _simulate_request_asgi(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1382,7 +1382,7 @@ def simulate_get(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1485,7 +1485,7 @@ def simulate_head(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1583,7 +1583,7 @@ def simulate_post(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1701,7 +1701,7 @@ def simulate_put(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1814,7 +1814,7 @@ def simulate_options(app: Callable[..., Any], path: str, **kwargs: Any) -> Resul
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -1908,7 +1908,7 @@ def simulate_patch(app: Callable[..., Any], path: str, **kwargs: Any) -> Result:
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:
@@ -2021,7 +2021,7 @@ def simulate_delete(app: Callable[..., Any], path: str, **kwargs: Any) -> Result
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -926,7 +926,7 @@ def create_scope(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110 and RFC 9112). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1069,7 +1069,7 @@ def create_scope_ws(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). When the
+            format (see also RFC 9110 and RFC 9112). When the
             request will include a body, the Content-Length header should be
             included in this list. Header names are not case-sensitive.
 
@@ -1166,7 +1166,7 @@ def create_environ(
             for an HTTP header. If desired, multiple header values may be
             combined into a single (*name*, *value*) pair by joining the values
             with a comma when the header in question supports the list
-            format (see also RFC 7230 and RFC 7231). Header names are not
+            format (see also RFC 9110 and RFC 9112). Header names are not
             case-sensitive.
 
             Note:

--- a/falcon/util/misc.py
+++ b/falcon/util/misc.py
@@ -181,7 +181,7 @@ def http_date_to_dt(http_date: str, obs_date: bool = False) -> datetime.datetime
 
     Keyword Arguments:
         obs_date (bool): Support obs-date formats according to
-            RFC 7231, e.g.:
+            RFC 9110, e.g.:
             "Sunday, 06-Nov-94 08:49:37 GMT" (default ``False``).
 
     Returns:

--- a/falcon/util/structures.py
+++ b/falcon/util/structures.py
@@ -237,7 +237,7 @@ class ETag(str):
 
     This class is simply a subclass of ``str`` with a few helper methods and
     an extra attribute to indicate whether the entity-tag is weak or strong. The
-    value of the string is equivalent to what RFC 7232 calls an "opaque-tag",
+    value of the string is equivalent to what RFC 9110 calls an "opaque-tag",
     i.e. an entity-tag sans quotes and the weakness indicator.
 
     Note:
@@ -261,7 +261,7 @@ class ETag(str):
             resp.etag = content_etag
             resp.status = falcon.HTTP_200
 
-    (See also: RFC 7232)
+    (See also: RFC 9110, Section 8.8.3)
     """
 
     is_weak: bool = False
@@ -273,7 +273,7 @@ class ETag(str):
         Two entity-tags are equivalent if both are not weak and their
         opaque-tags match character-by-character.
 
-        (See also: RFC 7232, Section 2.3.2)
+        (See also: RFC 9110, Section 8.8.3.2)
 
         Arguments:
             other (ETag): The other :class:`~.ETag` to which you are comparing
@@ -289,7 +289,7 @@ class ETag(str):
     def dumps(self) -> str:
         """Serialize the ETag to a string suitable for use in a precondition header.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Returns:
             str: An opaque quoted string, possibly prefixed by a weakness
@@ -313,11 +313,11 @@ class ETag(str):
             entity-tag. It can not be used to parse a comma-separated list of
             values.
 
-        (See also: RFC 7232, Section 2.3)
+        (See also: RFC 9110, Section 8.8.3)
 
         Arguments:
             etag_str (str): An ASCII string representing a single entity-tag,
-                as defined by RFC 7232.
+                as defined by RFC 9110.
 
         Returns:
             ETag: An instance of `~.ETag` representing the parsed entity-tag.
@@ -333,7 +333,7 @@ class ETag(str):
 
         # NOTE(kgriffs): We allow for an unquoted entity-tag just in case,
         #   although it has been non-standard to do so since at least 1999
-        #   with the advent of RFC 2616.
+        #   (RFC 2616, obsoleted by RFC 9110).
         if value[:1] == value[-1:] == '"':
             value = value[1:-1]
 

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -57,7 +57,7 @@ class HeaderHelpersResource:
         resp.retry_after = 3601
 
         # Relative URI's are OK per
-        # https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2
+        # https://datatracker.ietf.org/doc/html/rfc9110#section-10.2.2
         resp.location = '/things/87'
         resp.content_location = '/things/78'
 

--- a/tests/test_http_method_routing.py
+++ b/tests/test_http_method_routing.py
@@ -8,7 +8,7 @@ import falcon
 import falcon.constants
 import falcon.testing as testing
 
-# RFC 7231, 5789 methods
+# RFC 9110, 5789 methods
 HTTP_METHODS = [
     'CONNECT',
     'DELETE',

--- a/tests/test_mediatypes.py
+++ b/tests/test_mediatypes.py
@@ -121,7 +121,7 @@ _RFC_EXAMPLE_IDS = list(
         )
         for rfc, example_values in (
             ('RFC-7231', _RFC_7231_EXAMPLE_VALUES),
-            ('RFC-9110', _RFC_7231_EXAMPLE_VALUES),
+            ('RFC-9110', _RFC_9110_EXAMPLE_VALUES),
         )
     )
 )

--- a/tests/test_request_attrs.py
+++ b/tests/test_request_attrs.py
@@ -615,7 +615,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "Range" header is '
             'invalid. It must be a range formatted '
-            'according to RFC 7233.'
+            'according to RFC 9110.'
         )
         self._test_error_details(
             headers,
@@ -734,7 +734,7 @@ class TestRequestAttributes:
         expected_desc = (
             'The value provided for the "{}" '
             'header is invalid. It must be formatted '
-            'according to RFC 7231, Section 7.1.1.1'
+            'according to RFC 9110, Section 5.6.7'
         )
 
         self._test_error_details(
@@ -974,7 +974,7 @@ class TestRequestAttributes:
                     ETag('F9,22'),
                     _make_etag('41, 7F'),
                     _make_etag('22, 41, 7F', is_weak=True),
-                    # NOTE(kgriffs): According to the grammar in RFC 7232, zero
+                    # NOTE(kgriffs): According to the grammar in RFC 9110, zero
                     #  etagc's is acceptable.
                     _make_etag(''),
                     _make_etag('', is_weak=True),


### PR DESCRIPTION
# Summary of Changes

Replace this text with a high-level summary of the changes included in this PR.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e docs`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [ ] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
