### PR TITLE
chore(test_wsgi_servers): test uWSGI via pyuwsgi

### DIFF
--- a/tests/test_wsgi_servers.py
+++ b/tests/test_wsgi_servers.py
@@ -105,9 +105,14 @@ def _uvicorn_args(host, port):
 
 
 def _uwsgi_args(host, port):
-    """uWSGI"""
+    """uWSGI (via pyuwsgi)"""
+
+    pytest.importorskip('pyuwsgi')
+
     return (
-        'uwsgi',
+        sys.executable,
+        '-c',
+        'import pyuwsgi; pyuwsgi.run()',
         '--http',
         f'{host}:{port}',
         '--wsgi-file',

--- a/tox.ini
+++ b/tox.ini
@@ -217,7 +217,7 @@ setenv = {[with-cython]setenv}
 deps = {[with-cython]deps}
        cheroot
        gunicorn
-       uwsgi
+       pyuwsgi
        waitress
 commands = pytest -v tests/test_wsgi_servers.py
 


### PR DESCRIPTION
Run uWSGI via [`pyuwsgi`](https://pypi.org/project/pyuwsgi/).

This makes it easier to execute the server via the environment's `python`, otherwise the tests could pick any other uWSGI binary on the path.

See also: https://github.com/falconry/falcon/pull/2047 by @mgorny , uWSGI was the only one not run via `sys.executable`. (Although it is probably no longer relevant for Gentoo, as IIRC Falcon was removed from the portage tree together with mailman3, citing bad quality -- which I didn't take lightly, but let's not dwell on that.)