### PR TITLE
Fix mypy no-redef error from conditional testtools import

### DIFF
--- a/docs/_newsfragments/2156.bugfix.rst
+++ b/docs/_newsfragments/2156.bugfix.rst
@@ -1,0 +1,10 @@
+The optional :mod:`testtools` integration in
+:class:`~falcon.testing.TestCase` could trip up ``mypy`` when
+:mod:`testtools` was installed in the environment, since the module is
+conditionally imported under the same name as the standard library's
+:mod:`unittest`. The import is now hidden from type checkers (which
+always see it as :mod:`unittest`), while the runtime behavior of
+preferring :mod:`testtools` when available is unchanged. The
+:class:`~falcon.testing.TestCase` docstring was also reworded to
+clarify that using :mod:`testtools` is not the recommended way to test
+a Falcon app, and points to the pytest-based tutorial instead.

--- a/falcon/testing/test_case.py
+++ b/falcon/testing/test_case.py
@@ -18,12 +18,15 @@ This package includes a unittest-style base class and requests-like
 utilities for simulating and validating HTTP requests.
 """
 
-from typing import Any
+from typing import Any, TYPE_CHECKING
 
-try:
-    import testtools as unittest
-except ImportError:  # pragma: nocover
+if TYPE_CHECKING:
     import unittest
+else:
+    try:
+        import testtools as unittest
+    except ImportError:  # pragma: nocover
+        import unittest
 
 import falcon
 import falcon.request
@@ -33,12 +36,16 @@ from falcon.testing.client import Result  # NOQA
 from falcon.testing.client import TestClient
 
 
-class TestCase(unittest.TestCase, TestClient):  # type: ignore[misc]
+class TestCase(unittest.TestCase, TestClient):
     """Extends :mod:`unittest` to support WSGI/ASGI functional testing.
 
     Note:
         If available, uses :mod:`testtools` in lieu of
-        :mod:`unittest`.
+        :mod:`unittest`. This is purely a runtime convenience for
+        projects that already depend on :mod:`testtools`; it is not
+        the recommended way to test a Falcon app. For new projects,
+        we recommend following the :ref:`pytest-based tutorial
+        <testing_tutorial>` instead.
 
     This base class provides some extra plumbing for unittest-style
     test cases, to help simulate WSGI or ASGI requests without having

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,6 @@ module = [
     "msgpack",
     "mujson",
     "pyximport",
-    "testtools",
     "uvicorn"
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary

\`falcon/testing/test_case.py\` conditionally imports \`testtools\` as \`unittest\`, falling back to the stdlib module if \`testtools\` isn't installed:

\`\`\`python
try:
    import testtools as unittest
except ImportError:
    import unittest
\`\`\`

When \`testtools\` *is* installed in the environment, mypy resolves both branches and raises:

\`\`\`
falcon/testing/test_case.py:26: error: Name "unittest" already defined (by an import)  [no-redef]
\`\`\`

This is what @vytas7 flagged in #2156 as a real bug uncovered by newer mypy versions, and a maintenance burden since it means \`mypy\` and \`testtools\` can't coexist in the same dev environment without extra ignores.

## Fix

- Gate the import behind \`TYPE_CHECKING\` so type checkers always see the stdlib \`unittest\` (identical to the runtime fallback path), while the runtime import still prefers \`testtools\` when available.
- Removed the now-unnecessary \`# type: ignore[misc]\` on the \`TestCase\` class definition and the now-unused \`testtools\` entry in the mypy \`ignore_missing_imports\` overrides in \`pyproject.toml\`.
- Reworded the \`TestCase\` docstring so it no longer reads as recommending \`testtools\` over \`unittest\`/\`pytest\`, per the discussion on #2156, and pointed to the pytest-based tutorial.
- Added a newsfragment.

Left the actual \`testtools\`-vs-\`unittest\` deprecation decision to the maintainers, as discussed on the issue.

## Test plan

- [x] \`mypy --strict falcon\` — no errors related to \`test_case.py\`
- [x] \`mypy falcon/testing/test_case.py\` with \`testtools\` installed — confirmed reproduces the original \`no-redef\` error on \`master\`, clean on this branch
- [x] \`ruff check\` / \`ruff format --check\` on the changed file
- [x] \`pytest tests/test_testing.py tests/asgi/test_testing_asgi.py\` — 244 passed, 40 skipped (with and without \`testtools\`)
- [x] Full \`pytest tests/\` — 3773 passed, 644 skipped
- [x] \`towncrier build --draft\` renders the newsfragment correctly

Fixes #2156

---

**AI disclosure:** parts of this change (diagnosis, implementation, and PR writeup) were drafted with the help of an AI coding assistant (Claude Code). I reviewed, tested, and verified the diagnosis and every change myself before submitting.