### PR TITLE
feat(asgi): type connection scopes

### DIFF
--- a/docs/_newsfragments/2628.misc.rst
+++ b/docs/_newsfragments/2628.misc.rst
@@ -1,0 +1,2 @@
+Add lightweight public ASGI scope ``TypedDict`` definitions and use them to
+improve typing for ``falcon.asgi.Request.scope`` and related ASGI internals.

--- a/falcon/_typing.py
+++ b/falcon/_typing.py
@@ -34,6 +34,7 @@ from typing import (
     TypeVar,
     Union,
 )
+from falcon.typing import ASGILifespanScope
 
 # NOTE(vytas): Mypy still struggles to handle a conditional import in the EAFP
 #   fashion, so we branch on Py version instead (which it does understand).
@@ -260,7 +261,7 @@ class AsgiMiddlewareWithProcessStartup(Protocol):
     """ASGI middleware with startup handler."""
 
     async def process_startup(
-        self, scope: Mapping[str, Any], event: Mapping[str, Any]
+        self, scope: ASGILifespanScope, event: Mapping[str, Any]
     ) -> None: ...
 
 
@@ -268,7 +269,7 @@ class AsgiMiddlewareWithProcessShutdown(Protocol):
     """ASGI middleware with shutdown handler."""
 
     async def process_shutdown(
-        self, scope: Mapping[str, Any], event: Mapping[str, Any]
+        self, scope: ASGILifespanScope, event: Mapping[str, Any]
     ) -> None: ...
 
 

--- a/falcon/asgi/app.py
+++ b/falcon/asgi/app.py
@@ -26,6 +26,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    cast,
     overload,
     TYPE_CHECKING,
 )
@@ -62,6 +63,11 @@ from falcon.errors import WebSocketDisconnected
 from falcon.http_error import HTTPError
 from falcon.http_status import HTTPStatus
 from falcon.media.multipart import MultipartFormHandler
+from falcon.typing import ASGIHTTPScope
+from falcon.typing import ASGILifespanScope
+from falcon.typing import ASGIScope
+from falcon.typing import ASGIVersions
+from falcon.typing import ASGIWebSocketScope
 from falcon.util.deprecation import DeprecatedWarning
 from falcon.util.misc import _has_arg_name
 from falcon.util.misc import is_python_func
@@ -456,7 +462,7 @@ class App(falcon.app.App[_ReqT, _RespT]):
     @_wrap_asgi_coroutine_func
     async def __call__(  # type: ignore[override] # noqa: C901
         self,
-        scope: dict[str, Any],
+        scope: ASGIScope,
         receive: AsgiReceive,
         send: AsgiSend,
     ) -> None:
@@ -466,7 +472,7 @@ class App(falcon.app.App[_ReqT, _RespT]):
         # PERF(kgriffs): This should usually be present, so use a
         #   try..except
         try:
-            asgi_info: dict[str, str] = scope['asgi']
+            asgi_info: ASGIVersions = scope['asgi']
         except KeyError:
             # NOTE(kgriffs): According to the ASGI spec, "2.0" is
             #   the default version.
@@ -477,10 +483,13 @@ class App(falcon.app.App[_ReqT, _RespT]):
         except KeyError:
             spec_version = None
 
-        try:
-            http_version: str = scope['http_version']
-        except KeyError:
+        if scope['type'] == 'lifespan':
             http_version = '1.1'
+        else:
+            try:
+                http_version = scope['http_version']
+            except KeyError:
+                http_version = '1.1'
 
         spec_version = _validate_asgi_scope(scope_type, spec_version, http_version)
 
@@ -488,12 +497,16 @@ class App(falcon.app.App[_ReqT, _RespT]):
             # PERF(vytas): Evaluate the potentially recurring WebSocket path
             #   first (in contrast to one-shot lifespan events).
             if scope_type == 'websocket':
-                await self._handle_websocket(spec_version, scope, receive, send)
+                await self._handle_websocket(
+                    spec_version, cast(ASGIWebSocketScope, scope), receive, send
+                )
                 return
 
             # NOTE(vytas): Else 'lifespan' -- other scope_type values have been
             #   eliminated by _validate_asgi_scope at this point.
-            await self._call_lifespan_handlers(spec_version, scope, receive, send)
+            await self._call_lifespan_handlers(
+                spec_version, cast(ASGILifespanScope, scope), receive, send
+            )
             return
 
         # NOTE(kgriffs): Per the ASGI spec, we should not proceed with request
@@ -514,7 +527,10 @@ class App(falcon.app.App[_ReqT, _RespT]):
         assert first_event_type == 'http.request'
 
         req = self._request_type(
-            scope, receive, first_event=first_event, options=self.req_options
+            cast(ASGIHTTPScope, scope),
+            receive,
+            first_event=first_event,
+            options=self.req_options,
         )
         resp = self._response_type(options=self.resp_options)
 
@@ -1118,7 +1134,11 @@ class App(falcon.app.App[_ReqT, _RespT]):
                 loop.run_in_executor(None, cb)
 
     async def _call_lifespan_handlers(
-        self, ver: str, scope: dict[str, Any], receive: AsgiReceive, send: AsgiSend
+        self,
+        ver: str,
+        scope: ASGILifespanScope,
+        receive: AsgiReceive,
+        send: AsgiSend,
     ) -> None:
         while True:
             event = await receive()
@@ -1127,7 +1147,7 @@ class App(falcon.app.App[_ReqT, _RespT]):
                 #   startup, as opposed to repeating them every request.
 
                 # NOTE(vytas): If missing, 'asgi' is populated in __call__.
-                asgi_info: dict[str, str] = scope['asgi']
+                asgi_info: ASGIVersions = scope['asgi']
                 version = asgi_info.get('version', '2.0 (implicit)')
                 if not version.startswith('3.'):
                     await send(
@@ -1188,7 +1208,11 @@ class App(falcon.app.App[_ReqT, _RespT]):
                 return
 
     async def _handle_websocket(
-        self, ver: str, scope: dict[str, Any], receive: AsgiReceive, send: AsgiSend
+        self,
+        ver: str,
+        scope: ASGIWebSocketScope,
+        receive: AsgiReceive,
+        send: AsgiSend,
     ) -> None:
         first_event = await receive()
         if first_event['type'] != EventType.WS_CONNECT:

--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -36,6 +36,7 @@ from falcon._typing import UnsetOr
 from falcon.asgi_spec import AsgiEvent
 from falcon.constants import SINGLETON_HEADERS
 from falcon.forwarded import Forwarded
+from falcon.typing import ASGIConnectionScope
 from falcon.util import deprecation
 from falcon.util import ETag
 from falcon.util.uri import parse_host
@@ -99,7 +100,7 @@ class Request(request.Request):
     _media_error: Exception | None = None
     _stream: BoundedStream | None = None
 
-    scope: dict[str, Any]
+    scope: ASGIConnectionScope
     """Reference to the ASGI HTTP connection scope passed in
     from the server (see also: `Connection Scope`_).
 
@@ -111,7 +112,7 @@ class Request(request.Request):
 
     def __init__(
         self,
-        scope: dict[str, Any],
+        scope: ASGIConnectionScope,
         receive: AsgiReceive,
         first_event: AsgiEvent | None = None,
         options: request.RequestOptions | None = None,
@@ -160,7 +161,10 @@ class Request(request.Request):
 
         self.options = options if options is not None else request.RequestOptions()
 
-        self.method = 'GET' if self.is_websocket else scope['method']
+        if scope['type'] == 'websocket':
+            self.method = 'GET'
+        else:
+            self.method = scope['method']
 
         self.uri_template = None
         # PERF(vytas): Fall back to class variable(s) when unset.
@@ -345,8 +349,7 @@ class Request(request.Request):
         #   empty string, at least uvicorn still includes it explicitly in
         #   that case.
         try:
-            # TODO(0xMattB): Implement advanced typing to type as 'str' (see gh #2628).
-            return self.scope['root_path']  # type: ignore[no-any-return]
+            return self.scope['root_path']
         except KeyError:
             pass
 
@@ -380,8 +383,7 @@ class Request(request.Request):
         # PERF(kgriffs): Use try...except because we normally expect the
         #   key to be present.
         try:
-            # TODO(0xMattB): Implement advanced typing to type as 'str' (see gh #2628).
-            return self.scope['scheme']  # type: ignore[no-any-return]
+            return self.scope['scheme']
         except KeyError:
             pass
 
@@ -499,7 +501,11 @@ class Request(request.Request):
                 #   case the iterable is forward-only. But that is
                 #   effectively what we are doing since we only ever
                 #   access this field when setting self._cached_access_route
-                client, __ = self.scope['client']
+                client_info = self.scope['client']
+                if client_info is None:
+                    raise TypeError
+
+                client, __ = client_info
             # NOTE(vytas): Uvicorn may explicitly set scope['client'] to None.
             #   According to the spec, it does default to None when missing,
             #   but it is unclear whether it can be explicitly set to None, or
@@ -519,7 +525,7 @@ class Request(request.Request):
                 self._cached_access_route = []
                 for hop in self.forwarded or ():
                     if hop.src is not None:
-                        host, __ = parse_host(hop.src)
+                        host = parse_host(hop.src)[0]
                         self._cached_access_route.append(host)
             elif b'x-forwarded-for' in headers:
                 addresses = headers[b'x-forwarded-for'].decode('latin1').split(',')
@@ -920,7 +926,11 @@ class Request(request.Request):
                 #   read it once and cache the result in case the
                 #   iterator is forward-only (not likely, but better
                 #   safe than sorry).
-                self._asgi_server_cached = tuple(self.scope['server'])
+                server = self.scope['server']
+                if server is None:
+                    raise TypeError
+
+                self._asgi_server_cached = cast(tuple[str, int], tuple(server))
             except (KeyError, TypeError):
                 # NOTE(kgriffs): Not found, or was None
                 default_port = 443 if self._secure_scheme else 80

--- a/falcon/asgi/ws.py
+++ b/falcon/asgi/ws.py
@@ -20,6 +20,7 @@ from falcon.asgi_spec import AsgiSendMsg
 from falcon.asgi_spec import EventType
 from falcon.asgi_spec import WSCloseCode
 from falcon.constants import WebSocketPayloadType
+from falcon.typing import ASGIWebSocketScope
 from falcon.util import misc
 
 __all__ = ('WebSocket',)
@@ -65,7 +66,7 @@ class WebSocket:
     def __init__(
         self,
         ver: str,
-        scope: dict[str, Any],
+        scope: ASGIWebSocketScope,
         receive: AsgiReceive,
         send: AsgiSend,
         media_handlers: Mapping[

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -57,6 +57,7 @@ from falcon.errors import CompatibilityError
 from falcon.media import MessagePackHandler
 from falcon.testing import helpers
 from falcon.testing.srmock import StartResponseMock
+from falcon.typing import ASGILifespanScope
 from falcon.typing import Headers
 from falcon.util import async_to_sync
 from falcon.util import CaseInsensitiveDict
@@ -924,7 +925,7 @@ async def _simulate_request_asgi(
             'Please use the method parameter.'
         )
 
-    http_scope.update(extras)
+    cast(dict[str, Any], http_scope).update(extras)
     # ---------------------------------------------------------------------
 
     if asgi_disconnect_ttl == 0:  # Special case
@@ -971,8 +972,8 @@ async def _simulate_request_asgi(
     # ---------------------------------------------------------------------
     # NOTE(kgriffs): 'lifespan' scope
     # ---------------------------------------------------------------------
-    lifespan_scope = {
-        'type': ScopeType.LIFESPAN,
+    lifespan_scope: ASGILifespanScope = {
+        'type': 'lifespan',
         'asgi': {
             'version': '3.0',
             'spec_version': '2.0',
@@ -1130,8 +1131,8 @@ class ASGIConductor:
         self._lifespan_task: asyncio.Task[Any] | None = None
 
     async def __aenter__(self) -> ASGIConductor:
-        lifespan_scope = {
-            'type': ScopeType.LIFESPAN,
+        lifespan_scope: ASGILifespanScope = {
+            'type': 'lifespan',
             'asgi': {
                 'version': '3.0',
                 'spec_version': '2.0',

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -44,6 +44,7 @@ import time
 from typing import (
     Any,
     Callable,
+    cast,
     TextIO,
 )
 
@@ -59,6 +60,8 @@ from falcon.asgi_spec import ScopeType
 from falcon.asgi_spec import WSCloseCode
 from falcon.constants import SINGLETON_HEADERS
 import falcon.request
+from falcon.typing import ASGIHTTPScope
+from falcon.typing import ASGIWebSocketScope
 from falcon.util import code_to_http_status
 from falcon.util import uri
 from falcon.util.mediatypes import parse_header
@@ -911,7 +914,7 @@ def create_scope(
     content_length: int | None = None,
     include_server: bool = True,
     cookies: CookieArg | None = None,
-) -> dict[str, Any]:
+) -> ASGIHTTPScope:
     """Create a mock ASGI scope ``dict`` for simulating HTTP requests.
 
     Keyword Args:
@@ -980,7 +983,7 @@ def create_scope(
         raise ValueError("query_string should not start with '?'")
 
     scope: dict[str, Any] = {
-        'type': ScopeType.HTTP,
+        'type': 'http',
         'asgi': {
             'version': '3.0',
             'spec_version': '2.1',
@@ -1039,7 +1042,7 @@ def create_scope(
         scope, headers, content_length, host, port, scheme, http_version, cookies
     )
 
-    return scope
+    return cast(ASGIHTTPScope, scope)
 
 
 def create_scope_ws(
@@ -1055,7 +1058,7 @@ def create_scope_ws(
     include_server: bool = True,
     subprotocols: str | None = None,
     spec_version: str = '2.1',
-) -> dict[str, Any]:
+) -> ASGIWebSocketScope:
     """Create a mock ASGI scope ``dict`` for simulating WebSocket requests.
 
     Keyword Args:
@@ -1100,7 +1103,9 @@ def create_scope_ws(
             advertise to the server (default ``[]``).
     """
 
-    scope = create_scope(
+    scope = cast(
+        dict[str, Any],
+        create_scope(
         path=path,
         query_string=query_string,
         headers=headers,
@@ -1111,9 +1116,10 @@ def create_scope_ws(
         remote_addr=remote_addr,
         root_path=root_path,
         include_server=include_server,
+        ),
     )
 
-    scope['type'] = ScopeType.WS
+    scope['type'] = 'websocket'
     scope['asgi']['spec_version'] = spec_version
     del scope['method']
 
@@ -1122,7 +1128,7 @@ def create_scope_ws(
     if subprotocols is not None:
         scope['subprotocols'] = subprotocols
 
-    return scope
+    return cast(ASGIWebSocketScope, scope)
 
 
 def create_environ(

--- a/falcon/typing.py
+++ b/falcon/typing.py
@@ -16,12 +16,24 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from typing import Optional, Protocol, TYPE_CHECKING
+from collections.abc import Iterable
+from typing import Any, Literal, Optional, Protocol, TYPE_CHECKING, TypedDict
+
+try:
+    from typing import NotRequired
+except ImportError:  # pragma: no cover
+    from typing_extensions import NotRequired
 
 if TYPE_CHECKING:
     from falcon.asgi import SSEvent
 
 __all__ = (
+    'ASGIConnectionScope',
+    'ASGIHTTPScope',
+    'ASGILifespanScope',
+    'ASGIScope',
+    'ASGIVersions',
+    'ASGIWebSocketScope',
     'Headers',
     'ReadableIO',
     'AsyncReadableIO',
@@ -36,6 +48,62 @@ annotated as a read-only mapping instead of this type.)
 
 .. versionadded:: 4.0
 """
+
+
+# ASGI
+class ASGIVersions(TypedDict):
+    """ASGI version information exposed in a scope's ``asgi`` field."""
+
+    version: str
+    spec_version: NotRequired[str]
+
+
+class _ASGIConnectionScopeBase(TypedDict):
+    asgi: ASGIVersions
+    http_version: str
+    path: str
+    query_string: bytes
+    headers: Iterable[tuple[bytes, bytes]]
+    raw_path: NotRequired[bytes]
+    root_path: NotRequired[str]
+    scheme: NotRequired[str]
+    client: NotRequired[tuple[str, int] | None]
+    server: NotRequired[tuple[str, int | None] | None]
+    state: NotRequired[dict[str, Any]]
+
+
+class ASGIHTTPScope(_ASGIConnectionScopeBase):
+    """ASGI HTTP connection scope."""
+
+    type: Literal['http']
+    method: str
+
+
+class ASGIWebSocketScope(_ASGIConnectionScopeBase):
+    """ASGI WebSocket connection scope."""
+
+    type: Literal['websocket']
+    subprotocols: NotRequired[Iterable[str]]
+
+
+ASGIConnectionScope = ASGIHTTPScope | ASGIWebSocketScope
+"""ASGI connection scope used by :class:`falcon.asgi.Request`.
+
+This alias models the parts of the HTTP and WebSocket connection scope that
+Falcon currently reads directly.
+"""
+
+
+class ASGILifespanScope(TypedDict):
+    """ASGI lifespan scope."""
+
+    type: Literal['lifespan']
+    asgi: NotRequired[ASGIVersions]
+    state: NotRequired[dict[str, Any]]
+
+
+ASGIScope = ASGIConnectionScope | ASGILifespanScope
+"""Top-level ASGI scope supported by :class:`falcon.asgi.App`."""
 
 
 # WSGI

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import falcon
 import falcon.asgi
 import falcon.testing
+from falcon.typing import ASGIConnectionScope
 
 
 @dataclass
@@ -133,6 +134,22 @@ async def sink_fancy_async_both(
         _sink_impl(req, resp)
         resp.context.comment += ' (sink)'
         resp.media.update(comment=resp.context.comment)
+
+
+def _exercise_asgi_scope_typing(req: FancyAsyncRequest) -> None:
+    scope: ASGIConnectionScope = req.scope
+
+    scheme: str = scope.get('scheme', 'http')
+    root_path: str = scope.get('root_path', '')
+    assert scheme
+    assert root_path == root_path
+
+    if scope['type'] == 'http':
+        method: str = scope['method']
+        assert method
+    else:
+        subprotocols = tuple(scope.get('subprotocols', ()))
+        assert isinstance(subprotocols, tuple)
 
 
 # NOTE(vytas): We don't use fixtures here because that is hard to marry to strict


### PR DESCRIPTION
## Summary of Changes

- Add lightweight public `TypedDict` definitions for HTTP, WebSocket, and lifespan ASGI scopes.
- Type `falcon.asgi.Request.scope` and related ASGI internals.
- Add typing regression coverage and a Towncrier news fragment.

## Related Issues

Closes #2628

