### PR TITLE
docs(install): add Granian to installation docs & integration tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -83,6 +83,7 @@ jobs:
           - env: "zizmor_github"
           # ASGI & WSGI servers
           - env: "daphne"
+          - env: "granian"
           - env: "hypercorn"
           - env: "wsgi_servers"
           # E2E tests

--- a/README.rst
+++ b/README.rst
@@ -248,12 +248,12 @@ the more popular ones out there, but anything that can load a WSGI app will do.
 ASGI Server
 -----------
 
-In order to serve a Falcon ASGI app, you will need an ASGI server. Uvicorn
-is a popular choice:
+In order to serve a Falcon ASGI app, you will need an ASGI server. Uvicorn and
+Granian are popular choices:
 
 .. code:: bash
 
-    $ pip install uvicorn
+    $ pip install [granian|uvicorn]
 
 Source Code
 -----------

--- a/docs/user/install.rst
+++ b/docs/user/install.rst
@@ -175,9 +175,13 @@ Conversely, in order to run an ``async``
 `ASGI <https://asgi.readthedocs.io/en/latest/>`_ application server
 (Falcon only supports ASGI 3.0+, aka the single-callable application style).
 
-Uvicorn is a popular choice, owing to its fast and stable
+`Uvicorn <https://uvicorn.dev/>`__ is a popular choice, owing to its fast
 implementation. What is more, Uvicorn is supported on Windows, and on PyPy
 (however, both at a performance loss compared to CPython on Unix-like systems).
+
+`Granian <https://github.com/emmett-framework/granian>`__ is another very
+performant and stable option (often outperforming Uvicorn on both throughput
+and predictable latency).
 
 Falcon is also regularly tested against Daphne, the current ASGI reference
 server.
@@ -187,7 +191,7 @@ For a more in-depth overview of available servers, see also:
 
 .. code:: bash
 
-    $ pip install [uvicorn|daphne|hypercorn]
+    $ pip install [uvicorn|granian|hypercorn]
 
 .. note::
 
@@ -200,7 +204,7 @@ For a more in-depth overview of available servers, see also:
         $ pip install uvicorn[standard]
 
     See also a longer explanation on Uvicorn's website:
-    `Quickstart <https://www.uvicorn.org/#quickstart>`_.
+    `Optional Dependencies <https://uvicorn.dev/installation/#optional-dependencies>`__.
 
 .. _source_code:
 

--- a/docs/user/tutorial-asgi.rst
+++ b/docs/user/tutorial-asgi.rst
@@ -76,7 +76,7 @@ For running our async application, we'll need an
 `ASGI <https://asgi.readthedocs.io/>`_ application server. Popular choices
 include:
 
-* `Uvicorn <https://www.uvicorn.org/>`_
+* `Uvicorn <https://uvicorn.dev/>`_
 * `Daphne <https://github.com/django/daphne/>`_
 * `Hypercorn <https://github.com/pgjones/hypercorn/>`_
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ module = [
     "cbor2",
     "cython",
     "daphne",
+    "granian",
     "gunicorn",
     "hypercorn",
     "meinheld",

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -555,6 +555,24 @@ def _daphne_factory(host, port):
     )
 
 
+def _granian_factory(host, port):
+    return subprocess.Popen(
+        (
+            sys.executable,
+            '-m',
+            'granian',
+            '--interface',
+            'asgi',
+            '--host',
+            host,
+            '--port',
+            str(port),
+            '_asgi_test_app:application',
+        ),
+        cwd=_MODULE_DIR,
+    )
+
+
 def _hypercorn_factory(host, port):
     if _WIN32:
         script = f"""
@@ -608,9 +626,16 @@ def _can_run(factory):
             import uvicorn  # noqa
         except Exception:
             pytest.skip('uvicorn not installed')
+    elif factory == _granian_factory:
+        try:
+            import granian  # noqa
+        except Exception:
+            pytest.skip('granian not installed')
 
 
-@pytest.fixture(params=[_uvicorn_factory, _daphne_factory, _hypercorn_factory])
+@pytest.fixture(
+    params=[_uvicorn_factory, _daphne_factory, _granian_factory, _hypercorn_factory]
+)
 def server_base_url(request, requests):
     process_factory = request.param
     _can_run(process_factory)

--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -44,6 +44,25 @@ def _cheroot_args(host, port):
     return args + ('_wsgi_test_app:app',)
 
 
+def _granian_args(host, port):
+    """Granian"""
+
+    pytest.importorskip('granian')
+
+    return (
+        sys.executable,
+        '-m',
+        'granian',
+        '--interface',
+        'wsgi',
+        '--host',
+        host,
+        '--port',
+        str(port),
+        '_wsgi_test_app:app',
+    )
+
+
 def _gunicorn_args(host, port, extra_opts=()):
     """Gunicorn"""
     pytest.importorskip('gunicorn')
@@ -131,7 +150,15 @@ def _waitress_args(host, port):
 
 
 @pytest.fixture(
-    params=['cheroot', 'gunicorn', 'meinheld', 'uvicorn', 'uwsgi', 'waitress']
+    params=[
+        'cheroot',
+        'granian',
+        'gunicorn',
+        'meinheld',
+        'uvicorn',
+        'uwsgi',
+        'waitress',
+    ]
 )
 def wsgi_server(request):
     return request.param
@@ -141,6 +168,7 @@ def wsgi_server(request):
 def server_args(wsgi_server):
     servers = {
         'cheroot': _cheroot_args,
+        'granian': _granian_args,
         'gunicorn': _gunicorn_args,
         'meinheld': _meinheld_args,
         'uvicorn': _uvicorn_args,

--- a/tox.ini
+++ b/tox.ini
@@ -216,6 +216,7 @@ commands = {[with-cython]commands}
 setenv = {[with-cython]setenv}
 deps = {[with-cython]deps}
        cheroot
+       granian
        gunicorn
        uwsgi
        waitress
@@ -237,6 +238,11 @@ commands = pytest -v tests/test_wsgi_servers.py
 [testenv:daphne]
 deps = {[testenv]deps}
        daphne
+commands = pytest -v tests/asgi/test_asgi_servers.py
+
+[testenv:granian]
+deps = {[testenv]deps}
+       granian
 commands = pytest -v tests/asgi/test_asgi_servers.py
 
 [testenv:hypercorn]


### PR DESCRIPTION
Adding [Granian](https://github.com/emmett-framework/granian) to the server recommendations for ASGI, as well as integration tests for verifying its compatibility with Falcon.

We'll probably recommend it for WSGI too (except it doesn't support `gevent` yet, but @gi0baro mentioned he may consider adding it), I just need to give it a spin myself in a more realistic scenario than our integration tests.