### PR TITLE
chore(wheels): upgrade to cibw 4.2.0, fix builds

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -218,7 +218,7 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - master
+  # TODO(vytas): Remove when demonstrated to pass.
+  pull_request:
+    branches:
+      - master
 
 jobs:
   test-emulated:
@@ -46,11 +50,11 @@ jobs:
           platforms: all
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           # NOTE(vytas): Uncomment to test against alpha/beta CPython
           #   (usually May-July until rc1).
-          CIBW_ENABLE: cpython-prerelease
+          # CIBW_ENABLE: cpython-prerelease
 
           CIBW_ARCHS_LINUX: all
           CIBW_BUILD: ${{ matrix.platform.build }}

--- a/.github/workflows/test-wheels.yaml
+++ b/.github/workflows/test-wheels.yaml
@@ -7,10 +7,6 @@ on:
   push:
     branches:
       - master
-  # TODO(vytas): Remove when demonstrated to pass.
-  pull_request:
-    branches:
-      - master
 
 jobs:
   test-emulated:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,9 +65,9 @@ jobs:
           - env: py314_cython
             python-version: "3.14"
           - env: py315
-            python-version: "3.15.0-beta.3 - 3.15.0"
+            python-version: "3.15.0-rc.2 - 3.15.0"
           - env: py315_cython
-            python-version: "3.15.0-beta.3 - 3.15.0"
+            python-version: "3.15.0-rc.2 - 3.15.0"
           - env: py312_nocover
             os: macos-latest
             platform-label: ' (macos)'

--- a/.github/workflows/tox-sdist.yaml
+++ b/.github/workflows/tox-sdist.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: ${{ matrix.python-version != '3.15' && matrix.python-version || '3.15.0-beta.3 - 3.15.0'}}
+          python-version: ${{ matrix.python-version != '3.15' && matrix.python-version || '3.15.0-rc.2 - 3.15.0'}}
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,5 +247,5 @@ testpaths = [
 
 [tool.cibuildwheel]
 build-frontend = "build"
-test-requires = ["-r requirements/cibwtest"]
+test-requires = ["-r", "requirements/cibwtest"]
 test-command = "pytest {project}/tests"


### PR DESCRIPTION
It seems CIBW 4.2.0 made a breaking change in quoting requirements... updated.