### PR TITLE
refactor(examples): use built-in media handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -585,7 +585,7 @@ Note that this example assumes that the
             proper_thing = self.db.add_thing(doc)
 
             resp.status = falcon.HTTP_201
-            resp.location = '/{}/things/{}'.format(user_id, proper_thing['id'])
+            resp.location = f'/{user_id}/things/{proper_thing["id"]}'
 
 
     # Configure your WSGI server to load "things.app" (app is a WSGI callable)
@@ -803,7 +803,7 @@ Here's the ASGI version of the app from above. Note that it uses the
             proper_thing = await self.db.add_thing(doc)
 
             resp.status = falcon.HTTP_201
-            resp.location = '/%s/things/%s' % (user_id, proper_thing['id'])
+            resp.location = f'/{user_id}/things/{proper_thing["id"]}'
 
 
     # The app instance is an ASGI callable

--- a/README.rst
+++ b/README.rst
@@ -752,6 +752,10 @@ Here's the ASGI version of the app from above. Note that it uses the
     def max_body(limit):
 
         async def hook(req, resp, resource, params):
+            # NOTE: The limit is enforced via the Content-Length header,
+            #   which is not present in the case of a request using chunked
+            #   transfer encoding (req.content_length would be None), so
+            #   streamed request bodies cannot be limited with this hook.
             length = req.content_length
             if length is not None and length > limit:
                 msg = ('The size of the request is too large. The body must not '

--- a/README.rst
+++ b/README.rst
@@ -441,7 +441,6 @@ Note that this example assumes that the
 
     # examples/things_advanced.py
 
-    import json
     import logging
     import uuid
     from wsgiref import simple_server
@@ -533,45 +532,6 @@ Note that this example assumes that the
                     )
 
 
-    class JSONTranslator:
-        # NOTE: Normally you would simply use req.media and resp.media for
-        # this particular use case; this example serves only to illustrate
-        # what is possible.
-
-        def process_request(self, req, resp):
-            # req.stream corresponds to the WSGI wsgi.input environ variable,
-            # and allows you to read bytes from the request body.
-            #
-            # See also: PEP 3333
-            if req.content_length in (None, 0):
-                # Nothing to do
-                return
-
-            body = req.bounded_stream.read()
-            if not body:
-                raise falcon.HTTPBadRequest(
-                    title='Empty request body',
-                    description='A valid JSON document is required.',
-                )
-
-            try:
-                req.context.doc = json.loads(body.decode('utf-8'))
-
-            except (ValueError, UnicodeDecodeError):
-                description = (
-                    'Could not decode the request body. The '
-                    'JSON was incorrect or not encoded as '
-                    'UTF-8.'
-                )
-
-                raise falcon.HTTPBadRequest(title='Malformed JSON', description=description)
-
-        def process_response(self, req, resp, resource, req_succeeded):
-            if not hasattr(resp.context, 'result'):
-                return
-
-            resp.text = json.dumps(resp.context.result)
-
 
     def max_body(limit):
         def hook(req, resp, resource, params):
@@ -613,24 +573,14 @@ Note that this example assumes that the
                     title='Service Outage', description=description, retry_after=30
                 )
 
-            # NOTE: Normally you would use resp.media for this sort of thing;
-            # this example serves only to demonstrate how the context can be
-            # used to pass arbitrary values between middleware components,
-            # hooks, and resources.
-            resp.context.result = result
+            resp.media = result
 
             resp.set_header('Powered-By', 'Falcon')
             resp.status = falcon.HTTP_200
 
         @falcon.before(max_body(64 * 1024))
         def on_post(self, req, resp, user_id):
-            try:
-                doc = req.context.doc
-            except AttributeError:
-                raise falcon.HTTPBadRequest(
-                    title='Missing thing',
-                    description='A thing must be submitted in the request body.',
-                )
+            doc = req.get_media()
 
             proper_thing = self.db.add_thing(doc)
 
@@ -643,7 +593,6 @@ Note that this example assumes that the
         middleware=[
             AuthMiddleware(),
             RequireJSON(),
-            JSONTranslator(),
         ]
     )
 
@@ -661,7 +610,7 @@ Note that this example assumes that the
     sink = SinkAdapter()
     app.add_sink(sink, r'/search/(?P<engine>ddg|y)\Z')
 
-    # Useful for debugging problems in your API; works with pdb.set_trace(). You
+    # Useful for debugging problems in your App; works with pdb.set_trace(). You
     # can also use Gunicorn to host your app. Gunicorn can be configured to
     # auto-restart workers when it detects a code change, and it also works
     # with pdb.
@@ -708,7 +657,6 @@ Here's the ASGI version of the app from above. Note that it uses the
 
     # examples/things_advanced_asgi.py
 
-    import json
     import logging
     import uuid
 
@@ -799,41 +747,6 @@ Here's the ASGI version of the app from above. Note that it uses the
                         href='http://docs.examples.com/api/json')
 
 
-    class JSONTranslator:
-        # NOTE: Normally you would simply use req.get_media() and resp.media for
-        # this particular use case; this example serves only to illustrate
-        # what is possible.
-
-        async def process_request(self, req, resp):
-            # NOTE: Test explicitly for 0, since this property could be None in
-            # the case that the Content-Length header is missing (in which case we
-            # can't know if there is a body without actually attempting to read
-            # it from the request stream.)
-            if req.content_length == 0:
-                # Nothing to do
-                return
-
-            body = await req.stream.read()
-            if not body:
-                raise falcon.HTTPBadRequest(title='Empty request body',
-                                            description='A valid JSON document is required.')
-
-            try:
-                req.context.doc = json.loads(body.decode('utf-8'))
-
-            except (ValueError, UnicodeDecodeError):
-                description = ('Could not decode the request body. The '
-                               'JSON was incorrect or not encoded as '
-                               'UTF-8.')
-
-                raise falcon.HTTPBadRequest(title='Malformed JSON',
-                                            description=description)
-
-        async def process_response(self, req, resp, resource, req_succeeded):
-            if not hasattr(resp.context, 'result'):
-                return
-
-            resp.text = json.dumps(resp.context.result)
 
 
     def max_body(limit):
@@ -874,23 +787,14 @@ Here's the ASGI version of the app from above. Note that it uses the
                     description=description,
                     retry_after=30)
 
-            # NOTE: Normally you would use resp.media for this sort of thing;
-            # this example serves only to demonstrate how the context can be
-            # used to pass arbitrary values between middleware components,
-            # hooks, and resources.
-            resp.context.result = result
+            resp.media = result
 
             resp.set_header('Powered-By', 'Falcon')
             resp.status = falcon.HTTP_200
 
         @falcon.before(max_body(64 * 1024))
         async def on_post(self, req, resp, user_id):
-            try:
-                doc = req.context.doc
-            except AttributeError:
-                raise falcon.HTTPBadRequest(
-                    title='Missing thing',
-                    description='A thing must be submitted in the request body.')
+            doc = await req.get_media()
 
             proper_thing = await self.db.add_thing(doc)
 
@@ -902,7 +806,6 @@ Here's the ASGI version of the app from above. Note that it uses the
     app = falcon.asgi.App(middleware=[
         # AuthMiddleware(),
         RequireJSON(),
-        JSONTranslator(),
     ])
 
     db = StorageEngine()

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -128,11 +128,8 @@ parameters, handling errors, and working with request and response bodies.
             • Middleware (Middleware are independent):
                 → AuthMiddleware.process_request
                   → RequireJSON.process_request
-                    → JSONTranslator.process_request
 
-                        ├── Process route responder
-
-                    ↢ JSONTranslator.process_response
+                      ├── Process route responder
             • Sinks:
                 ⇥ /search/(?P<engine>ddg|y)\Z SinkAdapter
             • Error handlers:

--- a/examples/things_advanced.py
+++ b/examples/things_advanced.py
@@ -143,7 +143,7 @@ class ThingsResource:
         proper_thing = self.db.add_thing(doc)
 
         resp.status = falcon.HTTP_201
-        resp.location = '/{}/things/{}'.format(user_id, proper_thing['id'])
+        resp.location = f'/{user_id}/things/{proper_thing["id"]}'
 
 
 # Configure your WSGI server to load "things.app" (app is a WSGI callable)

--- a/examples/things_advanced.py
+++ b/examples/things_advanced.py
@@ -1,6 +1,5 @@
 # examples/things_advanced.py
 
-import json
 import logging
 import uuid
 from wsgiref import simple_server
@@ -92,46 +91,6 @@ class RequireJSON:
                 )
 
 
-class JSONTranslator:
-    # NOTE: Normally you would simply use req.media and resp.media for
-    # this particular use case; this example serves only to illustrate
-    # what is possible.
-
-    def process_request(self, req, resp):
-        # req.stream corresponds to the WSGI wsgi.input environ variable,
-        # and allows you to read bytes from the request body.
-        #
-        # See also: PEP 3333
-        if req.content_length in (None, 0):
-            # Nothing to do
-            return
-
-        body = req.bounded_stream.read()
-        if not body:
-            raise falcon.HTTPBadRequest(
-                title='Empty request body',
-                description='A valid JSON document is required.',
-            )
-
-        try:
-            req.context.doc = json.loads(body.decode('utf-8'))
-
-        except (ValueError, UnicodeDecodeError):
-            description = (
-                'Could not decode the request body. The '
-                'JSON was incorrect or not encoded as '
-                'UTF-8.'
-            )
-
-            raise falcon.HTTPBadRequest(title='Malformed JSON', description=description)
-
-    def process_response(self, req, resp, resource, req_succeeded):
-        if not hasattr(resp.context, 'result'):
-            return
-
-        resp.text = json.dumps(resp.context.result)
-
-
 def max_body(limit):
     def hook(req, resp, resource, params):
         length = req.content_length
@@ -172,24 +131,14 @@ class ThingsResource:
                 title='Service Outage', description=description, retry_after=30
             )
 
-        # NOTE: Normally you would use resp.media for this sort of thing;
-        # this example serves only to demonstrate how the context can be
-        # used to pass arbitrary values between middleware components,
-        # hooks, and resources.
-        resp.context.result = result
+        resp.media = result
 
         resp.set_header('Powered-By', 'Falcon')
         resp.status = falcon.HTTP_200
 
     @falcon.before(max_body(64 * 1024))
     def on_post(self, req, resp, user_id):
-        try:
-            doc = req.context.doc
-        except AttributeError:
-            raise falcon.HTTPBadRequest(
-                title='Missing thing',
-                description='A thing must be submitted in the request body.',
-            )
+        doc = req.get_media()
 
         proper_thing = self.db.add_thing(doc)
 
@@ -202,7 +151,6 @@ app = falcon.App(
     middleware=[
         AuthMiddleware(),
         RequireJSON(),
-        JSONTranslator(),
     ]
 )
 

--- a/examples/things_advanced_asgi.py
+++ b/examples/things_advanced_asgi.py
@@ -149,7 +149,7 @@ class ThingsResource:
         proper_thing = await self.db.add_thing(doc)
 
         resp.status = falcon.HTTP_201
-        resp.location = '/{}/things/{}'.format(user_id, proper_thing['id'])
+        resp.location = f'/{user_id}/things/{proper_thing["id"]}'
 
 
 # The app instance is an ASGI callable

--- a/examples/things_advanced_asgi.py
+++ b/examples/things_advanced_asgi.py
@@ -1,6 +1,5 @@
 # examples/things_advanced_asgi.py
 
-import json
 import logging
 import uuid
 
@@ -94,46 +93,6 @@ class RequireJSON:
                 )
 
 
-class JSONTranslator:
-    # NOTE: Normally you would simply use req.get_media() and resp.media for
-    # this particular use case; this example serves only to illustrate
-    # what is possible.
-
-    async def process_request(self, req, resp):
-        # NOTE: Test explicitly for 0, since this property could be None in
-        # the case that the Content-Length header is missing (in which case we
-        # can't know if there is a body without actually attempting to read
-        # it from the request stream.)
-        if req.content_length == 0:
-            # Nothing to do
-            return
-
-        body = await req.stream.read()
-        if not body:
-            raise falcon.HTTPBadRequest(
-                title='Empty request body',
-                description='A valid JSON document is required.',
-            )
-
-        try:
-            req.context.doc = json.loads(body.decode('utf-8'))
-
-        except (ValueError, UnicodeDecodeError):
-            description = (
-                'Could not decode the request body. The '
-                'JSON was incorrect or not encoded as '
-                'UTF-8.'
-            )
-
-            raise falcon.HTTPBadRequest(title='Malformed JSON', description=description)
-
-    async def process_response(self, req, resp, resource, req_succeeded):
-        if not hasattr(resp.context, 'result'):
-            return
-
-        resp.text = json.dumps(resp.context.result)
-
-
 def max_body(limit):
     async def hook(req, resp, resource, params):
         length = req.content_length
@@ -174,24 +133,14 @@ class ThingsResource:
                 title='Service Outage', description=description, retry_after=30
             )
 
-        # NOTE: Normally you would use resp.media for this sort of thing;
-        # this example serves only to demonstrate how the context can be
-        # used to pass arbitrary values between middleware components,
-        # hooks, and resources.
-        resp.context.result = result
+        resp.media = result
 
         resp.set_header('Powered-By', 'Falcon')
         resp.status = falcon.HTTP_200
 
     @falcon.before(max_body(64 * 1024))
     async def on_post(self, req, resp, user_id):
-        try:
-            doc = req.context.doc
-        except AttributeError:
-            raise falcon.HTTPBadRequest(
-                title='Missing thing',
-                description='A thing must be submitted in the request body.',
-            )
+        doc = await req.get_media()
 
         proper_thing = await self.db.add_thing(doc)
 
@@ -204,7 +153,6 @@ app = falcon.asgi.App(
     middleware=[
         AuthMiddleware(),
         RequireJSON(),
-        JSONTranslator(),
     ]
 )
 

--- a/examples/things_advanced_asgi.py
+++ b/examples/things_advanced_asgi.py
@@ -95,6 +95,10 @@ class RequireJSON:
 
 def max_body(limit):
     async def hook(req, resp, resource, params):
+        # NOTE: The limit is enforced via the Content-Length header,
+        #   which is not present in the case of a request using chunked
+        #   transfer encoding (req.content_length would be None), so
+        #   streamed request bodies cannot be limited with this hook.
         length = req.content_length
         if length is not None and length > limit:
             msg = (

--- a/requirements/tests
+++ b/requirements/tests
@@ -17,7 +17,9 @@ ujson
 
 # it's slow to compile on emulated architectures; wheels missing for some EoL interpreters
 # (and there is a new issue with building on PyPy in Actions, but we don't really need to test it with PyPy)
-python-rapidjson; platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
+# and 3.9 support was dropped upstream, but without a pip-friendly requires-python
+# (see https://github.com/python-rapidjson/python-rapidjson/issues/240)
+python-rapidjson; python_version >= '3.10' and platform_python_implementation != 'PyPy' and platform_machine != 's390x' and platform_machine != 'aarch64'
 
 # wheels are missing some EoL interpreters and non-x86 platforms; build would fail unless rust is available
 # (not available for CPython 3.15 either yet)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -42,18 +42,13 @@ def test_things_advanced(asgi, util, httpx, requests):
     suffix = '_asgi' if asgi else ''
     advanced = util.load_module(f'examples/things_advanced{suffix}.py')
 
-    # NOTE(vytas): The ASGI example explicitly requires Content-Length
-    #   (its middleware errors out otherwise with 400).
-    #   Should we change this?
-    resp1 = testing.simulate_get(
-        advanced.app, '/1337/things', headers={'Content-Length': '0'}
-    )
+    resp1 = testing.simulate_get(advanced.app, '/1337/things')
     assert resp1.status_code == 401
 
     resp2 = testing.simulate_get(
         advanced.app,
         '/1337/things',
-        headers={'Authorization': 'custom-token', 'Content-Length': '0'},
+        headers={'Authorization': 'custom-token'},
     )
     assert resp2.status_code == 200
     assert len(resp2.json) == 1


### PR DESCRIPTION
# Summary of Changes

* Replace the custom `JSONTranslator` middleware in the WSGI and ASGI examples with Falcon's built-in media handling.
* Use `req.get_media()` in the WSGI POST responder and `await req.get_media()` in the ASGI POST responder.
* Assign response data to `resp.media` so that Falcon serializes it automatically
* Update the mirrored examples in `README.rst`.
* Revise “problems in your API” to “problems in your App”.

Removing the custom middleware also prevents a bodyless ASGI GET request from being incorrectly rejected when the `Content-Length` header is absent.

## Testing

* Ran the full `tox` suite successfully.
* Exercised GET and POST requests for both WSGI and ASGI with `falcon.testing.TestClient`.
* Verified `200 OK` for GET and `201 Created` for POST in both variants.

No permanent tests were added because this PR changes only the examples and their mirrored README snippets, rather than Falcon framework functionality.

## LLM Usage

LLM assistance was used to explain coding concepts, suggest implementation and testing steps, help me use Git, and review grammar. It did not autonomously modify any code. I manually applied, reviewed, and tested every proposed change, discarding suggestions that did not convince me.

# Related Issues

Closes #2309

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all *appropriate* boxes. Reading our [[contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html)](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

* [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
* [x] Added **tests** for changed code.
* [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
* [x] Prefixed code comments with GitHub nick and an appropriate prefix.
* [x] Coding style is consistent with the rest of the framework.
* [x] Updated **documentation** for changed code.

  * [x] Added docstrings for any new classes, functions, or modules.
  * [x] Updated docstrings for any modifications to existing code.
  * [x] Updated both WSGI and ASGI docs (where applicable).
  * [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
  * [x] Updated all relevant supporting documentation files under `docs/`.
  * [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
  * [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` directives.
* [x] Changes (and possible deprecations) have towncrier news fragments under `docs/_newsfragments/`.
* [x] LLM output, if any, has been carefully reviewed and tested by a human developer.