### PR TITLE
feat(request): add an optional argument `single` to `get_param`

### DIFF
--- a/falcon/asgi/request.py
+++ b/falcon/asgi/request.py
@@ -806,6 +806,7 @@ class Request(request.Request):
         required: Literal[True],
         store: StoreArg = ...,
         default: str | None = ...,
+        single: bool = ...,
     ) -> str: ...
 
     @overload
@@ -816,6 +817,7 @@ class Request(request.Request):
         store: StoreArg = ...,
         *,
         default: str,
+        single: bool = ...,
     ) -> str: ...
 
     @overload
@@ -825,6 +827,7 @@ class Request(request.Request):
         required: bool = False,
         store: StoreArg = None,
         default: str | None = None,
+        single: bool = ...,
     ) -> str | None: ...
 
     def get_param(
@@ -833,6 +836,7 @@ class Request(request.Request):
         required: bool = False,
         store: StoreArg = None,
         default: str | None = None,
+        single: bool = False,
     ) -> str | None:
         """Return the raw value of a query string parameter as a string.
 
@@ -851,12 +855,13 @@ class Request(request.Request):
             one. This caveat also applies when
             :attr:`~falcon.RequestOptions.auto_parse_qs_csv` is enabled and the
             given parameter is assigned to a comma-separated list of values
-            (e.g., ``foo=a,b,c``).
+            (e.g., ``foo=a,b,c``). To refuse the request instead of guessing,
+            pass ``single=True``: the method then raises ``HTTPInvalidParam``
+            when the parameter has more than one value.
 
             When multiple values are expected for a parameter,
             :meth:`~.get_param_as_list` can be used to retrieve all of
             them at once.
-
         Args:
             name (str): Parameter name, case-sensitive (e.g., 'sort').
 
@@ -868,6 +873,9 @@ class Request(request.Request):
                 the value of the param, but only if the param is present.
             default (any): If the param is not found returns the
                 given value instead of ``None``
+            single (bool): Set to ``True`` to raise ``HTTPInvalidParam`` when
+                the param has more than one value, instead of returning an
+                arbitrary one of those values (default ``False``).
 
         Returns:
             str: The value of the param as a string, or ``None`` if param is
@@ -875,12 +883,16 @@ class Request(request.Request):
 
         Raises:
             HTTPBadRequest: A required param is missing from the request.
+            HTTPInvalidParam: ``single`` is ``True`` and the param has more
+                than one value.
         """
 
         # TODO(kgriffs): It seems silly to have to do this, simply to provide
         #   the ASGI-specific docstring above. Is there a better way?
 
-        return super().get_param(name, required=required, store=store, default=default)
+        return super().get_param(
+            name, required=required, store=store, default=default, single=single
+        )
 
     @property
     def env(self) -> NoReturn:  # type:ignore[override]

--- a/falcon/request.py
+++ b/falcon/request.py
@@ -1492,6 +1492,7 @@ class Request:
         required: Literal[True],
         store: StoreArg = ...,
         default: str | None = ...,
+        single: bool = ...,
     ) -> str: ...
 
     @overload
@@ -1502,6 +1503,7 @@ class Request:
         store: StoreArg = ...,
         *,
         default: str,
+        single: bool = ...,
     ) -> str: ...
 
     @overload
@@ -1511,6 +1513,7 @@ class Request:
         required: bool = False,
         store: StoreArg = None,
         default: str | None = None,
+        single: bool = ...,
     ) -> str | None: ...
 
     def get_param(
@@ -1519,6 +1522,7 @@ class Request:
         required: bool = False,
         store: StoreArg = None,
         default: str | None = None,
+        single: bool = False,
     ) -> str | None:
         """Return the raw value of a query string parameter as a string.
 
@@ -1546,7 +1550,9 @@ class Request:
             one. This caveat also applies when
             :attr:`~falcon.RequestOptions.auto_parse_qs_csv` is enabled and the
             given parameter is assigned to a comma-separated list of values
-            (e.g., ``foo=a,b,c``).
+            (e.g., ``foo=a,b,c``). To refuse the request instead of guessing,
+            pass ``single=True``: the method then raises ``HTTPInvalidParam``
+            when the parameter has more than one value.
 
             When multiple values are expected for a parameter,
             :meth:`~.get_param_as_list` can be used to retrieve all of
@@ -1563,6 +1569,9 @@ class Request:
                 the value of the param, but only if the param is present.
             default (any): If the param is not found returns the
                 given value instead of ``None``
+            single (bool): Set to ``True`` to raise ``HTTPInvalidParam`` when
+                the param has more than one value, instead of returning an
+                arbitrary one of those values (default ``False``).
 
         Returns:
             str: The value of the param as a string, or ``None`` if param is
@@ -1570,6 +1579,8 @@ class Request:
 
         Raises:
             HTTPBadRequest: A required param is missing from the request.
+            HTTPInvalidParam: ``single`` is ``True`` and the param has more
+                than one value.
 
         """
 
@@ -1581,8 +1592,14 @@ class Request:
             # NOTE(warsaw): If the key appeared multiple times, it will be
             # stored internally as a list.  We do not define which one
             # actually gets returned, but let's pick the last one for grins.
+            # NOTE (jap): Unless the caller opted out of guessing with
+            # single=True, in which case a multi-value param is refused below.
             param = params[name]
             if isinstance(param, list):
+                if single:
+                    msg = 'It may not have more than one value.'
+                    raise errors.HTTPInvalidParam(msg, name)
+
                 param = param[-1]
 
             if store is not None:

--- a/tests/test_query_params.py
+++ b/tests/test_query_params.py
@@ -816,6 +816,79 @@ class TestQueryParams:
         # There are three 'cat' keys; order is preserved.
         assert req.get_param_as_list('cat') == ['6', '5', '4']
 
+    def test_single_param(self, simulate_request, client, resource):
+        client.app.add_route('/', resource)
+        query_string = 'ant=1&bee=3&cat=6&cat=5'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        store = {}
+        assert req.get_param('ant', single=True) == '1'
+        assert req.get_param('bee', store=store, single=True) == '3'
+        assert store == {'bee': '3'}
+        assert req.get_param('ant', required=True, single=True) == '1'
+        # A repeated key is refused instead of being guessed; see the next test.
+        with pytest.raises(HTTPInvalidParam):
+            req.get_param('cat', single=True)
+
+    def test_single_param_not_found(self, simulate_request, client, resource):
+        client.app.add_route('/', resource)
+        query_string = 'ant=1'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        store = {}
+        assert req.get_param('bee', single=True) is None
+        assert req.get_param('bee', store=store, single=True) is None
+        assert req.get_param('bee', default='3', single=True) == '3'
+        assert not store
+        with pytest.raises(HTTPMissingParam):
+            req.get_param('bee', required=True, single=True)
+
+    def test_single_param_rejects_repeated_keys(
+        self, simulate_request, client, resource
+    ):
+        client.app.add_route('/', resource)
+        query_string = 'ant=1&ant=2&bee=3&bee=4'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        for name, values in (('ant', ('1', '2')), ('bee', ('3', '4'))):
+            # Without the keyword, one of the values is returned, undefined
+            # which one (see .test_multiple_form_keys).
+            assert req.get_param(name) in values
+            with pytest.raises(HTTPInvalidParam):
+                req.get_param(name, single=True)
+
+    def test_single_param_rejects_csv_when_enabled(
+        self, simulate_request, client, resource
+    ):
+        client.app.add_route('/', resource)
+        client.app.req_options.auto_parse_qs_csv = True
+        query_string = 'ant=1,2'
+        simulate_request(client=client, path='/', query_string=query_string)
+
+        req = resource.captured_req
+        # A comma-separated value is a list of values as well in this mode.
+        assert req.get_param_as_list('ant') == ['1', '2']
+        with pytest.raises(HTTPInvalidParam):
+            req.get_param('ant', single=True)
+
+    def test_single_param_error_response(self, client):
+        class Resource:
+            def on_get(self, req, resp):
+                resp.text = req.get_param('ant', single=True)
+
+        client.app.add_route('/', Resource())
+
+        response = client.simulate_get('/', query_string='ant=1')
+        assert response.status_code == 200
+        assert response.text == '1'
+
+        response = client.simulate_get('/', query_string='ant=1&ant=2')
+        assert response.status_code == 400
+        assert response.json['title'] == 'Invalid parameter'
+
     def test_get_date_valid(self, simulate_request, client, resource):
         client.app.add_route('/', resource)
         date_value = '2015-04-20'


### PR DESCRIPTION
# Summary of Changes

This adds an optional argument `single` to `Request.get_param`. 

When this argument is set to True, get_param will raise an exception if the requested parameter has multiple values. This turns the undefined behavior (what value is returned) into an error.

The inspiration for this was a LLM assisted migration to falcon4 of another codebase. This codebase tries to be strict and for that reason the LLM noted that the `get_param` behaviour of returning a value at will was troublesome and it suggested a large helper function.
I declined and wrote this instead.

# Related Issues

Fixes #2735.

# Pull Request Checklist

- [x] Applied changes to both WSGI and ASGI code paths and interfaces (where applicable).
- [x] Added **tests** for changed code.
- [x] Performed automated tests and code quality checks by [running `tox`](https://falcon.readthedocs.io/en/stable/community/contributing.html#pull-requests).
- [x] Prefixed code comments with GitHub nick and an appropriate prefix.
- [x] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code.
    - [x] Added docstrings for any new classes, functions, or modules.
    - [x] Updated docstrings for any modifications to existing code.
    - [x] Updated both WSGI and ASGI docs (where applicable).
    - [x] Added references to new classes, functions, or modules to the relevant RST file under `docs/`.
    - [x] Updated all relevant supporting documentation files under `docs/`.
    - [x] A copyright notice is included at the top of any new modules (using your own name or the name of your organization).
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/usage/restructuredtext/directives.html?highlight=versionadded#directive-versionadded).
- [ ] Changes (and possible deprecations) have [towncrier news fragments](https://falcon.readthedocs.io/en/stable/community/contributing.html#changelog) under `docs/_newsfragments/`, with the file name format `{issue_number}.{fragment_type}.rst`. (Run `tox -e docs`, and inspect `docs/_build/html/changes/` in the browser to ensure it renders correctly.)
- [x] LLM output, if any, has been carefully reviewed and tested by a human developer. (See also: [Use of LLMs ("AI")](https://falcon.readthedocs.io/en/latest/community/contributing.html#use-of-llms-ai).)

If you have *any* questions to *any* of the points above, just **submit and ask**! This checklist is here to *help* you, not to deter you from contributing!

*PR template inspired by the attrs project.*
