### PR TITLE
chore(tests/asgi): skip Uvicorn tests when testing other ASGI servers

### DIFF
--- a/.github/workflows/cibuildwheel.yaml
+++ b/.github/workflows/cibuildwheel.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build sdist and pure-Python wheel
         env:
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -251,7 +251,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Download artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/test-dist.yaml
+++ b/.github/workflows/test-dist.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Build dist
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,6 @@ jobs:
           - env: py311_cython
             python-version: "3.11"
           - env: py312
-            coverage: true
             python-version: "3.12"
           - env: py312_cython
             python-version: "3.12"
@@ -61,6 +60,7 @@ jobs:
           - env: py313_cython
             python-version: "3.13"
           - env: py314
+            coverage: true
             python-version: "3.14"
           - env: py314_cython
             python-version: "3.14"
@@ -92,7 +92,7 @@ jobs:
           #   newly released Firefox 131.0, SeleniumBase, and our tests.
           # NOTE(vytas,cycloctane): Apparently, it seems that the issue is
           #   caused by a segfault in Uvicorn, but it happens only in Actions.
-          - env: "e2e_firefox"
+          # - env: "e2e_firefox"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
         default-os:
           - "ubuntu-latest"
         python-version:
-          - "3.12"
+          - "3.14"
         tox:
           # Lint
           - env: pep8
@@ -68,10 +68,10 @@ jobs:
             python-version: "3.15.0-rc.2 - 3.15.0"
           - env: py315_cython
             python-version: "3.15.0-rc.2 - 3.15.0"
-          - env: py312_nocover
+          - env: py314_nocover
             os: macos-latest
             platform-label: ' (macos)'
-          - env: py312_nocover
+          - env: py314_nocover
             os: windows-latest
             platform-label: ' (windows)'
           # Tutorials
@@ -92,7 +92,7 @@ jobs:
           #   newly released Firefox 131.0, SeleniumBase, and our tests.
           # NOTE(vytas,cycloctane): Apparently, it seems that the issue is
           #   caused by a segfault in Uvicorn, but it happens only in Actions.
-          # - env: "e2e_firefox"
+          - env: "e2e_firefox"
 
     steps:
       - name: Checkout repo

--- a/requirements/asgiservers
+++ b/requirements/asgiservers
@@ -1,0 +1,7 @@
+# NOTE(vytas): These are the requirements to run ASGI server integration tests,
+#   but not the servers themselves. Tox environments specify them instead.
+
+pytest >= 7.0
+httpx
+requests
+websockets >= 13.1

--- a/tests/asgi/_asgi_test_app.py
+++ b/tests/asgi/_asgi_test_app.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections import Counter
 import hashlib
+import pathlib
 import platform
 import sys
 import time
@@ -9,6 +10,9 @@ import falcon
 import falcon.asgi
 import falcon.errors
 import falcon.util
+
+HERE = pathlib.Path(__file__).resolve().parent
+FALCON_ROOT = HERE.parent.parent
 
 SSE_TEST_MAX_DELAY_SEC = 1
 _WIN32 = sys.platform.startswith('win')
@@ -300,6 +304,8 @@ def create_app():
     app.add_route('/jars', TestJar())
     app.add_route('/feeds/{feed_id}', Feed())
     app.add_route('/wsoptions', WSOptions(app.ws_options))
+
+    app.add_static_route('/static', FALCON_ROOT, downloadable=True)
 
     app.add_middleware(lifespan_handler)
 

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -196,6 +196,46 @@ class TestASGIServer:
             assert resp.json().get('drops') >= 1
 
 
+class TestStaticFiles:
+    def test_get(self, server_base_url, requests):
+        expected = (_asgi_test_app.FALCON_ROOT / 'LICENSE').read_text()
+
+        resp = requests.get(
+            server_base_url + 'static/LICENSE', timeout=_REQUEST_TIMEOUT
+        )
+        assert resp.status_code == 200
+        assert resp.text == expected
+
+        range_resp = requests.get(
+            server_base_url + 'static/LICENSE',
+            headers={'Range': 'bytes=13-37'},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        assert range_resp.status_code == 206
+        assert range_resp.text == expected[13 : 37 + 1]
+
+    def test_not_modified(self, server_base_url, requests):
+        resp1 = requests.get(
+            server_base_url + 'static/README.rst', timeout=_REQUEST_TIMEOUT
+        )
+        assert resp1.status_code == 200
+
+        etag = resp1.headers.get('ETag')
+        assert etag, 'missing ETag header'
+        assert (
+            resp1.headers.get('Content-Disposition')
+            == 'attachment; filename="README.rst"'
+        )
+        assert resp1.headers.get('Last-Modified'), 'missing Last-Modified header'
+
+        resp2 = requests.get(
+            server_base_url + 'static/README.rst',
+            headers={'If-None-Match': etag},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        assert resp2.status_code == 304
+
+
 @pytest.mark.skipif(
     websockets is None, reason='websockets is required for this test class'
 )
@@ -607,39 +647,28 @@ run(config)
     )
 
 
-def _can_run(factory):
-    if _WIN32 and factory == _daphne_factory:
+@pytest.fixture(params=['daphne', 'granian', 'hypercorn', 'uvicorn'])
+def asgi_server(request):
+    if _WIN32 and request.param == 'daphne':
         pytest.skip('daphne does not support windows')
-
-    if factory == _daphne_factory:
-        try:
-            import daphne  # noqa
-        except Exception:
-            pytest.skip('daphne not installed')
-    elif factory == _hypercorn_factory:
-        try:
-            import hypercorn  # noqa
-        except Exception:
-            pytest.skip('hypercorn not installed')
-    elif factory == _uvicorn_factory:
-        try:
-            import uvicorn  # noqa
-        except Exception:
-            pytest.skip('uvicorn not installed')
-    elif factory == _granian_factory:
-        try:
-            import granian  # noqa
-        except Exception:
-            pytest.skip('granian not installed')
+    return request.param
 
 
-@pytest.fixture(
-    params=[_uvicorn_factory, _daphne_factory, _granian_factory, _hypercorn_factory]
-)
-def server_base_url(request, requests):
-    process_factory = request.param
-    _can_run(process_factory)
+@pytest.fixture()
+def process_factory(asgi_server):
+    pytest.importorskip(asgi_server)
 
+    servers = {
+        'daphne': _daphne_factory,
+        'granian': _granian_factory,
+        'hypercorn': _hypercorn_factory,
+        'uvicorn': _uvicorn_factory,
+    }
+    return servers[asgi_server]
+
+
+@pytest.fixture()
+def server_base_url(requests, process_factory):
     for i in range(3):
         server_port = testing.get_unused_port()
         base_url = f'http://{_SERVER_HOST}:{server_port}/'

--- a/tests/asgi/test_asgi_servers.py
+++ b/tests/asgi/test_asgi_servers.py
@@ -198,13 +198,13 @@ class TestASGIServer:
 
 class TestStaticFiles:
     def test_get(self, server_base_url, requests):
-        expected = (_asgi_test_app.FALCON_ROOT / 'LICENSE').read_text()
+        expected = (_asgi_test_app.FALCON_ROOT / 'LICENSE').read_bytes()
 
         resp = requests.get(
             server_base_url + 'static/LICENSE', timeout=_REQUEST_TIMEOUT
         )
         assert resp.status_code == 200
-        assert resp.text == expected
+        assert resp.content == expected
 
         range_resp = requests.get(
             server_base_url + 'static/LICENSE',
@@ -212,7 +212,7 @@ class TestStaticFiles:
             timeout=_REQUEST_TIMEOUT,
         )
         assert range_resp.status_code == 206
-        assert range_resp.text == expected[13 : 37 + 1]
+        assert range_resp.content == expected[13 : 37 + 1]
 
     def test_not_modified(self, server_base_url, requests):
         resp1 = requests.get(

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 
 # --------------------------------------------------------------------
 #
-# NOTE(kgriffs,vytas): Python 3.10, 3.11, 3.12, or 3.13 are required
-# when checking combined coverage. To check coverage:
+# NOTE(kgriffs,vytas): CPython 3.10-3.15 is required when checking
+# combined coverage. To check coverage:
 #
 #   $ tox
 #
@@ -72,16 +72,16 @@ deps = {[testenv]deps}
        testtools
 commands = coverage run -m pytest tests []
 
-[testenv:py312]
-basepython = python3.12
+[testenv:py314]
+basepython = python3.14
 deps = {[testenv]deps}
        pytest-randomly
        jsonschema
        testtools
 commands = {[with-coverage]commands}
 
-[testenv:py312_nocover]
-basepython = python3.12
+[testenv:py314_nocover]
+basepython = python3.14
 deps = {[testenv]deps}
        pytest-randomly
        jsonschema
@@ -103,7 +103,7 @@ deps = -r{toxinidir}/requirements/tests
        pdbpp
 
 [testenv:py3_debug]
-basepython = python3.12
+basepython = python3.14
 deps = {[with-debug-tools]deps}
        uvicorn
        jsonschema
@@ -424,7 +424,7 @@ commands =
     pytest {toxinidir}/examples/look/tests
 
 [testenv:asgilook]
-basepython = python3.12
+basepython = python3.14
 deps =
     -r{toxinidir}/examples/asgilook/requirements/asgilook
     -r{toxinidir}/examples/asgilook/requirements/test
@@ -437,7 +437,7 @@ commands =
         {toxinidir}/examples/asgilook/tests/
 
 [testenv:ws_tutorial]
-basepython = python3.12
+basepython = python3.14
 deps =
     -r{toxinidir}/examples/ws_tutorial/requirements/app
     -r{toxinidir}/examples/ws_tutorial/requirements/test
@@ -454,14 +454,14 @@ commands =
 # --------------------------------------------------------------------
 
 [testenv:e2e_chrome]
-basepython = python3.12
+basepython = python3.14
 deps =
     -r{toxinidir}/requirements/e2e
 commands =
     pytest {toxinidir}/e2e-tests/ --browser=chrome
 
 [testenv:e2e_firefox]
-basepython = python3.12
+basepython = python3.14
 deps =
     -r{toxinidir}/requirements/e2e
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -214,6 +214,7 @@ commands = {[with-cython]commands}
 
 [testenv:wsgi_servers]
 setenv = {[with-cython]setenv}
+# NOTE(vytas): Uvicorn is also included (via default deps) and tested.
 deps = {[with-cython]deps}
        cheroot
        granian
@@ -236,17 +237,17 @@ commands = pytest -v tests/test_wsgi_servers.py
 # --------------------------------------------------------------------
 
 [testenv:daphne]
-deps = {[testenv]deps}
+deps = -r{toxinidir}/requirements/asgiservers
        daphne
 commands = pytest -v tests/asgi/test_asgi_servers.py
 
 [testenv:granian]
-deps = {[testenv]deps}
+deps = -r{toxinidir}/requirements/asgiservers
        granian
 commands = pytest -v tests/asgi/test_asgi_servers.py
 
 [testenv:hypercorn]
-deps = {[testenv]deps}
+deps = -r{toxinidir}/requirements/asgiservers
        hypercorn
 commands = pytest -v tests/asgi/test_asgi_servers.py
 
@@ -279,12 +280,12 @@ commands = {[smoke-test]commands}
 # --------------------------------------------------------------------
 
 [testenv:pep8]
-deps = ruff>=0.11.6
+deps = ruff>=0.16.7
 skip_install = True
 commands = ruff check []
 
 [testenv:pep8-docstrings]
-deps = ruff>=0.11.6
+deps = ruff>=0.16.7
 skip_install = True
 commands = ruff check \
              --exclude=.ecosystem,.eggs,.git,.tox,.venv,build,dist,docs,examples,tests,falcon/bench/nuts \
@@ -292,12 +293,12 @@ commands = ruff check \
              []
 
 [testenv:ruff]
-deps = ruff>=0.11.6
+deps = ruff>=0.16.7
 skip_install = True
 commands = ruff format --check . []
 
 [testenv:reformat]
-deps = ruff>=0.11.6
+deps = ruff>=0.16.7
 skip_install = True
 commands =
     ruff format . []


### PR DESCRIPTION
Other additions:

* Add very basic static route tests for ASGI, just to make sure we catch regressions.
* Migrate to CPython 3.14 as the default CI version.