### PR TITLE
feat(testing): add timeout when waiting for `simulate_ws()` to complete

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -237,6 +237,8 @@ listed below by date of first contribution:
 * Gaurav Yadav (MeGaurav4)
 * Alex Chen (l46983284-cpu)
 * KetanHegde
+* Alex Chen (alexchen-sys)
+* Ashay (AshayK003)
 
 (et al.)
 

--- a/docs/_newsfragments/2585.newandimproved.rst
+++ b/docs/_newsfragments/2585.newandimproved.rst
@@ -1,0 +1,1 @@
+TODO: write me

--- a/docs/_newsfragments/2585.newandimproved.rst
+++ b/docs/_newsfragments/2585.newandimproved.rst
@@ -1,1 +1,11 @@
-TODO: write me
+Previously, it was not possible to cleanly test the case where a
+:ref:`WebSocket <ws>` responder would keep running without sending or receiving
+any messages --
+:meth:`ASGIConductor.simulate_ws <falcon.testing.ASGIConductor.simulate_ws>`
+would hang forever upon exiting the context.
+
+To afford this scenario, a new optional `timeout` keyword argument was added to
+:meth:`~falcon.testing.ASGIConductor.simulate_ws` that limits how long the test
+harness waits, both for the handshake (accept or deny), and for the app's task
+to complete after the connection is closed; when the deadline passes, an
+instance of :class:`TimeoutError` is raised.

--- a/docs/changes/4.4.0.rst
+++ b/docs/changes/4.4.0.rst
@@ -23,7 +23,9 @@ Contributors to this Release
 
 Many thanks to all of our talented and stylish contributors for this release!
 
+- `alexchen-sys <https://github.com/alexchen-sys>`__
 - `apoorva-01 <https://github.com/apoorva-01>`__
+- `AshayK003 <https://github.com/AshayK003>`__
 - `CaselIT <https://github.com/CaselIT>`__
 - `chbndrhnns <https://github.com/chbndrhnns>`__
 - `KetanHegde <https://github.com/KetanHegde>`__

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -1211,10 +1211,12 @@ class ASGIConductor:
 
         return _AsyncContextManager(self.simulate_request('GET', path, **kwargs))
 
-    def simulate_ws(self, path: str = '/', **kwargs: Any) -> _WSContextManager:
+    def simulate_ws(
+        self, path: str = '/', timeout: float | None = None, **kwargs: Any
+    ) -> helpers._WSContextManager:
         """Simulate a WebSocket connection to an ASGI application.
 
-        All keyword arguments are passed through to
+        All keyword arguments (except `timeout`) are passed through to
         :meth:`falcon.testing.create_scope_ws`.
 
         This method returns an async context manager that can be used to obtain
@@ -1230,14 +1232,19 @@ class ASGIConductor:
                 while some_condition:
                     message = await ws.receive_text()
 
+        Keyword Args:
+            timeout (float): todo writeme
+
+                .. versionadded:: 4.4
+                    The `timeout` keyword argument.
         """
 
         scope = helpers.create_scope_ws(path=path, **kwargs)
-        ws = helpers.ASGIWebSocketSimulator()
+        ws = helpers.ASGIWebSocketSimulator(timeout)
 
         task_req = asyncio.create_task(self.app(scope, ws._emit, ws._collect))
 
-        return _WSContextManager(ws, task_req)
+        return helpers._WSContextManager(ws, task_req, timeout)
 
     async def simulate_head(self, path: str = '/', **kwargs: Any) -> Result:
         """Simulate a HEAD request to an ASGI application.
@@ -2281,43 +2288,6 @@ class _AsyncContextManager:
         assert self._obj is not None
         await self._obj.finalize()
         self._obj = None
-
-
-class _WSContextManager:
-    def __init__(
-        self, ws: helpers.ASGIWebSocketSimulator, task_req: asyncio.Task[Any]
-    ) -> None:
-        self._ws = ws
-        self._task_req = task_req
-
-    async def __aenter__(self) -> helpers.ASGIWebSocketSimulator:
-        ready_waiter = asyncio.create_task(self._ws.wait_ready())
-
-        # NOTE(kgriffs): Wait on both so that in the case that the request
-        #   task raises an error, we don't just end up masking it with an
-        #   asyncio.TimeoutError.
-        await asyncio.wait(
-            [ready_waiter, self._task_req],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        if ready_waiter.done():
-            await ready_waiter
-        else:
-            # NOTE(kgriffs): Retrieve the exception, if any
-            await self._task_req
-
-            # NOTE(kgriffs): This should complete gracefully (without a
-            #   timeout). It may raise WebSocketDisconnected, but that
-            #   is expected and desired for "normal" reasons that the
-            #   request task finished without accepting the connection.
-            await ready_waiter
-
-        return self._ws
-
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        await self._ws.close()
-        await self._task_req
 
 
 def _prepare_sim_args(

--- a/falcon/testing/client.py
+++ b/falcon/testing/client.py
@@ -1233,7 +1233,13 @@ class ASGIConductor:
                     message = await ws.receive_text()
 
         Keyword Args:
-            timeout (float): todo writeme
+            timeout (float): Number of seconds to wait before giving up and
+                raising :class:`TimeoutError`.
+
+                This applies both when waiting for the app to accept or deny
+                the connection (default: 5 seconds), and when waiting for
+                the app's task to complete after the context is exited and
+                the connection is closed (default: 30 seconds).
 
                 .. versionadded:: 4.4
                     The `timeout` keyword argument.

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -411,25 +411,36 @@ class _WSContextManager:
     async def __aenter__(self) -> ASGIWebSocketSimulator:
         ready_waiter = asyncio.create_task(self._ws.wait_ready())
 
-        # NOTE(kgriffs): Wait on both so that in the case that the request
-        #   task raises an error, we don't just end up masking it with an
-        #   asyncio.TimeoutError.
-        await asyncio.wait(
-            [ready_waiter, self._task_req],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
+        try:
+            # NOTE(kgriffs): Wait on both so that in the case that the request
+            #   task raises an error, we don't just end up masking it with an
+            #   asyncio.TimeoutError.
+            await asyncio.wait(
+                [ready_waiter, self._task_req],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
 
-        if ready_waiter.done():
-            await ready_waiter
-        else:
-            # NOTE(kgriffs): Retrieve the exception, if any
-            await self._task_req
+            if ready_waiter.done():
+                await ready_waiter
+            else:
+                # NOTE(kgriffs): Retrieve the exception, if any
+                await self._task_req
 
-            # NOTE(kgriffs): This should complete gracefully (without a
-            #   timeout). It may raise WebSocketDisconnected, but that
-            #   is expected and desired for "normal" reasons that the
-            #   request task finished without accepting the connection.
-            await ready_waiter
+                # NOTE(kgriffs): This should complete gracefully (without a
+                #   timeout). It may raise WebSocketDisconnected, but that
+                #   is expected and desired for "normal" reasons that the
+                #   request task finished without accepting the connection.
+                await ready_waiter
+
+        except (Exception, asyncio.CancelledError):
+            # NOTE(vytas): Clean up if we failed to __enter__, e.g., the
+            #   handshake timed out, the app raised, or we were cancelled.
+            # NOTE(vytas): CancelledError is subclassed directly from
+            #   BaseException on 3.8+, hence the explicit inclusion; we only
+            #   cancel() the other tasks and immediately re-raise.
+            self._task_req.cancel()
+            ready_waiter.cancel()
+            raise
 
         return self._ws
 
@@ -549,13 +560,12 @@ class ASGIWebSocketSimulator:
         try:
             await asyncio.wait_for(self._event_handshake_complete.wait(), timeout)
         except asyncio.TimeoutError:
-            msg = (
+            raise asyncio.TimeoutError(
                 f'Timed out after waiting {timeout} seconds for the WebSocket '
                 f'handshake to complete. Check the on_websocket responder and '
                 f'any middleware for any conditions that may be stalling the '
                 f'request flow.'
             )
-            raise asyncio.TimeoutError(msg)
 
         self._require_accepted()
 

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -439,6 +439,12 @@ class _WSContextManager:
         try:
             await asyncio.wait_for(self._task_req, self._close_timeout)
         except asyncio.TimeoutError:
+            # TODO(vytas): Here we catch and reraise asyncio.TimeoutError,
+            #   which is a deprecated alias of the built-in TimeoutError since
+            #   Python 3.11; however, we still support 3.10 in the Falcon 4.x
+            #   series.
+            #   In Falcon 5.0, change this and other instances in this file to
+            #   reference TimeoutError directly.
             raise asyncio.TimeoutError(
                 f'Timed out after waiting {self._close_timeout} seconds for '
                 f'the WebSocket task to complete. Check the on_websocket '

--- a/falcon/testing/helpers.py
+++ b/falcon/testing/helpers.py
@@ -44,6 +44,7 @@ import time
 from typing import (
     Any,
     Callable,
+    Final,
     TextIO,
 )
 
@@ -394,6 +395,61 @@ class _WebSocketState(Enum):
     CLOSED = auto()
 
 
+class _WSContextManager:
+    _DEFAULT_CLOSE_TIMEOUT: Final[float] = 30.0
+
+    def __init__(
+        self,
+        ws: ASGIWebSocketSimulator,
+        task_req: asyncio.Task[Any],
+        close_timeout: float | None,
+    ) -> None:
+        self._ws = ws
+        self._task_req = task_req
+        self._close_timeout = close_timeout or self._DEFAULT_CLOSE_TIMEOUT
+
+    async def __aenter__(self) -> ASGIWebSocketSimulator:
+        ready_waiter = asyncio.create_task(self._ws.wait_ready())
+
+        # NOTE(kgriffs): Wait on both so that in the case that the request
+        #   task raises an error, we don't just end up masking it with an
+        #   asyncio.TimeoutError.
+        await asyncio.wait(
+            [ready_waiter, self._task_req],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if ready_waiter.done():
+            await ready_waiter
+        else:
+            # NOTE(kgriffs): Retrieve the exception, if any
+            await self._task_req
+
+            # NOTE(kgriffs): This should complete gracefully (without a
+            #   timeout). It may raise WebSocketDisconnected, but that
+            #   is expected and desired for "normal" reasons that the
+            #   request task finished without accepting the connection.
+            await ready_waiter
+
+        return self._ws
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self._ws.close()
+
+        try:
+            await asyncio.wait_for(self._task_req, self._close_timeout)
+        except asyncio.TimeoutError:
+            raise asyncio.TimeoutError(
+                f'Timed out after waiting {self._close_timeout} seconds for '
+                f'the WebSocket task to complete. Check the on_websocket '
+                f'responder for any conditions that may be preventing the '
+                f'task from terminating cleanly. '
+                f'(If you intentionally want to test how a long running task is '
+                f'cancelled by the ASGI server, you can pass a short timeout '
+                f'value to simulate_ws, and catch this asyncio.TimeoutError.)'
+            )
+
+
 class ASGIWebSocketSimulator:
     """Simulates a WebSocket client for testing a Falcon ASGI app.
 
@@ -409,9 +465,9 @@ class ASGIWebSocketSimulator:
         :meth:`~falcon.testing.ASGIConductor.simulate_ws`.
     """
 
-    _DEFAULT_WAIT_READY_TIMEOUT = 5
+    _DEFAULT_WAIT_READY_TIMEOUT: Final[float] = 5.0
 
-    def __init__(self) -> None:
+    def __init__(self, _timeout: float | None = None) -> None:
         self.__msgpack = None
 
         self._state = _WebSocketState.CONNECT
@@ -424,6 +480,7 @@ class ASGIWebSocketSimulator:
         self._collected_client_events: deque[AsgiEvent] = deque()
 
         self._event_handshake_complete = asyncio.Event()
+        self._wait_ready_timeout = _timeout or self._DEFAULT_WAIT_READY_TIMEOUT
 
     @property
     def ready(self) -> bool:
@@ -469,7 +526,7 @@ class ASGIWebSocketSimulator:
         """  # noqa: D205
         return self._accepted_headers
 
-    async def wait_ready(self, timeout: int | None = None) -> None:
+    async def wait_ready(self, timeout: float | None = None) -> None:
         """Wait until the connection has been accepted or denied.
 
         This coroutine can be awaited in order to pause execution until the
@@ -477,11 +534,11 @@ class ASGIWebSocketSimulator:
         error will be raised to the caller.
 
         Keyword Args:
-            timeout (int): Number of seconds to wait before giving up and
-                raising an error (default: ``5``).
+            timeout (float): Number of seconds to wait before giving up and
+                raising an error (default: ``5.0``).
         """
 
-        timeout = timeout or self._DEFAULT_WAIT_READY_TIMEOUT
+        timeout = timeout or self._wait_ready_timeout
 
         try:
             await asyncio.wait_for(self._event_handshake_complete.wait(), timeout)

--- a/tests/asgi/test_ws.py
+++ b/tests/asgi/test_ws.py
@@ -1061,7 +1061,7 @@ def test_ws_base_not_implemented():
 
 
 @pytest.mark.slow
-async def test_ws_context_timeout(conductor):
+async def test_ws_enter_context_timeout(conductor):
     class Resource:
         async def on_websocket(self, req, ws):
             await asyncio.sleep(5.1)  # Anything longer than 5 is sufficient
@@ -1071,6 +1071,23 @@ async def test_ws_context_timeout(conductor):
     async with conductor as c:
         with pytest.raises(asyncio.TimeoutError):
             async with c.simulate_ws():
+                pass
+
+
+@pytest.mark.parametrize('timeout_on', ['accept', 'close'])
+async def test_ws_context_timeout(conductor, timeout_on):
+    class SleepyWebSocket:
+        async def on_websocket(self, req, ws):
+            if timeout_on != 'accept':
+                await ws.accept()
+
+            await asyncio.sleep(3600)
+
+    conductor.app.add_route('/', SleepyWebSocket())
+
+    async with conductor as c:
+        with pytest.raises(asyncio.TimeoutError):
+            async with c.simulate_ws(timeout=0.05):
                 pass
 
 


### PR DESCRIPTION
Fixes #2585.

No LLMs were used to generate the code. Open-weight LLMs were used for review and minor polishing.