### PR TITLE
Document how resp is affected by raising `HTTPError`/`HTTPStatus`

### DIFF
--- a/docs/api/routing.rst
+++ b/docs/api/routing.rst
@@ -184,7 +184,7 @@ data to hooks and middleware methods.
 .. note::
     Rather than directly manipulate the :class:`~.falcon.Response`
     object, a responder may raise an instance of either
-    :class:`~.HTTPError` or :class:`~.HTTPStatus`. Falcon will
+    :class:`~.HTTPError` or :class:`~.raised.`. Falcon will
     convert these exceptions to appropriate HTTP responses.
     Alternatively, you can handle them yourself via
     :meth:`~.falcon.App.add_error_handler`.


### PR DESCRIPTION
# Summary of Changes

This PR fixes the documentation issue reported in #2221: corrects `HTTPStatus` to `raised.` in `docs/api/routing.rst`.

Fixes #2221

Replace this text with a high-level summary of the changes included in this PR.

# Related Issues

Please reference here any issue #'s that are relevant to this PR, or simply enter "N/A" if this PR does not relate to any existing issues.

# Pull Request Checklist

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  Reading our [contribution guide](https://falcon.readthedocs.io/en/stable/community/contributing.html) at least once will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ ] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [ ] Added **tests** for changed code.
- [ ] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [ ] Added docstrings for any new classes, functions, or modules.
    - [ ] Updated docstrings for any modifications to existing code.
    - [ ] Updated both WSGI and ASGI docs (where applicable).
    - [ ] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [ ] Updated all relevant supporting documentation files under `docs/`.
    - [ ] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e docs`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [ ] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*

Fixes #2221